### PR TITLE
feat: downstream catalog reconciliation and fan-out (FANOUT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **A downstream server's own `notifications/tools/list_changed`,
+  `notifications/resources/list_changed`, and `notifications/prompts/list_changed`
+  now reach subscribed clients.** Previously the read loop parsed these frames
+  and silently dropped them on both transports — a notification has no `id`, so
+  it fell through the pending-request gate with no `else`. A downstream server
+  that added or removed a tool at runtime was invisible until the next
+  `gateway.refresh()`; that gap was v11 P3B's own Non-Goal.
+
+  This is reconciliation, not forwarding: `ClientManager`'s indexes back
+  `gateway.catalog_search`, `gateway.describe`, and `gateway.invoke`, so
+  relaying the raw notification to the subscription sink would have told a
+  client "refetch" and handed it the *old* catalog — with a tool the server
+  just removed still invocable. The gateway now re-indexes the announcing
+  server first and publishes only once that finishes, and only for the catalog
+  kinds whose identifier set actually changed (compared by identifier, not
+  count, so a rename still publishes). A downstream that announces a change
+  and then fails to re-list rolls its previous entries back rather than
+  leaving the catalog half-removed, and publishes nothing. **The guarantee for
+  a subscribed client:** the catalog is reconciled *before* the notification
+  goes out, so a client that refetches on receipt sees the change, every time.
+
+  Reconciliation runs as a spawned, per-server-coalesced background task
+  rather than inline in the read loop — re-indexing awaits a response that the
+  very read loop which received the notification is responsible for
+  resolving, so an inline await would deadlock the connection instantly. A
+  downstream that emits `list_changed` in reply to reconciliation's own
+  `tools/list` is bounded by a debounce on the re-run, not just coalescing, so
+  it costs one extra reconcile per interval instead of a hot spin. Both
+  transports are covered: stdio (`_handle_stdout_line`) and streamable
+  HTTP/SSE (`_read_sse`) previously shared the same silent-drop, and both now
+  dispatch through the same reconcile path. Unrecognised `notifications/*`
+  methods (progress, logging) remain a no-op, as before.
+
+### Fixed
+- **A downstream server's JSON-RPC `error` object no longer loses its `code`
+  and `data`.** Both dispatch paths kept only `message`, discarding the rest
+  of the `error` member. `ClientManager` now raises a typed `DownstreamError`
+  carrying `code` and `data` alongside `message`. Scoped to the
+  `ClientManager` boundary — `gateway.invoke` still maps every exception to
+  `E302` through `str(e)`, which is byte-identical to the old message, so no
+  `gateway.*` output changes; surfacing `code`/`data` to MCP clients is
+  tracked separately.
+
 ### Changed
 - **`version_checker.compare_versions(current, latest, package_type)` is now the
   sole version-classification path; `is_version_newer` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,10 +64,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   offers **zero** entries is a genuine answer — the server emptied that kind —
   and still clears the entries and publishes.
 
+  A reply the gateway cannot read is a failed listing too, and an **absent**
+  collection is not an empty one. A `tools/list` reply of `{}` — missing the
+  `tools` array the protocol requires — is malformed, not an announcement that
+  the server has no tools, and the same goes for a reply carrying something
+  other than an array in its place (`{"tools": {}}`, `{"tools": null}`). Each
+  of those now keeps the kind's previous entries and publishes nothing, exactly
+  like a request that failed; only a genuine array is an answer, and an empty
+  array still clears. Per kind, still: an unreadable `tools` reply no longer
+  costs an honest `resources` answer arriving in the same pass.
+
+  A catalog entry carrying no identity fails to parse rather than acquiring
+  one. A resource with no `uri`, or a prompt or tool with no `name` (or an
+  empty one), used to be indexed under a synthesized identifier of the form
+  `server::` — a catalog entry the downstream never offered, which replaced the
+  real entries and was published as a change. Such an entry is now skipped like
+  any other unparseable one, and a listing of nothing but those falls under the
+  all-unparseable rule above and keeps the previous entries.
+
   Failure classification is conservative by design. Any failure to list a kind
-  — a transport error, a server that does not implement it, or a listing that
-  could not be parsed at all — keeps that kind's previous entries; only an
-  explicit empty answer clears them. The accepted cost is the mirror case: a
+  — a transport error, a server that does not implement it, a reply whose
+  collection is absent or is not an array, or a listing that could not be
+  parsed at all — keeps that kind's previous entries; only an explicit empty
+  answer clears them. The accepted cost is the mirror case: a
   server that drops a capability mid-session and never reconnects keeps stale
   entries in the catalog, which then fail loudly at invoke time. That is the
   deliberate trade — a stale entry that errors when called is recoverable and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   notification goes out, so a client that refetches on receipt sees the change,
   every time.
 
+  A malformed catalog entry costs only itself. Indexing guards each entry
+  individually, so one tool the gateway cannot parse is logged and skipped
+  while the rest of that listing is indexed normally — the entries before it
+  *and* after it. This matters most on the reconcile path, where the swap has
+  already removed the server's previous entries by the time indexing runs: an
+  exception escaping there would have left the server with no catalog at all,
+  permanently, because the read loop stays healthy and no reconnect arrives to
+  heal it. `gateway.refresh` and connect-time indexing reach the same code, so
+  this is a deliberate connect-time behaviour change too: **a server with one
+  unparseable tool now connects with the rest of its catalog instead of failing
+  outright.**
+
+  A listing whose entries are *all* unparseable is treated as a failed listing,
+  not as an empty one. Offered entries of which not one survives parsing leaves
+  the gateway in the same epistemic state as a request that failed — it could
+  not read the answer — so that kind keeps its previous entries and publishes
+  nothing. Failing to parse a listing costs visibility of the server's catalog;
+  it does not stop the server's tools from working, and announcing a removal on
+  the strength of it would tell every subscribed client those tools are gone.
+  The boundary is the count offered, not the count indexed: a listing that
+  offers **zero** entries is a genuine answer — the server emptied that kind —
+  and still clears the entries and publishes.
+
+  Failure classification is conservative by design. Any failure to list a kind
+  — a transport error, a server that does not implement it, or a listing that
+  could not be parsed at all — keeps that kind's previous entries; only an
+  explicit empty answer clears them. The accepted cost is the mirror case: a
+  server that drops a capability mid-session and never reconnects keeps stale
+  entries in the catalog, which then fail loudly at invoke time. That is the
+  deliberate trade — a stale entry that errors when called is recoverable and
+  self-announcing, whereas a falsely removed entry is invisible: it silently
+  disappears from every subscribed client's catalog with nothing to point at.
+
   Reconciliation runs as a spawned, per-server-coalesced background task
   rather than inline in the read loop — re-indexing awaits a response that the
   very read loop which received the notification is responsible for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   client "refetch" and handed it the *old* catalog — with a tool the server
   just removed still invocable. The gateway now re-indexes the announcing
   server first and publishes only once that finishes, and only for the catalog
-  kinds whose identifier set actually changed (compared by identifier, not
-  count, so a rename still publishes). A downstream that announces a change
-  and then fails to re-list rolls its previous entries back rather than
-  leaving the catalog half-removed, and publishes nothing. **The guarantee for
-  a subscribed client:** the catalog is reconciled *before* the notification
-  goes out, so a client that refetches on receipt sees the change, every time.
+  kinds that actually changed. Changed by *content*, not by identifier and not
+  by count: a rename publishes, and so does a tool whose description or input
+  schema was edited under an unchanged name.
+
+  Reconciliation fetches first and swaps second. It lists the server's tools,
+  resources, and prompts without touching the catalog, then removes and
+  re-indexes in a single synchronous block that contains no `await` — so a
+  `gateway.invoke` arriving mid-reconcile sees either the whole old catalog or
+  the whole new one, and never the empty window in between. A downstream that
+  announces a change and then fails `tools/list` therefore costs nothing:
+  nothing was removed, so there is nothing to roll back, and nothing is
+  published. Each kind is handled independently — a `resources/list` that
+  fails (which is also how a server that simply does not implement resources
+  answers) leaves the existing resources in place and publishes nothing for
+  them, while the kinds that did answer still reconcile normally. **The
+  guarantee for a subscribed client:** the catalog is reconciled *before* the
+  notification goes out, so a client that refetches on receipt sees the change,
+  every time.
 
   Reconciliation runs as a spawned, per-server-coalesced background task
   rather than inline in the read loop — re-indexing awaits a response that the

--- a/README.md
+++ b/README.md
@@ -811,11 +811,16 @@ routes. The replacement for server-initiated notifications is
 `subscriptions/listen` — a long-lived POST stream reachable **only** at
 protocol version `2026-07-28` — over which a client that opens a subscription
 receives `notifications/tools/list_changed`, `notifications/resources/list_changed`,
-and `notifications/prompts/list_changed` as PMCP's own catalog changes (a
+and `notifications/prompts/list_changed` as PMCP's own catalog changes — a
 `gateway.connect_server`, `gateway.disconnect_server`, or `gateway.refresh`
-call that adds, removes, or updates downstream tools, resources, or prompts).
-It does not proxy downstream servers' own `notifications/*` (see Non-Goals in
-the roadmap). No existing client loses delivered data from the GET
+call that adds, removes, or updates downstream tools, resources, or prompts,
+**or a downstream server's own `notifications/*/list_changed`**. A downstream
+notification is not relayed as-is: PMCP re-indexes that server's catalog
+first and publishes only once reconciliation confirms something actually
+moved, so a client that refetches on receipt of the notification sees the
+new catalog rather than the stale one. Progress and logging notifications
+from a downstream server are not proxied — catalog-change notifications
+only. No existing client loses delivered data from the GET
 retirement — PMCP never published anything on the old GET stream, so this
 removes a channel PMCP never wrote to, not one clients were receiving events
 over. The concurrency cap the old pre-session keep-alive shim enforced

--- a/specs/phase-plans-v12.md
+++ b/specs/phase-plans-v12.md
@@ -187,6 +187,12 @@ When a downstream server announces its catalog changed, **re-fetch and reconcile
 **Produces**
 - IF-0-FANOUT-1 — The downstream-event contract: which downstream `notifications/*` method maps to which `CatalogEventSink` call, the reconcile-then-publish ordering, the suppress-if-unchanged rule, and the no-op guarantee for unrecognised methods.
 
+### Post-execution amendments (2026-08-23)
+
+- **Lane B was a no-op.** The plan's `src/pmcp/subscriptions.py` in Key files implied a new publish path there. There wasn't one to add: `_index_*` and `_remove_server_indexes` already call `self._catalog_events.note_*` unconditionally, so once reconciliation calls them in the right order — remove, re-index, compare, publish-if-changed — the existing `note_*` → `SubscriptionBus` wiring publishes for free. `subscriptions.py` has zero diff across the phase.
+- **The Lane A/C branch partition described in Scope notes was never actually available**, for a more specific reason than "A and C sit in the same `if/else`": the two `TODO(post-P3B)` error branches this phase closed live in *two different functions* (`_handle_stdout_line` and the `_read_sse` loop), one per transport, not one shared branch. Serializing A → B → C within the same file, as the plan already recommended, is what actually happened; there was no branch-level split to reject at merge time because none existed to consider.
+- **SL-1's owned-files list omitted a test file.** SL-1 (Lanes A+B) is source-only by its own accounting, but its RED tests for `_handle_downstream_notification` and the reconcile scheduler had nowhere else to go and landed in `tests/test_client_manager.py` — the file SL-3 (Lane D) owned — as two clearly-named additions (`TestDownstreamReconcileScheduler` and its reconciliation-behaviour siblings). This did not collide with SL-3's own additions to the same file; it is recorded here as a gap in the plan's owned-files split, not as lane drift.
+
 ## Top Interface-Freeze Gates
 
 - **IF-0-TRISTATE-1** — `compare_versions(current: str, latest: str, package_type: str | None) -> Literal["newer", "not_newer", "incomparable"]`, the sole classification path. `is_version_newer` and `are_versions_comparable` are deleted by phase end (EC-TRISTATE-3), so there is no boolean form to keep in agreement. UPDPATH's Lane A consumes this.

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -473,6 +473,21 @@ def _raw_metadata(
     return metadata or None
 
 
+def _entry_label(entry: Any, key: str = "name") -> str:
+    """Best-effort identifier for a catalog entry we failed to parse.
+
+    Deliberately total: it is only ever called from an `except` branch, so a
+    label that itself raised would turn a skipped entry back into the lost
+    catalog the guard exists to prevent. `entry` is typed `Any` because the
+    whole point is that it did not have the shape we expected.
+    """
+    if isinstance(entry, dict):
+        identifier = entry.get(key)
+        if isinstance(identifier, str) and identifier:
+            return repr(identifier)
+    return repr(entry)[:120]
+
+
 def _schema_dialect(*schemas: dict[str, Any] | None) -> str:
     for schema in schemas:
         if schema and isinstance(schema.get("$schema"), str):
@@ -1322,6 +1337,22 @@ class ClientManager:
         return cancelled, errors
 
     def _index_tools(self, name: str, tools: list[dict[str, Any]]) -> int:
+        """Index one server's tools, skipping any entry we cannot parse.
+
+        The guard below is per *entry*, not per call, and that placement is the
+        whole point. Reconciliation removes this server's entries and then calls
+        this method; an exception escaping here would leave the removal done and
+        the re-index half-finished, so one malformed tool from a downstream
+        would silently cost the server its entire catalog -- permanently, since
+        the read loop stays healthy and no reconnect comes along to heal it. A
+        single `try` around the loop would be barely better: it would still lose
+        every entry after the bad one.
+
+        `_index_resources` / `_index_prompts` guard identically. `connect_server`
+        and `refresh` reach the same three methods, so they inherit this too: a
+        server with one unparseable tool now connects with the rest of its
+        catalog instead of failing outright.
+        """
         indexed = 0
         known_fields = {
             "name",
@@ -1340,31 +1371,37 @@ class ClientManager:
                 )
                 break
 
-            tool_name = tool["name"]
-            tool_id = make_tool_id(name, tool_name)
-            description = tool.get("description", "")
-            input_schema = tool.get("inputSchema", {})
-            output_schema = tool.get("outputSchema")
+            try:
+                tool_name = tool["name"]
+                tool_id = make_tool_id(name, tool_name)
+                description = tool.get("description", "")
+                input_schema = tool.get("inputSchema", {})
+                output_schema = tool.get("outputSchema")
 
-            tool_info = ToolInfo(
-                tool_id=tool_id,
-                server_name=name,
-                tool_name=tool_name,
-                title=tool.get("title"),
-                description=description,
-                short_description=_truncate_description(description),
-                input_schema=input_schema,
-                icons=tool.get("icons"),
-                output_schema=output_schema,
-                annotations=tool.get("annotations"),
-                execution=tool.get("execution"),
-                schema_dialect=_schema_dialect(input_schema, output_schema),
-                raw_metadata=_raw_metadata(tool, known_fields),
-                tags=_extract_tags(name, tool_name, description),
-                risk_hint=_infer_risk_hint(
-                    tool_name, description, tool.get("annotations")
-                ),
-            )
+                tool_info = ToolInfo(
+                    tool_id=tool_id,
+                    server_name=name,
+                    tool_name=tool_name,
+                    title=tool.get("title"),
+                    description=description,
+                    short_description=_truncate_description(description),
+                    input_schema=input_schema,
+                    icons=tool.get("icons"),
+                    output_schema=output_schema,
+                    annotations=tool.get("annotations"),
+                    execution=tool.get("execution"),
+                    schema_dialect=_schema_dialect(input_schema, output_schema),
+                    raw_metadata=_raw_metadata(tool, known_fields),
+                    tags=_extract_tags(name, tool_name, description),
+                    risk_hint=_infer_risk_hint(
+                        tool_name, description, tool.get("annotations")
+                    ),
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[{name}] Skipping unparseable tool {_entry_label(tool)}: {e}"
+                )
+                continue
 
             self._tools[tool_id] = tool_info
             indexed += 1
@@ -1373,6 +1410,13 @@ class ClientManager:
         return indexed
 
     def _index_resources(self, name: str, resources: list[dict[str, Any]]) -> int:
+        """Index one server's resources, skipping any entry we cannot parse.
+
+        Per-entry, for the reason spelled out on `_index_tools`. The count
+        returned is what was actually indexed, not what was offered, so a caller
+        reporting it is not overstating the catalog.
+        """
+        indexed = 0
         known_fields = {
             "uri",
             "name",
@@ -1383,26 +1427,41 @@ class ClientManager:
             "annotations",
         }
         for resource in resources:
-            uri = resource.get("uri", "")
-            resource_id = f"{name}::{uri}"
-            resource_info = ResourceInfo(
-                resource_id=resource_id,
-                server_name=name,
-                uri=uri,
-                name=resource.get("name"),
-                title=resource.get("title"),
-                description=resource.get("description"),
-                mime_type=resource.get("mimeType"),
-                icons=resource.get("icons"),
-                annotations=resource.get("annotations"),
-                raw_metadata=_raw_metadata(resource, known_fields),
-            )
+            try:
+                uri = resource.get("uri", "")
+                resource_id = f"{name}::{uri}"
+                resource_info = ResourceInfo(
+                    resource_id=resource_id,
+                    server_name=name,
+                    uri=uri,
+                    name=resource.get("name"),
+                    title=resource.get("title"),
+                    description=resource.get("description"),
+                    mime_type=resource.get("mimeType"),
+                    icons=resource.get("icons"),
+                    annotations=resource.get("annotations"),
+                    raw_metadata=_raw_metadata(resource, known_fields),
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[{name}] Skipping unparseable resource "
+                    f"{_entry_label(resource, key='uri')}: {e}"
+                )
+                continue
+
             self._resources[resource_id] = resource_info
-        if resources and not self._catalog_publishing_suppressed(name):
+            indexed += 1
+        if indexed and not self._catalog_publishing_suppressed(name):
             self._catalog_events.note_resources_changed()
-        return len(resources)
+        return indexed
 
     def _index_prompts(self, name: str, prompts: list[dict[str, Any]]) -> int:
+        """Index one server's prompts, skipping any entry we cannot parse.
+
+        Per-entry, for the reason spelled out on `_index_tools`. The count
+        returned is what was actually indexed, not what was offered.
+        """
+        indexed = 0
         known_prompt_fields = {
             "name",
             "title",
@@ -1413,35 +1472,43 @@ class ClientManager:
         }
         known_arg_fields = {"name", "title", "description", "required"}
         for prompt in prompts:
-            prompt_name = prompt.get("name", "")
-            prompt_id = f"{name}::{prompt_name}"
-            arguments = None
-            if prompt.get("arguments"):
-                arguments = [
-                    PromptArgumentInfo(
-                        name=arg.get("name", ""),
-                        title=arg.get("title"),
-                        description=arg.get("description"),
-                        required=arg.get("required", False),
-                        raw_metadata=_raw_metadata(arg, known_arg_fields),
-                    )
-                    for arg in prompt["arguments"]
-                ]
-            prompt_info = PromptInfo(
-                prompt_id=prompt_id,
-                server_name=name,
-                name=prompt_name,
-                title=prompt.get("title"),
-                description=prompt.get("description"),
-                arguments=arguments,
-                icons=prompt.get("icons"),
-                annotations=prompt.get("annotations"),
-                raw_metadata=_raw_metadata(prompt, known_prompt_fields),
-            )
+            try:
+                prompt_name = prompt.get("name", "")
+                prompt_id = f"{name}::{prompt_name}"
+                arguments = None
+                if prompt.get("arguments"):
+                    arguments = [
+                        PromptArgumentInfo(
+                            name=arg.get("name", ""),
+                            title=arg.get("title"),
+                            description=arg.get("description"),
+                            required=arg.get("required", False),
+                            raw_metadata=_raw_metadata(arg, known_arg_fields),
+                        )
+                        for arg in prompt["arguments"]
+                    ]
+                prompt_info = PromptInfo(
+                    prompt_id=prompt_id,
+                    server_name=name,
+                    name=prompt_name,
+                    title=prompt.get("title"),
+                    description=prompt.get("description"),
+                    arguments=arguments,
+                    icons=prompt.get("icons"),
+                    annotations=prompt.get("annotations"),
+                    raw_metadata=_raw_metadata(prompt, known_prompt_fields),
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[{name}] Skipping unparseable prompt {_entry_label(prompt)}: {e}"
+                )
+                continue
+
             self._prompts[prompt_id] = prompt_info
-        if prompts and not self._catalog_publishing_suppressed(name):
+            indexed += 1
+        if indexed and not self._catalog_publishing_suppressed(name):
             self._catalog_events.note_prompts_changed()
-        return len(prompts)
+        return indexed
 
     async def _fetch_server_listings(
         self, managed: ManagedClient

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -495,6 +495,161 @@ def _schema_dialect(*schemas: dict[str, Any] | None) -> str:
     return DEFAULT_SCHEMA_DIALECT
 
 
+def _parse_tool_entries(
+    name: str, tools: list[dict[str, Any]], limit: int
+) -> list[tuple[str, ToolInfo]]:
+    """Parse one server's `tools/list` payload into indexable entries.
+
+    Pure: it reads the listing, logs the entries it had to skip, and returns
+    what survived. It touches no catalog dict, which is what lets
+    `_reconcile_once` run it *before* removing anything and decide from the
+    result whether the listing is usable at all -- see its "offered but none
+    parseable" rule. `_index_tools` does the writing.
+    """
+    entries: list[tuple[str, ToolInfo]] = []
+    known_fields = {
+        "name",
+        "title",
+        "description",
+        "inputSchema",
+        "outputSchema",
+        "icons",
+        "annotations",
+        "execution",
+    }
+    for tool in tools:
+        if len(entries) >= limit:
+            logger.warning(f"Server {name} has more than {limit} tools, truncating")
+            break
+
+        try:
+            tool_name = tool["name"]
+            tool_id = make_tool_id(name, tool_name)
+            description = tool.get("description", "")
+            input_schema = tool.get("inputSchema", {})
+            output_schema = tool.get("outputSchema")
+
+            tool_info = ToolInfo(
+                tool_id=tool_id,
+                server_name=name,
+                tool_name=tool_name,
+                title=tool.get("title"),
+                description=description,
+                short_description=_truncate_description(description),
+                input_schema=input_schema,
+                icons=tool.get("icons"),
+                output_schema=output_schema,
+                annotations=tool.get("annotations"),
+                execution=tool.get("execution"),
+                schema_dialect=_schema_dialect(input_schema, output_schema),
+                raw_metadata=_raw_metadata(tool, known_fields),
+                tags=_extract_tags(name, tool_name, description),
+                risk_hint=_infer_risk_hint(
+                    tool_name, description, tool.get("annotations")
+                ),
+            )
+        except Exception as e:
+            logger.warning(
+                f"[{name}] Skipping unparseable tool {_entry_label(tool)}: {e}"
+            )
+            continue
+
+        entries.append((tool_id, tool_info))
+    return entries
+
+
+def _parse_resource_entries(
+    name: str, resources: list[dict[str, Any]]
+) -> list[tuple[str, ResourceInfo]]:
+    """Parse one server's `resources/list` payload. Pure, per `_parse_tool_entries`."""
+    entries: list[tuple[str, ResourceInfo]] = []
+    known_fields = {
+        "uri",
+        "name",
+        "title",
+        "description",
+        "mimeType",
+        "icons",
+        "annotations",
+    }
+    for resource in resources:
+        try:
+            uri = resource.get("uri", "")
+            resource_id = f"{name}::{uri}"
+            resource_info = ResourceInfo(
+                resource_id=resource_id,
+                server_name=name,
+                uri=uri,
+                name=resource.get("name"),
+                title=resource.get("title"),
+                description=resource.get("description"),
+                mime_type=resource.get("mimeType"),
+                icons=resource.get("icons"),
+                annotations=resource.get("annotations"),
+                raw_metadata=_raw_metadata(resource, known_fields),
+            )
+        except Exception as e:
+            logger.warning(
+                f"[{name}] Skipping unparseable resource "
+                f"{_entry_label(resource, key='uri')}: {e}"
+            )
+            continue
+
+        entries.append((resource_id, resource_info))
+    return entries
+
+
+def _parse_prompt_entries(
+    name: str, prompts: list[dict[str, Any]]
+) -> list[tuple[str, PromptInfo]]:
+    """Parse one server's `prompts/list` payload. Pure, per `_parse_tool_entries`."""
+    entries: list[tuple[str, PromptInfo]] = []
+    known_prompt_fields = {
+        "name",
+        "title",
+        "description",
+        "arguments",
+        "icons",
+        "annotations",
+    }
+    known_arg_fields = {"name", "title", "description", "required"}
+    for prompt in prompts:
+        try:
+            prompt_name = prompt.get("name", "")
+            prompt_id = f"{name}::{prompt_name}"
+            arguments = None
+            if prompt.get("arguments"):
+                arguments = [
+                    PromptArgumentInfo(
+                        name=arg.get("name", ""),
+                        title=arg.get("title"),
+                        description=arg.get("description"),
+                        required=arg.get("required", False),
+                        raw_metadata=_raw_metadata(arg, known_arg_fields),
+                    )
+                    for arg in prompt["arguments"]
+                ]
+            prompt_info = PromptInfo(
+                prompt_id=prompt_id,
+                server_name=name,
+                name=prompt_name,
+                title=prompt.get("title"),
+                description=prompt.get("description"),
+                arguments=arguments,
+                icons=prompt.get("icons"),
+                annotations=prompt.get("annotations"),
+                raw_metadata=_raw_metadata(prompt, known_prompt_fields),
+            )
+        except Exception as e:
+            logger.warning(
+                f"[{name}] Skipping unparseable prompt {_entry_label(prompt)}: {e}"
+            )
+            continue
+
+        entries.append((prompt_id, prompt_info))
+    return entries
+
+
 def _is_protocol_version_initialize_error(exc: Exception) -> bool:
     message = str(exc).lower()
     return (
@@ -1336,15 +1491,21 @@ class ClientManager:
                 errors.append(message)
         return cancelled, errors
 
-    def _index_tools(self, name: str, tools: list[dict[str, Any]]) -> int:
+    def _index_tools(
+        self,
+        name: str,
+        tools: list[dict[str, Any]],
+        *,
+        parsed: list[tuple[str, ToolInfo]] | None = None,
+    ) -> int:
         """Index one server's tools, skipping any entry we cannot parse.
 
-        The guard below is per *entry*, not per call, and that placement is the
-        whole point. Reconciliation removes this server's entries and then calls
-        this method; an exception escaping here would leave the removal done and
-        the re-index half-finished, so one malformed tool from a downstream
-        would silently cost the server its entire catalog -- permanently, since
-        the read loop stays healthy and no reconnect comes along to heal it. A
+        The guard is per *entry*, not per call, and that placement is the whole
+        point. Reconciliation removes this server's entries and then calls this
+        method; an exception escaping here would leave the removal done and the
+        re-index half-finished, so one malformed tool from a downstream would
+        silently cost the server its entire catalog -- permanently, since the
+        read loop stays healthy and no reconnect comes along to heal it. A
         single `try` around the loop would be barely better: it would still lose
         every entry after the bad one.
 
@@ -1352,160 +1513,64 @@ class ClientManager:
         and `refresh` reach the same three methods, so they inherit this too: a
         server with one unparseable tool now connects with the rest of its
         catalog instead of failing outright.
+
+        The parsing itself lives in `_parse_tool_entries`, which writes nothing.
+        `parsed` lets a caller that has already run it -- `_reconcile_once`,
+        which must know how many entries survive parsing *before* it removes
+        anything -- hand the result straight in, so each listing is parsed once
+        and each unparseable entry is logged once. Callers with a raw listing
+        omit it and this method parses for them.
         """
-        indexed = 0
-        known_fields = {
-            "name",
-            "title",
-            "description",
-            "inputSchema",
-            "outputSchema",
-            "icons",
-            "annotations",
-            "execution",
-        }
-        for tool in tools:
-            if indexed >= self._max_tools_per_server:
-                logger.warning(
-                    f"Server {name} has more than {self._max_tools_per_server} tools, truncating"
-                )
-                break
-
-            try:
-                tool_name = tool["name"]
-                tool_id = make_tool_id(name, tool_name)
-                description = tool.get("description", "")
-                input_schema = tool.get("inputSchema", {})
-                output_schema = tool.get("outputSchema")
-
-                tool_info = ToolInfo(
-                    tool_id=tool_id,
-                    server_name=name,
-                    tool_name=tool_name,
-                    title=tool.get("title"),
-                    description=description,
-                    short_description=_truncate_description(description),
-                    input_schema=input_schema,
-                    icons=tool.get("icons"),
-                    output_schema=output_schema,
-                    annotations=tool.get("annotations"),
-                    execution=tool.get("execution"),
-                    schema_dialect=_schema_dialect(input_schema, output_schema),
-                    raw_metadata=_raw_metadata(tool, known_fields),
-                    tags=_extract_tags(name, tool_name, description),
-                    risk_hint=_infer_risk_hint(
-                        tool_name, description, tool.get("annotations")
-                    ),
-                )
-            except Exception as e:
-                logger.warning(
-                    f"[{name}] Skipping unparseable tool {_entry_label(tool)}: {e}"
-                )
-                continue
-
+        entries = (
+            _parse_tool_entries(name, tools, self._max_tools_per_server)
+            if parsed is None
+            else parsed
+        )
+        for tool_id, tool_info in entries:
             self._tools[tool_id] = tool_info
-            indexed += 1
+        indexed = len(entries)
         if indexed and not self._catalog_publishing_suppressed(name):
             self._catalog_events.note_tools_changed()
         return indexed
 
-    def _index_resources(self, name: str, resources: list[dict[str, Any]]) -> int:
+    def _index_resources(
+        self,
+        name: str,
+        resources: list[dict[str, Any]],
+        *,
+        parsed: list[tuple[str, ResourceInfo]] | None = None,
+    ) -> int:
         """Index one server's resources, skipping any entry we cannot parse.
 
-        Per-entry, for the reason spelled out on `_index_tools`. The count
-        returned is what was actually indexed, not what was offered, so a caller
-        reporting it is not overstating the catalog.
+        Per-entry, for the reason spelled out on `_index_tools`, and `parsed`
+        for the reason spelled out there too. The count returned is what was
+        actually indexed, not what was offered, so a caller reporting it is not
+        overstating the catalog.
         """
-        indexed = 0
-        known_fields = {
-            "uri",
-            "name",
-            "title",
-            "description",
-            "mimeType",
-            "icons",
-            "annotations",
-        }
-        for resource in resources:
-            try:
-                uri = resource.get("uri", "")
-                resource_id = f"{name}::{uri}"
-                resource_info = ResourceInfo(
-                    resource_id=resource_id,
-                    server_name=name,
-                    uri=uri,
-                    name=resource.get("name"),
-                    title=resource.get("title"),
-                    description=resource.get("description"),
-                    mime_type=resource.get("mimeType"),
-                    icons=resource.get("icons"),
-                    annotations=resource.get("annotations"),
-                    raw_metadata=_raw_metadata(resource, known_fields),
-                )
-            except Exception as e:
-                logger.warning(
-                    f"[{name}] Skipping unparseable resource "
-                    f"{_entry_label(resource, key='uri')}: {e}"
-                )
-                continue
-
+        entries = _parse_resource_entries(name, resources) if parsed is None else parsed
+        for resource_id, resource_info in entries:
             self._resources[resource_id] = resource_info
-            indexed += 1
+        indexed = len(entries)
         if indexed and not self._catalog_publishing_suppressed(name):
             self._catalog_events.note_resources_changed()
         return indexed
 
-    def _index_prompts(self, name: str, prompts: list[dict[str, Any]]) -> int:
+    def _index_prompts(
+        self,
+        name: str,
+        prompts: list[dict[str, Any]],
+        *,
+        parsed: list[tuple[str, PromptInfo]] | None = None,
+    ) -> int:
         """Index one server's prompts, skipping any entry we cannot parse.
 
         Per-entry, for the reason spelled out on `_index_tools`. The count
         returned is what was actually indexed, not what was offered.
         """
-        indexed = 0
-        known_prompt_fields = {
-            "name",
-            "title",
-            "description",
-            "arguments",
-            "icons",
-            "annotations",
-        }
-        known_arg_fields = {"name", "title", "description", "required"}
-        for prompt in prompts:
-            try:
-                prompt_name = prompt.get("name", "")
-                prompt_id = f"{name}::{prompt_name}"
-                arguments = None
-                if prompt.get("arguments"):
-                    arguments = [
-                        PromptArgumentInfo(
-                            name=arg.get("name", ""),
-                            title=arg.get("title"),
-                            description=arg.get("description"),
-                            required=arg.get("required", False),
-                            raw_metadata=_raw_metadata(arg, known_arg_fields),
-                        )
-                        for arg in prompt["arguments"]
-                    ]
-                prompt_info = PromptInfo(
-                    prompt_id=prompt_id,
-                    server_name=name,
-                    name=prompt_name,
-                    title=prompt.get("title"),
-                    description=prompt.get("description"),
-                    arguments=arguments,
-                    icons=prompt.get("icons"),
-                    annotations=prompt.get("annotations"),
-                    raw_metadata=_raw_metadata(prompt, known_prompt_fields),
-                )
-            except Exception as e:
-                logger.warning(
-                    f"[{name}] Skipping unparseable prompt {_entry_label(prompt)}: {e}"
-                )
-                continue
-
+        entries = _parse_prompt_entries(name, prompts) if parsed is None else parsed
+        for prompt_id, prompt_info in entries:
             self._prompts[prompt_id] = prompt_info
-            indexed += 1
+        indexed = len(entries)
         if indexed and not self._catalog_publishing_suppressed(name):
             self._catalog_events.note_prompts_changed()
         return indexed
@@ -1607,7 +1672,10 @@ class ClientManager:
         a single synchronous block. Nothing can interleave inside that block, so
         a `gateway.invoke` running concurrently with a reconcile sees the old
         catalog or the new one, never an empty one. A kind whose listing failed
-        is left exactly as it was -- "we could not ask" is not "they are gone".
+        is left exactly as it was -- "we could not ask" is not "they are gone" --
+        and so is a kind that offered entries of which not one could be parsed,
+        which is the same state reached by a different route. An answer of zero
+        entries is still an answer and does clear the kind.
 
         Suppress-while-churning, publish-once-if-changed. The swap's removal and
         re-index halves both call `CatalogEventSink.note_*` unconditionally, so
@@ -1729,6 +1797,29 @@ class ClientManager:
         `refreshed`: it is neither removed nor re-indexed nor published, because
         "we could not ask" is not "they are gone". A kind that answered is
         replaced wholesale and published only if its entries actually differ.
+
+        A listing nobody could parse is a failed listing. If a kind offers
+        entries and *not one* of them survives parsing, we are in the same
+        epistemic state as a failed request -- we could not read the answer --
+        so that kind is dropped from `refreshed` too and left exactly as it was.
+        A parse failure degrades our visibility of the server's catalog; it does
+        not make the server's tools stop working, and publishing a removal on
+        the strength of it would tell every subscriber they are gone. Note the
+        boundary: a listing that offers *zero* entries is a real answer -- the
+        server emptied that kind -- and still clears and publishes. Only
+        offered-but-none-parseable is treated as failure. Mixed listings keep
+        the per-entry semantics: something parsed, so the kind answered and is
+        replaced by what parsed.
+
+        (On connect there is no prior catalog to protect -- `_connect_stdio` and
+        friends remove this server's indexes first -- so `_index_capabilities`
+        deliberately keeps the plain per-entry behaviour: an all-malformed
+        listing there yields an empty catalog for that kind, not a failed
+        connect.)
+
+        Parsing happens before the apply block, not inside it. It is pure CPU
+        and writes nothing, so doing it early costs nothing and is what lets the
+        decision above be made while the old catalog is still intact.
         """
         try:
             listings = await self._fetch_server_listings(managed)
@@ -1739,7 +1830,41 @@ class ClientManager:
             logger.warning(f"[{name}] Catalog reconciliation failed: {e}")
             return
 
-        refreshed = tuple(k for k in CATALOG_KINDS if listings[k] is not None)
+        tools = listings["tools"]
+        resources = listings["resources"]
+        prompts = listings["prompts"]
+        parsed_tools = (
+            None
+            if tools is None
+            else _parse_tool_entries(name, tools, self._max_tools_per_server)
+        )
+        parsed_resources = (
+            None if resources is None else _parse_resource_entries(name, resources)
+        )
+        parsed_prompts = (
+            None if prompts is None else _parse_prompt_entries(name, prompts)
+        )
+
+        usable: dict[str, bool] = {}
+        for kind, offered, parsed in (
+            ("tools", tools, parsed_tools),
+            ("resources", resources, parsed_resources),
+            ("prompts", prompts, parsed_prompts),
+        ):
+            if offered is None:
+                usable[kind] = False
+                continue
+            if offered and not parsed:
+                logger.warning(
+                    f"[{name}] Every {kind} entry in the listing was unparseable "
+                    f"({len(offered)} offered); keeping the previous {kind} "
+                    "rather than reporting them removed"
+                )
+                usable[kind] = False
+                continue
+            usable[kind] = True
+
+        refreshed = tuple(k for k in CATALOG_KINDS if usable[k])
         before = self._server_catalog_snapshot(name)
 
         # ---- apply: synchronous, no `await` below this line --------------
@@ -1748,15 +1873,12 @@ class ClientManager:
             # `drop_tasks=False`: the server is still connected, so its tracked
             # task records must survive a catalog refresh.
             self._remove_server_indexes(name, drop_tasks=False, kinds=refreshed)
-            tools = listings["tools"]
-            if tools is not None:
-                self._index_tools(name, tools)
-            resources = listings["resources"]
-            if resources is not None:
-                self._index_resources(name, resources)
-            prompts = listings["prompts"]
-            if prompts is not None:
-                self._index_prompts(name, prompts)
+            if usable["tools"] and tools is not None:
+                self._index_tools(name, tools, parsed=parsed_tools)
+            if usable["resources"] and resources is not None:
+                self._index_resources(name, resources, parsed=parsed_resources)
+            if usable["prompts"] and prompts is not None:
+                self._index_prompts(name, prompts, parsed=parsed_prompts)
         finally:
             depth = self._catalog_suppressed.get(name, 1) - 1
             if depth > 0:

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -64,6 +64,16 @@ except ImportError:
 logger = logging.getLogger(__name__)
 _TaskT = TypeVar("_TaskT", bound=asyncio.Task[Any])
 
+# IF-0-FANOUT-1: the downstream `notifications/*` methods this gateway acts on,
+# mapped to the catalog kind whose identifier set decides whether reconciliation
+# publishes. Every method absent from this mapping is a no-op by construction --
+# see `ClientManager._handle_downstream_notification`.
+DOWNSTREAM_LIST_CHANGED_METHODS: dict[str, str] = {
+    "notifications/tools/list_changed": "tools",
+    "notifications/resources/list_changed": "resources",
+    "notifications/prompts/list_changed": "prompts",
+}
+
 
 class _NullCatalogEventSink:
     """No-op `CatalogEventSink` used when `ClientManager` is constructed with
@@ -1320,6 +1330,66 @@ class ClientManager:
         # acceptance test pass even if the self-scheduling drain were
         # completely broken.
         return indexed, resource_count, prompt_count
+
+    def _handle_downstream_notification(
+        self, name: str, managed: ManagedClient, method: str
+    ) -> bool:
+        """Act on one JSON-RPC notification received from a downstream server.
+
+        This is IF-0-FANOUT-1, the downstream-event contract. It is called from
+        both dispatch paths -- `_handle_stdout_line` (stdio) and `_read_sse`
+        (remote) -- for every frame that carries a `method` and no `id`.
+
+        Method mapping. Exactly three methods are recognised, each requesting a
+        re-index of the *whole* of that one server's catalog (the gateway's
+        catalog is index-backed, not proxied, so a per-kind refetch would still
+        need the same round trip):
+
+        - `notifications/tools/list_changed`
+        - `notifications/resources/list_changed`
+        - `notifications/prompts/list_changed`
+
+        Reconcile-then-publish ordering. The gateway serves `gateway.invoke` and
+        `gateway.catalog_search` out of its own index, so a notification
+        forwarded straight to the subscription sink would tell a client to
+        refetch and then hand it the stale catalog. Reconciliation therefore
+        always completes before anything is published.
+
+        Suppress-while-churning, publish-once-if-changed. Reconciliation is a
+        remove-then-reindex, and both halves call `CatalogEventSink.note_*`
+        unconditionally, so a chatty downstream would spam subscribers even when
+        nothing moved. Sink calls originating from the server under
+        reconciliation are suppressed for its duration; afterwards the server's
+        identifier sets are compared before against after, and exactly one
+        `note_*` is published per catalog kind that actually differs. Identifier
+        sets, never counts: a rename leaves the count unchanged.
+
+        Unrecognised methods are a no-op. Any other `notifications/*` (or any
+        other method name) returns False having published nothing, scheduled
+        nothing, and raised nothing. This function never raises: `_read_sse`
+        wraps its loop in a blanket `except Exception` that tears the connection
+        down and triggers a reconnect, so a raise here would turn an unknown
+        notification into a dropped server.
+
+        Never blocks the caller. The reconcile runs in a task spawned with
+        `asyncio.create_task`, never awaited inline -- see
+        `_reconcile_server_catalog` for why an inline await deadlocks
+        immediately.
+
+        Args:
+            name: The downstream server's registered name.
+            managed: The client that received the notification.
+            method: The notification's JSON-RPC `method`.
+
+        Returns:
+            True if the method was recognised and a reconcile was requested,
+            False if it was ignored.
+        """
+        if method not in DOWNSTREAM_LIST_CHANGED_METHODS:
+            return False
+        # IF-0-FANOUT-1 freeze (SL-1.2): recognition is published so peer lanes
+        # can build against it; the scheduler body lands in SL-1.4.
+        return True
 
     async def _connect_stdio(self, config: ResolvedServerConfig) -> None:
         """Connect to a local stdio MCP server."""

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -488,6 +488,74 @@ def _entry_label(entry: Any, key: str = "name") -> str:
     return repr(entry)[:120]
 
 
+def _required_identity(entry: Any, key: str) -> str:
+    """The identity a catalog entry cannot be indexed without.
+
+    Raises rather than defaulting, and that is the whole point. `entry.get(key,
+    "")` turns an entry with no identity into one whose identity is the empty
+    string, so `{}` indexes as `srv::` -- a wholly synthetic entry that replaces
+    the real one and gets published as a change. The MCP models reject those
+    payloads outright; defaulting here invents an identity the protocol never
+    offered.
+
+    Every caller runs inside its parser's per-entry `try`, so raising routes the
+    entry into the existing skip, and a listing in which *no* entry parses
+    routes into `_reconcile_once`'s offered-but-none-parseable rule, which keeps
+    the prior entries. Both are the behaviour we want for "this entry told us
+    nothing": not "it is gone".
+
+    `entry` is typed `Any` because a non-object entry (`["a string"]`) must land
+    here too, rather than raising `AttributeError` somewhere less legible.
+    """
+    if not isinstance(entry, dict):
+        raise TypeError(f"catalog entry is {type(entry).__name__}, not an object")
+    value = entry.get(key)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"catalog entry has no usable `{key}`")
+    return value
+
+
+def _listing_entries(name: str, kind: str, result: Any) -> list[dict[str, Any]] | None:
+    """The entries a `*/list` reply offered, or `None` if it offered none readably.
+
+    `result.get(kind, [])` conflates two different answers. A reply of
+    `{"tools": []}` says the server has no tools; a reply of `result: {}` is
+    missing a field the protocol requires, so it says nothing at all -- and the
+    default turns the second into the first, clearing the catalog and publishing
+    a removal built out of a malformed response. `list()` on a non-list widens
+    the same hole: `{"tools": {}}` coerces to `[]` and reads as an explicit
+    empty answer, while `{"tools": null}` raises `TypeError` out of
+    `_fetch_server_listings` and costs the *other* two kinds their reconcile.
+
+    So: absent field, non-object reply, or non-list value all return `None`,
+    which callers already treat as a failed listing -- prior entries kept,
+    nothing published. Only a genuine list is an answer, and an empty one still
+    clears. "We could not read the answer" is not "they are gone", the same
+    principle `_reconcile_once` applies to a request that failed and to a
+    listing whose every entry was unparseable.
+    """
+    if not isinstance(result, dict):
+        logger.warning(
+            f"[{name}] {kind}/list answered with "
+            f"{type(result).__name__}, not an object; treating as unreadable"
+        )
+        return None
+    if kind not in result:
+        logger.warning(
+            f"[{name}] {kind}/list answered without its required `{kind}` field; "
+            f"treating as unreadable rather than as an empty {kind} list"
+        )
+        return None
+    offered = result[kind]
+    if not isinstance(offered, list):
+        logger.warning(
+            f"[{name}] {kind}/list answered with `{kind}` as "
+            f"{type(offered).__name__}, not a list; treating as unreadable"
+        )
+        return None
+    return list(offered)
+
+
 def _schema_dialect(*schemas: dict[str, Any] | None) -> str:
     for schema in schemas:
         if schema and isinstance(schema.get("$schema"), str):
@@ -523,7 +591,7 @@ def _parse_tool_entries(
             break
 
         try:
-            tool_name = tool["name"]
+            tool_name = _required_identity(tool, "name")
             tool_id = make_tool_id(name, tool_name)
             description = tool.get("description", "")
             input_schema = tool.get("inputSchema", {})
@@ -574,7 +642,7 @@ def _parse_resource_entries(
     }
     for resource in resources:
         try:
-            uri = resource.get("uri", "")
+            uri = _required_identity(resource, "uri")
             resource_id = f"{name}::{uri}"
             resource_info = ResourceInfo(
                 resource_id=resource_id,
@@ -615,7 +683,7 @@ def _parse_prompt_entries(
     known_arg_fields = {"name", "title", "description", "required"}
     for prompt in prompts:
         try:
-            prompt_name = prompt.get("name", "")
+            prompt_name = _required_identity(prompt, "name")
             prompt_id = f"{name}::{prompt_name}"
             arguments = None
             if prompt.get("arguments"):
@@ -1588,10 +1656,17 @@ class ClientManager:
 
         Return shape, per kind:
 
-        - `list[...]` -- the server answered. An **empty list is an answer**: it
+        - `list[...]` -- the server answered, and the reply carried the
+          collection the protocol requires. An **empty list is an answer**: it
           means the kind is genuinely empty and its entries should be cleared.
-        - `None` -- the request failed, i.e. we could not ask. The caller must
-          leave that kind exactly as it was and publish nothing for it.
+        - `None` -- we could not read an answer. The caller must leave that kind
+          exactly as it was and publish nothing for it.
+
+        `None` covers two cases that used to look different and are not. The
+        request failing is the obvious one. The other is a reply we cannot read:
+        its required collection absent, or present but not a list. Those are
+        malformed, not empty -- see `_listing_entries`, which draws the line.
+        Any kind can now come back `None`, `tools` included.
 
         Only `tools/list` failing raises. A server that does not implement
         resources or prompts is ordinary and answers those two with an error,
@@ -1609,7 +1684,7 @@ class ClientManager:
         )
 
         listings: dict[str, list[dict[str, Any]] | None] = {
-            "tools": list(tools_result.get("tools", []))
+            "tools": _listing_entries(name, "tools", tools_result)
         }
         for kind, result in (
             ("resources", listing_results[0]),
@@ -1619,7 +1694,7 @@ class ClientManager:
                 logger.debug(f"Server {name} doesn't support {kind}: {result}")
                 listings[kind] = None
             else:
-                listings[kind] = list(result.get(kind, []))
+                listings[kind] = _listing_entries(name, kind, result)
         return listings
 
     async def _index_capabilities(self, managed: ManagedClient) -> tuple[int, int, int]:
@@ -1673,9 +1748,11 @@ class ClientManager:
         a `gateway.invoke` running concurrently with a reconcile sees the old
         catalog or the new one, never an empty one. A kind whose listing failed
         is left exactly as it was -- "we could not ask" is not "they are gone" --
-        and so is a kind that offered entries of which not one could be parsed,
-        which is the same state reached by a different route. An answer of zero
-        entries is still an answer and does clear the kind.
+        and so are the three states reached by different routes to the same
+        place: a reply missing its required collection or carrying a non-list in
+        its place, and a listing that offered entries of which not one could be
+        parsed. An answer of zero entries is still an answer and does clear the
+        kind.
 
         Suppress-while-churning, publish-once-if-changed. The swap's removal and
         re-index halves both call `CatalogEventSink.note_*` unconditionally, so
@@ -1810,6 +1887,17 @@ class ClientManager:
         offered-but-none-parseable is treated as failure. Mixed listings keep
         the per-entry semantics: something parsed, so the kind answered and is
         replaced by what parsed.
+
+        A listing that never arrived readably never reaches that rule at all.
+        `_listing_entries` has already collapsed an absent collection, or one
+        that is not a list, to `None` -- so it is `offered is None` here, the
+        same branch as a request that failed outright. That distinction is load
+        bearing: `result: {}` and `{"tools": []}` are different answers, and
+        only the second one means the kind is empty. Likewise an entry with no
+        identity now fails to parse (`_required_identity`) instead of indexing
+        as `srv::`, so a listing of nothing but such entries lands in the
+        offered-but-none-parseable rule above rather than replacing real entries
+        with synthetic ones.
 
         (On connect there is no prior catalog to protect -- `_connect_stdio` and
         friends remove this server's indexes first -- so `_index_capabilities`

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -14,6 +14,7 @@ import signal
 import string
 import time
 from collections import deque
+from collections.abc import Collection
 from dataclasses import dataclass, field
 from types import ModuleType
 from typing import Any, TypeVar
@@ -64,8 +65,13 @@ except ImportError:
 logger = logging.getLogger(__name__)
 _TaskT = TypeVar("_TaskT", bound=asyncio.Task[Any])
 
+# The three catalog kinds, in the order reconciliation fetches and applies them.
+# Iterating this rather than three hand-written branches is what keeps
+# "each kind is handled independently" true as kinds are added.
+CATALOG_KINDS: tuple[str, str, str] = ("tools", "resources", "prompts")
+
 # IF-0-FANOUT-1: the downstream `notifications/*` methods this gateway acts on,
-# mapped to the catalog kind whose identifier set decides whether reconciliation
+# mapped to the catalog kind whose entries decide whether reconciliation
 # publishes. Every method absent from this mapping is a no-op by construction --
 # see `ClientManager._handle_downstream_notification`.
 DOWNSTREAM_LIST_CHANGED_METHODS: dict[str, str] = {
@@ -1067,22 +1073,45 @@ class ClientManager:
         """
         return bool(self._catalog_suppressed.get(server_name))
 
-    def _server_catalog_ids(self, name: str) -> dict[str, set[str]]:
-        """The identifier sets one server currently owns, per catalog kind.
+    def _server_catalog_snapshot(self, name: str) -> dict[str, dict[str, Any]]:
+        """What one server currently owns, per catalog kind, by *content*.
 
-        Identifier *sets*, never counts: renaming a tool leaves the count
-        identical while the catalog genuinely moved, and a count-based diff
-        would silently swallow that change.
+        Not identifier sets and emphatically not counts. A count-based diff
+        misses a rename, an identifier-set diff misses an edit in place: a tool
+        whose `description` or `inputSchema` changed under the same name is a
+        real catalog change that a subscriber has to hear about. Comparing the
+        model dumps catches adds, removes, renames, and edits with one rule.
+
+        `model_dump()` in python mode, not `mode="json"`: every field here was
+        parsed out of JSON already, so the python dump is comparable by `==`
+        without paying for -- or risking a serializer warning on -- the
+        arbitrary values carried in `raw_metadata`.
         """
         return {
-            "tools": {k for k, v in self._tools.items() if v.server_name == name},
-            "resources": {
-                k for k, v in self._resources.items() if v.server_name == name
+            "tools": {
+                k: v.model_dump()
+                for k, v in self._tools.items()
+                if v.server_name == name
             },
-            "prompts": {k for k, v in self._prompts.items() if v.server_name == name},
+            "resources": {
+                k: v.model_dump()
+                for k, v in self._resources.items()
+                if v.server_name == name
+            },
+            "prompts": {
+                k: v.model_dump()
+                for k, v in self._prompts.items()
+                if v.server_name == name
+            },
         }
 
-    def _remove_server_indexes(self, name: str, *, drop_tasks: bool = True) -> None:
+    def _remove_server_indexes(
+        self,
+        name: str,
+        *,
+        drop_tasks: bool = True,
+        kinds: Collection[str] | None = None,
+    ) -> None:
         """Remove catalog entries owned by one server.
 
         `drop_tasks=False` keeps the server's tracked `McpTaskRecord`s. Dropping
@@ -1090,22 +1119,32 @@ class ClientManager:
         the connection, and wrong for a `list_changed` reconcile, where the
         server is still up and its in-flight tasks are still running -- evicting
         them there would silently break `gateway.tasks_list`/`tasks_result`.
+
+        `kinds=None` removes all three, which is what a disconnect wants.
+        Reconciliation passes only the kinds whose re-listing actually
+        succeeded: a `resources/list` that failed means "we could not ask", and
+        turning that into "they are gone" both deletes entries the server still
+        has and publishes a false removal.
         """
+        selected = CATALOG_KINDS if kinds is None else tuple(kinds)
         tools_removed = False
-        for tool_id, tool in list(self._tools.items()):
-            if tool.server_name == name:
-                self._tools.pop(tool_id, None)
-                tools_removed = True
+        if "tools" in selected:
+            for tool_id, tool in list(self._tools.items()):
+                if tool.server_name == name:
+                    self._tools.pop(tool_id, None)
+                    tools_removed = True
         resources_removed = False
-        for resource_id, resource in list(self._resources.items()):
-            if resource.server_name == name:
-                self._resources.pop(resource_id, None)
-                resources_removed = True
+        if "resources" in selected:
+            for resource_id, resource in list(self._resources.items()):
+                if resource.server_name == name:
+                    self._resources.pop(resource_id, None)
+                    resources_removed = True
         prompts_removed = False
-        for prompt_id, prompt in list(self._prompts.items()):
-            if prompt.server_name == name:
-                self._prompts.pop(prompt_id, None)
-                prompts_removed = True
+        if "prompts" in selected:
+            for prompt_id, prompt in list(self._prompts.items()):
+                if prompt.server_name == name:
+                    self._prompts.pop(prompt_id, None)
+                    prompts_removed = True
         if drop_tasks:
             for key in list(self._tasks):
                 if key[0] == name:
@@ -1404,11 +1443,32 @@ class ClientManager:
             self._catalog_events.note_prompts_changed()
         return len(prompts)
 
-    async def _index_capabilities(self, managed: ManagedClient) -> tuple[int, int, int]:
+    async def _fetch_server_listings(
+        self, managed: ManagedClient
+    ) -> dict[str, list[dict[str, Any]] | None]:
+        """List one server's three catalog kinds, mutating nothing.
+
+        Every downstream request reconciliation makes lives here, and no catalog
+        write does. That separation is the whole point: the caller can do all of
+        its awaiting first and then apply the result in one synchronous block,
+        so the catalog is never left empty across a network round trip for a
+        concurrent `gateway.invoke` to trip over.
+
+        Return shape, per kind:
+
+        - `list[...]` -- the server answered. An **empty list is an answer**: it
+          means the kind is genuinely empty and its entries should be cleared.
+        - `None` -- the request failed, i.e. we could not ask. The caller must
+          leave that kind exactly as it was and publish nothing for it.
+
+        Only `tools/list` failing raises. A server that does not implement
+        resources or prompts is ordinary and answers those two with an error,
+        which is why they are gathered with `return_exceptions=True` and mapped
+        to `None` rather than propagated.
+        """
         name = managed.config.name
 
         tools_result = await self._send_request(managed, "tools/list", {})
-        indexed = self._index_tools(name, tools_result.get("tools", []))
 
         resources_task = self._send_request(managed, "resources/list", {})
         prompts_task = self._send_request(managed, "prompts/list", {})
@@ -1416,21 +1476,33 @@ class ClientManager:
             resources_task, prompts_task, return_exceptions=True
         )
 
-        resource_count = 0
-        resources_result = listing_results[0]
-        if isinstance(resources_result, BaseException):
-            logger.debug(f"Server {name} doesn't support resources: {resources_result}")
-        else:
-            resource_count = self._index_resources(
-                name, resources_result.get("resources", [])
-            )
+        listings: dict[str, list[dict[str, Any]] | None] = {
+            "tools": list(tools_result.get("tools", []))
+        }
+        for kind, result in (
+            ("resources", listing_results[0]),
+            ("prompts", listing_results[1]),
+        ):
+            if isinstance(result, BaseException):
+                logger.debug(f"Server {name} doesn't support {kind}: {result}")
+                listings[kind] = None
+            else:
+                listings[kind] = list(result.get(kind, []))
+        return listings
 
-        prompt_count = 0
-        prompts_result = listing_results[1]
-        if isinstance(prompts_result, BaseException):
-            logger.debug(f"Server {name} doesn't support prompts: {prompts_result}")
-        else:
-            prompt_count = self._index_prompts(name, prompts_result.get("prompts", []))
+    async def _index_capabilities(self, managed: ManagedClient) -> tuple[int, int, int]:
+        name = managed.config.name
+        listings = await self._fetch_server_listings(managed)
+
+        indexed = self._index_tools(name, listings["tools"] or [])
+
+        resources = listings["resources"]
+        resource_count = (
+            0 if resources is None else self._index_resources(name, resources)
+        )
+
+        prompts = listings["prompts"]
+        prompt_count = 0 if prompts is None else self._index_prompts(name, prompts)
 
         # No flush() here, deliberately: IF-0-P3B-1's self-scheduling drain
         # is the correctness mechanism, not this call site, and EC-P3B-4
@@ -1463,14 +1535,22 @@ class ClientManager:
         refetch and then hand it the stale catalog. Reconciliation therefore
         always completes before anything is published.
 
-        Suppress-while-churning, publish-once-if-changed. Reconciliation is a
-        remove-then-reindex, and both halves call `CatalogEventSink.note_*`
-        unconditionally, so a chatty downstream would spam subscribers even when
-        nothing moved. Sink calls originating from the server under
-        reconciliation are suppressed for its duration; afterwards the server's
-        identifier sets are compared before against after, and exactly one
-        `note_*` is published per catalog kind that actually differs. Identifier
-        sets, never counts: a rename leaves the count unchanged.
+        Fetch-then-swap. Reconciliation lists the server's three catalog kinds
+        first and writes nothing while doing so, then removes and re-indexes in
+        a single synchronous block. Nothing can interleave inside that block, so
+        a `gateway.invoke` running concurrently with a reconcile sees the old
+        catalog or the new one, never an empty one. A kind whose listing failed
+        is left exactly as it was -- "we could not ask" is not "they are gone".
+
+        Suppress-while-churning, publish-once-if-changed. The swap's removal and
+        re-index halves both call `CatalogEventSink.note_*` unconditionally, so
+        a chatty downstream would spam subscribers even when nothing moved. Sink
+        calls originating from the server under reconciliation are suppressed
+        for the duration of the swap; afterwards its entries are compared before
+        against after, and exactly one `note_*` is published per catalog kind
+        that actually differs. Entries, not identifiers and certainly not
+        counts: a rename leaves the count unchanged, and an edited description
+        or schema leaves the identifiers unchanged too.
 
         Unrecognised methods are a no-op. Any other `notifications/*` (or any
         other method name) returns False having published nothing, scheduled
@@ -1520,7 +1600,7 @@ class ClientManager:
     async def _reconcile_server_catalog(self, name: str) -> None:
         """Re-index one server's catalog, then publish what actually moved.
 
-        Spawned, never awaited from a dispatch path. `_index_capabilities`
+        Spawned, never awaited from a dispatch path. `_fetch_server_listings`
         awaits `_send_request`, and the future it waits on is resolved by the
         very read loop that received the notification --
         `pending.future.set_result` in `_handle_stdout_line` (stdio) and in
@@ -1563,49 +1643,63 @@ class ClientManager:
                 self._reconcile_tasks.pop(name, None)
 
     async def _reconcile_once(self, name: str, managed: ManagedClient) -> None:
-        """One remove-then-reindex pass, published only if the catalog moved."""
-        before = self._server_catalog_ids(name)
-        prev_tools = {k: v for k, v in self._tools.items() if v.server_name == name}
-        prev_resources = {
-            k: v for k, v in self._resources.items() if v.server_name == name
-        }
-        prev_prompts = {k: v for k, v in self._prompts.items() if v.server_name == name}
+        """One fetch-then-swap pass, published per kind only if that kind moved.
 
+        Fetch first. Every downstream request happens before any catalog write,
+        so a `tools/list` that fails costs nothing: there is nothing to roll
+        back because nothing was removed. (The previous order -- remove, then
+        re-list -- needed a rollback precisely because it had already destroyed
+        the state it was trying to preserve.)
+
+        Then swap, synchronously. The block below contains no `await` by
+        construction: `_remove_server_indexes` and the three `_index_*` are all
+        plain methods. asyncio cannot interleave another task inside it, so a
+        concurrent `gateway.invoke` sees either the whole old catalog or the
+        whole new one and never the empty window between them. Adding an await
+        in there would silently reintroduce that window.
+
+        Per kind, independently. A kind whose listing failed is absent from
+        `refreshed`: it is neither removed nor re-indexed nor published, because
+        "we could not ask" is not "they are gone". A kind that answered is
+        replaced wholesale and published only if its entries actually differ.
+        """
+        try:
+            listings = await self._fetch_server_listings(managed)
+        except Exception as e:
+            # The downstream announced a change and then failed to list. The
+            # catalog has not been touched, so leaving it alone *is* the
+            # rollback, and there is nothing to publish.
+            logger.warning(f"[{name}] Catalog reconciliation failed: {e}")
+            return
+
+        refreshed = tuple(k for k in CATALOG_KINDS if listings[k] is not None)
+        before = self._server_catalog_snapshot(name)
+
+        # ---- apply: synchronous, no `await` below this line --------------
         self._catalog_suppressed[name] = self._catalog_suppressed.get(name, 0) + 1
         try:
             # `drop_tasks=False`: the server is still connected, so its tracked
             # task records must survive a catalog refresh.
-            self._remove_server_indexes(name, drop_tasks=False)
-            try:
-                await self._index_capabilities(managed)
-            except Exception as e:
-                # The downstream announced a change and then failed to list.
-                # Roll back rather than leave the catalog half-removed: the
-                # previous entries are strictly better than none.
-                logger.warning(f"[{name}] Catalog reconciliation failed: {e}")
-                self._remove_server_indexes(name, drop_tasks=False)
-                # Disclosure: these three writes are a catalog mutation outside
-                # the five publishing mutators that
-                # `tests/runtime/test_publisher_coverage.py` models. That guard
-                # does not currently see `dict.update`, so it does not fire
-                # here. It is safe on its own terms -- this restores exactly the
-                # entries `_remove_server_indexes` just took out, so the catalog
-                # ends identical to how it started and there is nothing to
-                # publish. Widening the guard to model `update` is a follow-up
-                # for whoever owns that file; it is not this lane's to edit.
-                self._tools.update(prev_tools)
-                self._resources.update(prev_resources)
-                self._prompts.update(prev_prompts)
-                return
+            self._remove_server_indexes(name, drop_tasks=False, kinds=refreshed)
+            tools = listings["tools"]
+            if tools is not None:
+                self._index_tools(name, tools)
+            resources = listings["resources"]
+            if resources is not None:
+                self._index_resources(name, resources)
+            prompts = listings["prompts"]
+            if prompts is not None:
+                self._index_prompts(name, prompts)
         finally:
             depth = self._catalog_suppressed.get(name, 1) - 1
             if depth > 0:
                 self._catalog_suppressed[name] = depth
             else:
                 self._catalog_suppressed.pop(name, None)
+        # ---- end apply ----------------------------------------------------
 
-        after = self._server_catalog_ids(name)
-        for kind in ("tools", "resources", "prompts"):
+        after = self._server_catalog_snapshot(name)
+        for kind in refreshed:
             if before[kind] != after[kind]:
                 self._publish_catalog_change(kind)
 

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -74,6 +74,49 @@ DOWNSTREAM_LIST_CHANGED_METHODS: dict[str, str] = {
     "notifications/prompts/list_changed": "prompts",
 }
 
+# Minimum gap between consecutive reconciles of the same server. The first
+# reconcile after a notification is never delayed; only a *re-run* waits. This
+# bounds the one pathological case coalescing alone does not: a downstream that
+# emits `list_changed` in response to the `tools/list` that reconciliation
+# itself issues, which would otherwise drive the re-run loop forever at full
+# speed. With the debounce that server costs one reconcile per interval instead
+# of a hot spin, and notifications arriving during the wait still collapse into
+# the single pending re-run.
+_RECONCILE_RERUN_DEBOUNCE_S = 0.25
+
+
+class DownstreamError(Exception):
+    """A JSON-RPC `error` object returned by a downstream MCP server.
+
+    Preserves the `code` and `data` members alongside `message`, which the two
+    dispatch paths previously discarded.
+
+    Scoped to the `ClientManager` boundary by design. `gateway.invoke` maps every
+    exception to `E302` through `str(e)`, so `str()` here is exactly the
+    downstream `message` and nothing about the `gateway.*` error contract
+    changes. Surfacing `code`/`data` to MCP clients is a separate contract change
+    tracked as a follow-up (EC-FANOUT-7).
+    """
+
+    def __init__(
+        self, message: str, *, code: int | None = None, data: Any = None
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.data = data
+
+
+def _downstream_error(error: Any) -> DownstreamError:
+    """Build a `DownstreamError` from a JSON-RPC `error` member."""
+    if not isinstance(error, dict):
+        return DownstreamError(str(error))
+    return DownstreamError(
+        str(error.get("message", "Unknown error")),
+        code=error.get("code"),
+        data=error.get("data"),
+    )
+
 
 class _NullCatalogEventSink:
     """No-op `CatalogEventSink` used when `ClientManager` is constructed with
@@ -568,6 +611,15 @@ class ClientManager:
         self._background_tasks: set[asyncio.Task[Any]] = set()
         self._background_task_servers: dict[asyncio.Task[Any], str | None] = {}
         self._reconnect_tasks: dict[str, asyncio.Task[None]] = {}
+        # FANOUT: at most one in-flight catalog reconcile per server name, plus
+        # the re-run flags a notification sets when it arrives while one is
+        # already running. See `_handle_downstream_notification`.
+        self._reconcile_tasks: dict[str, asyncio.Task[None]] = {}
+        self._reconcile_reruns: set[str] = set()
+        # Server names whose `note_*` publishes are currently suppressed, with a
+        # depth so overlapping reconciles of the same name nest correctly. Keyed
+        # by server so a reconcile of A never swallows a genuine publish for B.
+        self._catalog_suppressed: dict[str, int] = {}
         self._request_counters: dict[str, int] = {}
         self._tasks: dict[tuple[str, str], McpTaskRecord] = {}
         # Cap on retained terminal (completed/failed/cancelled) task records.
@@ -913,6 +965,12 @@ class ClientManager:
             await self._cancel_background_tasks(server_name=name)
             self._connect_tasks.pop(name, None)
             self._reconnect_tasks.pop(name, None)
+            # A reconcile cancelled before it ever started never runs its own
+            # `finally`, so clear its bookkeeping here too. The catalog removal
+            # below supersedes whatever it would have published.
+            self._reconcile_tasks.pop(name, None)
+            self._reconcile_reruns.discard(name)
+            self._catalog_suppressed.pop(name, None)
             self._clients.pop(name, None)
             self._remove_server_indexes(name)
             if config is not None and config.source in {"project", "user", "custom"}:
@@ -983,8 +1041,56 @@ class ClientManager:
 
         await self._connect_stdio(config)
 
-    def _remove_server_indexes(self, name: str) -> None:
-        """Remove catalog entries owned by one server."""
+    def _publish_catalog_change(self, kind: str) -> None:
+        """Publish one catalog-kind change to the sink, unconditionally."""
+        if kind == "tools":
+            self._catalog_events.note_tools_changed()
+        elif kind == "resources":
+            self._catalog_events.note_resources_changed()
+        elif kind == "prompts":
+            self._catalog_events.note_prompts_changed()
+
+    def _catalog_publishing_suppressed(self, server_name: str) -> bool:
+        """True while `server_name` is mid-reconcile, i.e. while its `note_*`
+        publishes are being withheld.
+
+        Suppression is keyed by server name rather than being a global flag on
+        purpose: reconciling A must not swallow the connect-time publishes of a
+        B being indexed concurrently. The reconcile republishes for itself, once
+        per kind that actually differs, once it has finished churning.
+
+        Deliberately a *predicate* rather than a wrapper around the sink: each
+        publishing mutator keeps its literal `self._catalog_events.note_*(...)`
+        call, which is what `tests/runtime/test_publisher_coverage.py`'s AST
+        honesty guard asserts. Hiding those calls behind a helper would make
+        that guard vacuous.
+        """
+        return bool(self._catalog_suppressed.get(server_name))
+
+    def _server_catalog_ids(self, name: str) -> dict[str, set[str]]:
+        """The identifier sets one server currently owns, per catalog kind.
+
+        Identifier *sets*, never counts: renaming a tool leaves the count
+        identical while the catalog genuinely moved, and a count-based diff
+        would silently swallow that change.
+        """
+        return {
+            "tools": {k for k, v in self._tools.items() if v.server_name == name},
+            "resources": {
+                k for k, v in self._resources.items() if v.server_name == name
+            },
+            "prompts": {k for k, v in self._prompts.items() if v.server_name == name},
+        }
+
+    def _remove_server_indexes(self, name: str, *, drop_tasks: bool = True) -> None:
+        """Remove catalog entries owned by one server.
+
+        `drop_tasks=False` keeps the server's tracked `McpTaskRecord`s. Dropping
+        them is right for a disconnect, where the downstream's tasks died with
+        the connection, and wrong for a `list_changed` reconcile, where the
+        server is still up and its in-flight tasks are still running -- evicting
+        them there would silently break `gateway.tasks_list`/`tasks_result`.
+        """
         tools_removed = False
         for tool_id, tool in list(self._tools.items()):
             if tool.server_name == name:
@@ -1000,14 +1106,16 @@ class ClientManager:
             if prompt.server_name == name:
                 self._prompts.pop(prompt_id, None)
                 prompts_removed = True
-        for key in list(self._tasks):
-            if key[0] == name:
-                self._tasks.pop(key, None)
-        if tools_removed:
+        if drop_tasks:
+            for key in list(self._tasks):
+                if key[0] == name:
+                    self._tasks.pop(key, None)
+        suppressed = self._catalog_publishing_suppressed(name)
+        if tools_removed and not suppressed:
             self._catalog_events.note_tools_changed()
-        if resources_removed:
+        if resources_removed and not suppressed:
             self._catalog_events.note_resources_changed()
-        if prompts_removed:
+        if prompts_removed and not suppressed:
             self._catalog_events.note_prompts_changed()
 
     def _server_supports_tasks(self, managed: ManagedClient) -> bool:
@@ -1221,7 +1329,7 @@ class ClientManager:
 
             self._tools[tool_id] = tool_info
             indexed += 1
-        if indexed:
+        if indexed and not self._catalog_publishing_suppressed(name):
             self._catalog_events.note_tools_changed()
         return indexed
 
@@ -1251,7 +1359,7 @@ class ClientManager:
                 raw_metadata=_raw_metadata(resource, known_fields),
             )
             self._resources[resource_id] = resource_info
-        if resources:
+        if resources and not self._catalog_publishing_suppressed(name):
             self._catalog_events.note_resources_changed()
         return len(resources)
 
@@ -1292,7 +1400,7 @@ class ClientManager:
                 raw_metadata=_raw_metadata(prompt, known_prompt_fields),
             )
             self._prompts[prompt_id] = prompt_info
-        if prompts:
+        if prompts and not self._catalog_publishing_suppressed(name):
             self._catalog_events.note_prompts_changed()
         return len(prompts)
 
@@ -1387,9 +1495,119 @@ class ClientManager:
         """
         if method not in DOWNSTREAM_LIST_CHANGED_METHODS:
             return False
-        # IF-0-FANOUT-1 freeze (SL-1.2): recognition is published so peer lanes
-        # can build against it; the scheduler body lands in SL-1.4.
+
+        existing = self._reconcile_tasks.get(name)
+        if existing is not None and not existing.done():
+            # Coalesce: a notification arriving mid-reconcile sets a re-run flag
+            # the running task picks up, rather than spawning a second task. A
+            # downstream that emits `list_changed` on every request is therefore
+            # bounded to one in-flight re-index plus one queued re-run.
+            self._reconcile_reruns.add(name)
+            return True
+
+        try:
+            task = asyncio.create_task(self._reconcile_server_catalog(name))
+        except RuntimeError:
+            # No running loop. Both real dispatch paths run inside one, so this
+            # is unreachable in production; returning False (rather than
+            # raising) keeps the never-raises guarantee absolute.
+            logger.debug(f"[{name}] No running loop; dropped {method}")
+            return False
+        self._reconcile_tasks[name] = task
+        self._track_background_task(task, name)
         return True
+
+    async def _reconcile_server_catalog(self, name: str) -> None:
+        """Re-index one server's catalog, then publish what actually moved.
+
+        Spawned, never awaited from a dispatch path. `_index_capabilities`
+        awaits `_send_request`, and the future it waits on is resolved by the
+        very read loop that received the notification --
+        `pending.future.set_result` in `_handle_stdout_line` (stdio) and in
+        `_read_sse` (remote). Awaiting inline would make that loop wait on a
+        future only it can resolve: an immediate, total deadlock of the
+        connection, not an occasional one.
+
+        (Line references as surveyed pre-FANOUT, at ff2cb95: the await is
+        `manager.py:1292`, the two resolutions are `:1791` and `:2010`. Anchored
+        by symbol above because this change shifts all three.)
+
+        Re-runs are a loop inside this one task rather than a second task, which
+        is what keeps the coalescing bound at one in-flight reconcile per server.
+        """
+        try:
+            while True:
+                self._reconcile_reruns.discard(name)
+                # Re-resolve the client every iteration: a reconnect swaps the
+                # ManagedClient object outright, and a stale reference would
+                # send `tools/list` down a transport that is already closed.
+                managed = self._clients.get(name)
+                if managed is None:
+                    return
+                await self._reconcile_once(name, managed)
+                if name not in self._reconcile_reruns:
+                    return
+                # A re-run is pending. Wait a beat before honouring it so a
+                # server that emits `list_changed` in reply to our own
+                # `tools/list` cannot spin this loop at full speed; further
+                # notifications during the wait fold into this same re-run.
+                await asyncio.sleep(_RECONCILE_RERUN_DEBOUNCE_S)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:  # pragma: no cover - defensive
+            # Never let a reconcile surface as an unhandled task exception.
+            logger.warning(f"[{name}] Catalog reconciliation task failed: {e}")
+        finally:
+            self._reconcile_reruns.discard(name)
+            if self._reconcile_tasks.get(name) is asyncio.current_task():
+                self._reconcile_tasks.pop(name, None)
+
+    async def _reconcile_once(self, name: str, managed: ManagedClient) -> None:
+        """One remove-then-reindex pass, published only if the catalog moved."""
+        before = self._server_catalog_ids(name)
+        prev_tools = {k: v for k, v in self._tools.items() if v.server_name == name}
+        prev_resources = {
+            k: v for k, v in self._resources.items() if v.server_name == name
+        }
+        prev_prompts = {k: v for k, v in self._prompts.items() if v.server_name == name}
+
+        self._catalog_suppressed[name] = self._catalog_suppressed.get(name, 0) + 1
+        try:
+            # `drop_tasks=False`: the server is still connected, so its tracked
+            # task records must survive a catalog refresh.
+            self._remove_server_indexes(name, drop_tasks=False)
+            try:
+                await self._index_capabilities(managed)
+            except Exception as e:
+                # The downstream announced a change and then failed to list.
+                # Roll back rather than leave the catalog half-removed: the
+                # previous entries are strictly better than none.
+                logger.warning(f"[{name}] Catalog reconciliation failed: {e}")
+                self._remove_server_indexes(name, drop_tasks=False)
+                # Disclosure: these three writes are a catalog mutation outside
+                # the five publishing mutators that
+                # `tests/runtime/test_publisher_coverage.py` models. That guard
+                # does not currently see `dict.update`, so it does not fire
+                # here. It is safe on its own terms -- this restores exactly the
+                # entries `_remove_server_indexes` just took out, so the catalog
+                # ends identical to how it started and there is nothing to
+                # publish. Widening the guard to model `update` is a follow-up
+                # for whoever owns that file; it is not this lane's to edit.
+                self._tools.update(prev_tools)
+                self._resources.update(prev_resources)
+                self._prompts.update(prev_prompts)
+                return
+        finally:
+            depth = self._catalog_suppressed.get(name, 1) - 1
+            if depth > 0:
+                self._catalog_suppressed[name] = depth
+            else:
+                self._catalog_suppressed.pop(name, None)
+
+        after = self._server_catalog_ids(name)
+        for kind in ("tools", "resources", "prompts"):
+            if before[kind] != after[kind]:
+                self._publish_catalog_change(kind)
 
     async def _connect_stdio(self, config: ResolvedServerConfig) -> None:
         """Connect to a local stdio MCP server."""
@@ -1849,16 +2067,17 @@ class ClientManager:
                 managed.status.pending_request_count = len(managed.pending_requests)
 
                 if "error" in message:
-                    # TODO(post-P3B): message["error"] also carries JSON-RPC
-                    # "code" and "data" fields that are dropped here, exposing
-                    # only "message" to callers. No P3B exit criterion
-                    # mentions typed downstream errors (Execution Notes >
-                    # Decision 5) — deferred again, not actioned in P3B.
-                    pending.future.set_exception(
-                        Exception(message["error"].get("message", "Unknown error"))
-                    )
+                    pending.future.set_exception(_downstream_error(message["error"]))
                 else:
                     pending.future.set_result(message.get("result", {}))
+            else:
+                # A notification carries a `method` and no `id`, so it falls
+                # through the gate above with nothing to resolve. Server->client
+                # *requests* also carry a method but do have an id, and are not
+                # ours to handle here — hence the explicit `msg_id is None`.
+                method = message.get("method")
+                if msg_id is None and isinstance(method, str):
+                    self._handle_downstream_notification(name, managed, method)
         except json.JSONDecodeError:
             # Non-JSON output already counted as a heartbeat by the caller.
             logger.debug(
@@ -2067,17 +2286,20 @@ class ClientManager:
                     managed.status.pending_request_count = len(managed.pending_requests)
 
                     if "error" in payload:
-                        # TODO(post-P3B): payload["error"] also carries
-                        # JSON-RPC "code" and "data" fields that are dropped
-                        # here, exposing only "message" to callers. No P3B
-                        # exit criterion mentions typed downstream errors
-                        # (Execution Notes > Decision 5) — deferred again,
-                        # not actioned in P3B.
                         pending.future.set_exception(
-                            Exception(payload["error"].get("message", "Unknown error"))
+                            _downstream_error(payload["error"])
                         )
                     else:
                         pending.future.set_result(payload.get("result", {}))
+                else:
+                    # Same fall-through as the stdio path: a notification has a
+                    # method and no id. `_handle_downstream_notification` never
+                    # raises, which matters more here — this loop's blanket
+                    # `except Exception` would tear the connection down and
+                    # trigger a reconnect.
+                    method = payload.get("method")
+                    if msg_id is None and isinstance(method, str):
+                        self._handle_downstream_notification(name, managed, method)
         except Exception as e:
             logger.debug(f"[{name}] SSE read error: {e}")
         finally:
@@ -2332,6 +2554,9 @@ class ClientManager:
         await self._cancel_background_tasks(exclude=exclude)
         self._connect_tasks.clear()
         self._reconnect_tasks.clear()
+        self._reconcile_tasks.clear()
+        self._reconcile_reruns.clear()
+        self._catalog_suppressed.clear()
         self._clients.clear()
         # Capture non-empty immediately before each clear (not after — the
         # clear must happen first for the dict to actually be empty

--- a/tests/runtime/fake_remote.py
+++ b/tests/runtime/fake_remote.py
@@ -10,6 +10,13 @@ genuine `mcp.server.MCPServer` served over Streamable HTTP by uvicorn's
 programmatic `Server` API, run in-process as a background task on the
 current event loop so a real, in-process `ClientManager` can connect to it
 within the same test.
+
+SL-2 (FANOUT) — `DownstreamEmitter` / `RemoteEmitter` here are IF-0-FANOUT-2's
+remote half: the ability for a test to command this fake to mutate its own
+tool catalog and emit an arbitrary `notifications/*` frame on cue, so the
+gateway's SSE dispatch path (`ClientManager._read_sse`) has something to
+prove itself against. `tests/runtime/fake_stdio_server.py` is the stdio half,
+behind the same shape.
 """
 
 from __future__ import annotations
@@ -18,9 +25,13 @@ import asyncio
 import contextlib
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
 
 import uvicorn
 from mcp.server import MCPServer
+from mcp.server.context import ServerRequestContext
+from mcp.server.session import ServerSession
+from mcp_types import PaginatedRequestParams
 from sse_starlette.sse import AppStatus
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -28,6 +39,51 @@ from starlette.responses import PlainTextResponse, RedirectResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 AUTH_HEADER = "authorization"
+
+# The three notification methods a real downstream can claim through the
+# SDK's typed `ServerSession` helpers -- anything else (including an
+# unrecognised method, EC-FANOUT-5's no-op case) has no typed helper and
+# falls to the raw-notify branch in `RemoteEmitter.emit`.
+_TOOLS_CHANGED = "notifications/tools/list_changed"
+_RESOURCES_CHANGED = "notifications/resources/list_changed"
+_PROMPTS_CHANGED = "notifications/prompts/list_changed"
+
+
+@runtime_checkable
+class DownstreamEmitter(Protocol):
+    """IF-0-FANOUT-2: the emitter API, identical across stdio
+    (`fake_stdio_server.StdioEmitter`) and remote (`RemoteEmitter` below), so
+    SL-3 writes one test body per scenario instead of two.
+
+    `add_tool`/`remove_tool` mutate the fake downstream's own catalog only --
+    neither sends anything on the wire by itself. `emit()` is the only thing
+    that puts a `notifications/*` frame on the wire, so a caller composes:
+
+      - `add_tool()` then `emit()` -- a real catalog change, notified
+      - `remove_tool()` then `emit()` -- a real catalog change, notified
+      - `emit()` alone -- notify with nothing changed (storm-suppression probe)
+
+    Both mutators and `emit()` require the downstream to already be
+    connected (a session/control-channel must exist); calling them first
+    raises.
+    """
+
+    async def add_tool(self, name: str, *, description: str = "") -> None:
+        """Add one real, invocable tool named `name` to the fake
+        downstream's catalog. Sends no notification."""
+        ...
+
+    async def remove_tool(self, name: str) -> None:
+        """Remove `name` from the fake downstream's catalog. Sends no
+        notification. Raises if `name` isn't present."""
+        ...
+
+    async def emit(self, method: str = _TOOLS_CHANGED) -> None:
+        """Put exactly this JSON-RPC notification method on the wire now.
+        Defaults to the tools variant; also accepts the resources/prompts
+        variants or any other string, including a method the gateway
+        doesn't recognise (EC-FANOUT-5)."""
+        ...
 
 
 class _AuthGate:
@@ -51,11 +107,65 @@ class _AuthGate:
         await self.app(scope, receive, send)
 
 
+@dataclass
+class RemoteEmitter:
+    """IF-0-FANOUT-2's remote half. `_server.add_tool`/`remove_tool` mutate
+    the real `MCPServer`'s catalog directly -- same process, same event
+    loop, no wire round-trip needed for the mutation itself. `emit()` routes
+    through the most recently captured `ServerSession` (`_session_box`,
+    populated by `build_fake_remote_app`'s wrapped `tools/list` handler): a
+    session is guaranteed available once the caller has connected at least
+    once, because `tools/list` is the FIRST request `_index_capabilities`
+    sends (`manager.py:1292`)."""
+
+    _server: MCPServer
+    _session_box: list[ServerSession]
+
+    async def add_tool(self, name: str, *, description: str = "") -> None:
+        def _dyn_tool(text: str = "") -> str:
+            return f"{name}:{text}"
+
+        _dyn_tool.__doc__ = description or f"dynamically added tool {name}"
+        self._server.add_tool(_dyn_tool, name=name, description=description or None)
+
+    async def remove_tool(self, name: str) -> None:
+        self._server.remove_tool(name)
+
+    async def emit(self, method: str = _TOOLS_CHANGED) -> None:
+        if not self._session_box:
+            raise RuntimeError(
+                "RemoteEmitter.emit() called before any tools/list request "
+                "captured a session -- connect the downstream first"
+            )
+        session = self._session_box[-1]
+        if method == _TOOLS_CHANGED:
+            await session.send_tool_list_changed()
+        elif method == _RESOURCES_CHANGED:
+            await session.send_resource_list_changed()
+        elif method == _PROMPTS_CHANGED:
+            await session.send_prompt_list_changed()
+        else:
+            # The typed `ServerNotification` union only covers the three
+            # variants above, by design -- the SDK doesn't let a server
+            # claim to be sending anything else. Reach past it to the
+            # session's own connection-scoped outbound channel so a test can
+            # still prove the gateway's dispatch treats an unrecognised
+            # method as a no-op (EC-FANOUT-5), not merely untested.
+            await session._connection.notify(method, {})
+
+
 def build_fake_remote_app(*, expected_auth_value: str) -> Starlette:
     """One real tool behind the auth gate, plus `/relocated`, which
     307-redirects to `/mcp` (307 preserves method + body, unlike 301/302/303
     — required for a POST-based MCP session to still resolve past it, and
-    the property that proves IF-0-P2-2's `follow_redirects=True`)."""
+    the property that proves IF-0-P2-2's `follow_redirects=True`).
+
+    Also wires up SL-2's `RemoteEmitter` (IF-0-FANOUT-2), stashed at
+    `app.state.fake_remote_emitter` so `run_fake_remote` can hand it to
+    callers without changing this function's return type -- preserved
+    because `scripts/probes/_serverkill_runner.py` and
+    `scripts/probes/sse_flake_probe_serverkill.py` call this directly and
+    expect a bare `Starlette`."""
     mcp = MCPServer("fake-remote")
 
     @mcp.tool()
@@ -64,6 +174,27 @@ def build_fake_remote_app(*, expected_auth_value: str) -> Starlette:
         return f"fr-echo:{text}"
 
     app = mcp.streamable_http_app()
+
+    # Capture the live `ServerSession` on every `tools/list` call -- the
+    # only public hook the SDK offers into a request's connection-scoped
+    # session (`ServerRequestContext.session`, mcp/server/context.py:40) --
+    # by re-registering the handler `MCPServer.__init__` already wired
+    # (`add_request_handler` overwrites the dict entry; verified empirically,
+    # see the FANOUT plan). Keeping only the latest session means a
+    # reconnect's `tools/list` naturally supersedes a stale one.
+    session_box: list[ServerSession] = []
+    original_list_tools = mcp._handle_list_tools
+
+    async def _capturing_list_tools(
+        ctx: ServerRequestContext[object], params: PaginatedRequestParams | None
+    ) -> object:
+        session_box[:] = [ctx.session]
+        return await original_list_tools(ctx, params)
+
+    mcp._lowlevel_server.add_request_handler(
+        "tools/list", PaginatedRequestParams, _capturing_list_tools
+    )
+    app.state.fake_remote_emitter = RemoteEmitter(_server=mcp, _session_box=session_box)
 
     async def redirect_to_mcp(request: Request) -> RedirectResponse:
         return RedirectResponse(url="/mcp", status_code=307)
@@ -79,6 +210,7 @@ class RunningFakeRemote:
     base_url: str
     mcp_url: str
     redirect_url: str
+    emitter: RemoteEmitter
 
 
 @contextlib.asynccontextmanager
@@ -119,6 +251,7 @@ async def run_fake_remote(
             base_url=f"http://127.0.0.1:{port}",
             mcp_url=f"http://127.0.0.1:{port}/mcp",
             redirect_url=f"http://127.0.0.1:{port}/relocated",
+            emitter=app.state.fake_remote_emitter,
         )
     finally:
         server.should_exit = True

--- a/tests/runtime/fake_stdio_server.py
+++ b/tests/runtime/fake_stdio_server.py
@@ -1,0 +1,284 @@
+"""SL-2 (FANOUT) — the stdio half of IF-0-FANOUT-2's emitter API.
+
+`tests/runtime/fake_remote.py` serves a real `mcp.server.MCPServer` over
+Streamable HTTP, so every existing runtime test built on it exercises
+`ClientManager._read_sse` alone -- the stdio dispatch path
+(`ClientManager._handle_stdout_line`) has no emitter at all. This module is
+that emitter, deliberately NOT a real `mcp.server.MCPServer`: only
+`initialize` and `tools/list` are implemented for real; `resources/list` and
+`prompts/list` return a JSON-RPC "method not found" error, which
+`_index_capabilities` already tolerates (treats as "server doesn't support
+resources/prompts", `manager.py:1303`, `:1312`).
+
+Two halves, in one file so the subprocess entry point and its test-side
+launcher stay next to each other:
+
+  - `__main__` -- the subprocess itself. Speaks newline-delimited JSON-RPC
+    2.0 on stdin/stdout (matching `ClientManager._send_request`,
+    `manager.py:2080`, and `_read_stdout`, `:1823`), and separately listens
+    on a TCP "control" port for commands that mutate its own tool catalog or
+    emit a `notifications/*` frame on stdout on cue. Only stdlib is imported
+    at module level so this still runs when `ClientManager` spawns it with
+    `sys.executable <this file> --control-port N` -- that invocation puts
+    this file's own directory on `sys.path[0]`, not the repo root, so a
+    repo-root-relative import (`tests.runtime.harness`, or `DownstreamEmitter`
+    from `fake_remote.py`, which pulls in uvicorn/starlette) would crash the
+    subprocess before it could even bind stdin. `pmcp.types` is safe to
+    import unconditionally because `pmcp` is an installed package in the
+    same venv as `sys.executable`, not a repo-root-relative one.
+  - `build_fake_stdio_downstream()` -- the test-side launcher. Returns the
+    `ResolvedServerConfig` a test passes to `ClientManager.connect_server`
+    (which spawns the subprocess above as that server's downstream) plus a
+    `StdioEmitter` already wired to the same control port. The caller
+    allocates the port itself (`tests.runtime.harness.alloc_port()`) so this
+    function doesn't need that harness import either.
+
+`StdioEmitter` is not declared as inheriting `fake_remote.DownstreamEmitter`
+(same import-safety reason) -- it satisfies that `Protocol` structurally;
+`test_emitter_harness.py` pins that with an `isinstance` check against the
+`@runtime_checkable` Protocol.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import socket
+import sys
+import threading
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pmcp.types import LocalMcpServerConfig, ResolvedServerConfig
+
+_THIS_FILE = Path(__file__).resolve()
+
+_TOOLS_CHANGED = "notifications/tools/list_changed"
+
+
+# ============================================================================
+# Subprocess side (__main__)
+# ============================================================================
+
+
+@dataclass
+class _ServerState:
+    """The fake downstream's own tool catalog and the lock serializing every
+    write to stdout -- both the JSON-RPC main loop's responses and the
+    control thread's on-cue notifications write there, from different
+    threads."""
+
+    tools: dict[str, dict[str, Any]] = field(default_factory=dict)
+    stdout_lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def handle_control(self, command: dict[str, Any]) -> dict[str, Any]:
+        op = command.get("op")
+        if op == "add_tool":
+            name = command["name"]
+            description = command.get("description") or f"dynamically added tool {name}"
+            self.tools[name] = {
+                "name": name,
+                "description": description,
+                "inputSchema": {"type": "object", "properties": {}},
+            }
+            return {"ok": True}
+        if op == "remove_tool":
+            name = command["name"]
+            if name not in self.tools:
+                return {"ok": False, "error": f"unknown tool: {name}"}
+            del self.tools[name]
+            return {"ok": True}
+        if op == "emit":
+            method = command.get("method", _TOOLS_CHANGED)
+            self.write_stdout({"jsonrpc": "2.0", "method": method, "params": {}})
+            return {"ok": True}
+        return {"ok": False, "error": f"unknown control op: {op!r}"}
+
+    def write_stdout(self, message: dict[str, Any]) -> None:
+        line = (json.dumps(message) + "\n").encode()
+        with self.stdout_lock:
+            sys.stdout.buffer.write(line)
+            sys.stdout.buffer.flush()
+
+
+class _ControlServer(threading.Thread):
+    """A TCP control channel, separate from the stdio JSON-RPC channel that
+    `ClientManager` owns -- the test process can't inject into that one
+    without impersonating the gateway. Binds synchronously in `__init__`
+    (before `main()` starts reading stdin), so by the time
+    `ClientManager.connect_server` returns (which requires a successful
+    `tools/list` round-trip, `manager.py:1292`), this port is guaranteed
+    already listening -- no race for a caller to guard against."""
+
+    def __init__(self, port: int, state: _ServerState) -> None:
+        super().__init__(daemon=True)
+        self._state = state
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._sock.bind(("127.0.0.1", port))
+        self._sock.listen(8)
+
+    def run(self) -> None:
+        while True:
+            try:
+                conn, _ = self._sock.accept()
+            except OSError:
+                return  # socket closed under us -- process is exiting
+            threading.Thread(target=self._handle, args=(conn,), daemon=True).start()
+
+    def _handle(self, conn: socket.socket) -> None:
+        with conn:
+            for raw_line in conn.makefile("r", encoding="utf-8"):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    command = json.loads(line)
+                except json.JSONDecodeError:
+                    reply: dict[str, Any] = {"ok": False, "error": "invalid JSON"}
+                else:
+                    reply = self._state.handle_control(command)
+                conn.sendall((json.dumps(reply) + "\n").encode())
+
+
+def _handle_request(
+    state: _ServerState, message: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Build the JSON-RPC response for one inbound message, or `None` for a
+    notification (no `id`) -- nothing to reply to, matching real MCP
+    servers' handling of e.g. `notifications/initialized`."""
+    msg_id = message.get("id")
+    method = message.get("method")
+    if msg_id is None:
+        return None
+    if method == "initialize":
+        # Echo whatever protocolVersion the client asked for -- the
+        # permissive choice, since this fake exists to prove notification
+        # dispatch, not version negotiation.
+        requested = (message.get("params") or {}).get("protocolVersion", "2025-06-18")
+        result = {
+            "protocolVersion": requested,
+            "capabilities": {
+                "tools": {"listChanged": True},
+                "resources": {"listChanged": True},
+                "prompts": {"listChanged": True},
+            },
+            "serverInfo": {"name": "fake-stdio", "version": "0.0.1"},
+        }
+        return {"jsonrpc": "2.0", "id": msg_id, "result": result}
+    if method == "tools/list":
+        return {
+            "jsonrpc": "2.0",
+            "id": msg_id,
+            "result": {"tools": list(state.tools.values())},
+        }
+    # resources/list, prompts/list, and anything else this fake doesn't
+    # implement all get the same "method not found" -- tolerated by
+    # `_index_capabilities` for resources/prompts (manager.py:1303, :1312).
+    return {
+        "jsonrpc": "2.0",
+        "id": msg_id,
+        "error": {"code": -32601, "message": f"Method not found: {method}"},
+    }
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--control-port", type=int, required=True)
+    args = parser.parse_args()
+
+    state = _ServerState()
+    _ControlServer(args.control_port, state).start()
+
+    for raw_line in sys.stdin.buffer:
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            message = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        reply = _handle_request(state, message)
+        if reply is not None:
+            state.write_stdout(reply)
+    # stdin closed (EOF) -- ClientManager tore down the pipe. Exit like any
+    # other stdio downstream would.
+
+
+# ============================================================================
+# Test-process side
+# ============================================================================
+
+
+class StdioEmitter:
+    """IF-0-FANOUT-2's stdio half: talks to `_ControlServer` above over a
+    fresh TCP connection per command (simpler than holding one open, and the
+    control channel is not itself the thing under test). Structurally
+    matches `fake_remote.DownstreamEmitter` without importing it, per this
+    module's docstring."""
+
+    def __init__(self, *, host: str, port: int) -> None:
+        self._host = host
+        self._port = port
+
+    async def _send(self, command: dict[str, Any]) -> dict[str, Any]:
+        reader, writer = await asyncio.open_connection(self._host, self._port)
+        try:
+            writer.write((json.dumps(command) + "\n").encode())
+            await writer.drain()
+            line = await reader.readline()
+            if not line:
+                raise RuntimeError(
+                    "fake stdio server control channel closed without replying"
+                )
+            return json.loads(line.decode())
+        finally:
+            writer.close()
+
+    async def add_tool(self, name: str, *, description: str = "") -> None:
+        reply = await self._send(
+            {"op": "add_tool", "name": name, "description": description}
+        )
+        if not reply.get("ok"):
+            raise RuntimeError(reply.get("error", "add_tool failed"))
+
+    async def remove_tool(self, name: str) -> None:
+        reply = await self._send({"op": "remove_tool", "name": name})
+        if not reply.get("ok"):
+            raise RuntimeError(reply.get("error", "remove_tool failed"))
+
+    async def emit(self, method: str = _TOOLS_CHANGED) -> None:
+        reply = await self._send({"op": "emit", "method": method})
+        if not reply.get("ok"):
+            raise RuntimeError(reply.get("error", "emit failed"))
+
+
+@dataclass
+class FakeStdioDownstream:
+    config: ResolvedServerConfig
+    emitter: StdioEmitter
+
+
+def build_fake_stdio_downstream(name: str, *, control_port: int) -> FakeStdioDownstream:
+    """Build the `ResolvedServerConfig` for a downstream named `name` that,
+    once passed to `ClientManager.connect_server`, spawns this file as the
+    subprocess, plus a `StdioEmitter` wired to `control_port`. The caller
+    allocates `control_port` (`tests.runtime.harness.alloc_port()`) -- see
+    this module's docstring for why that import doesn't belong here."""
+    config = ResolvedServerConfig(
+        name=name,
+        source="custom",
+        config=LocalMcpServerConfig(
+            command=sys.executable,
+            args=[str(_THIS_FILE), "--control-port", str(control_port)],
+        ),
+    )
+    return FakeStdioDownstream(
+        config=config, emitter=StdioEmitter(host="127.0.0.1", port=control_port)
+    )
+
+
+if __name__ == "__main__":
+    _main()

--- a/tests/runtime/test_downstream_remote.py
+++ b/tests/runtime/test_downstream_remote.py
@@ -49,6 +49,9 @@ the file is split.
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Awaitable, Callable
+
 import pytest
 
 from pmcp.client.manager import ClientManager
@@ -253,3 +256,212 @@ async def test_ec_p2_7_fake_remote_survives_a_pre_latched_appstatus() -> None:
     finally:
         await manager.disconnect_all()
         AppStatus.should_exit = False
+
+
+# ============================================================================
+# SL-3 (FANOUT) — EC-FANOUT-1/2/3/9: catalog freshness, remote transport.
+#
+# `tests/runtime/test_emitter_harness.py` (SL-2) already proves the emitter's
+# frames reach `ClientManager._read_sse`; that only proves the notification
+# arrived, which a forward-to-sink implementation that never re-indexes would
+# also satisfy. This proves the CATALOG moved: after a real emission, an
+# ADDED tool is returned by `gateway.catalog_search` and answers a real
+# `gateway.invoke`, and a REMOVED tool is gone from both.
+# `tests/runtime/test_downstream_stdio.py` is this section's stdio twin;
+# EC-FANOUT-3 requires both to pass independently.
+# ============================================================================
+
+
+async def _catalog_tool_ids(gateway_tools: GatewayTools, server: str) -> set[str]:
+    """The tool_ids `gateway.catalog_search` currently returns for `server`,
+    with no text query -- `CatalogSearchInput.query` is optional, and the
+    server filter alone is enough to scope this to one downstream."""
+    output = await gateway_tools.catalog_search(
+        {"filters": {"server": server}, "limit": 100}
+    )
+    return {card.tool_id for card in output.results}
+
+
+async def _wait_until(
+    predicate: Callable[[], Awaitable[bool]],
+    *,
+    attempts: int = 50,
+    interval: float = 0.05,
+) -> bool:
+    """Poll an async predicate until it is True or `attempts` is exhausted.
+    Returns the last observed value, so a failing assertion shows what the
+    catalog actually held rather than just "timed out"."""
+    result = False
+    for _ in range(attempts):
+        result = await predicate()
+        if result:
+            return True
+        await asyncio.sleep(interval)
+    return result
+
+
+@pytest.mark.asyncio
+class TestRemoteDownstreamNotificationCatalogFreshness:
+    async def test_downstream_notification_added_tool_is_searchable_and_invocable(
+        self,
+    ) -> None:
+        """EC-FANOUT-1/9, remote half of EC-FANOUT-3: a tool ADDED by the
+        downstream after connect is returned by `gateway.catalog_search` and
+        answers a real `gateway.invoke` call -- proof the index actually
+        moved, not just that a notification was received."""
+        manager = ClientManager()
+        try:
+            async with run_fake_remote(
+                alloc_port(), expected_auth_value=AUTH_VALUE
+            ) as remote:
+                errors = await manager.connect_server(
+                    _config(
+                        "fr-fanout-add",
+                        remote.mcp_url,
+                        headers={"Authorization": AUTH_VALUE},
+                    )
+                )
+                assert errors == []
+                gateway_tools = GatewayTools(
+                    client_manager=manager, policy_manager=PolicyManager()
+                )
+                tool_id = "fr-fanout-add::fr_dyn"
+
+                assert tool_id not in await _catalog_tool_ids(
+                    gateway_tools, "fr-fanout-add"
+                )
+
+                await remote.emitter.add_tool("fr_dyn", description="dynamic")
+                await remote.emitter.emit("notifications/tools/list_changed")
+
+                found = await _wait_until(
+                    lambda: _tool_present(gateway_tools, "fr-fanout-add", tool_id)
+                )
+                assert found, "gateway.catalog_search never reflected the added tool"
+
+                result = await gateway_tools.invoke(
+                    {"tool_id": tool_id, "arguments": {"text": "hi"}}
+                )
+                assert result.ok is True, result.errors
+        finally:
+            await manager.disconnect_all()
+
+    async def test_downstream_notification_removed_tool_disappears_from_catalog_and_invoke(
+        self,
+    ) -> None:
+        """EC-FANOUT-2, remote half of EC-FANOUT-3: the flip side. A tool the
+        downstream REMOVES is gone from both `gateway.catalog_search` and
+        `gateway.invoke` after the server announces the change."""
+        manager = ClientManager()
+        try:
+            async with run_fake_remote(
+                alloc_port(), expected_auth_value=AUTH_VALUE
+            ) as remote:
+                errors = await manager.connect_server(
+                    _config(
+                        "fr-fanout-remove",
+                        remote.mcp_url,
+                        headers={"Authorization": AUTH_VALUE},
+                    )
+                )
+                assert errors == []
+                gateway_tools = GatewayTools(
+                    client_manager=manager, policy_manager=PolicyManager()
+                )
+                tool_id = "fr-fanout-remove::fr_removable"
+
+                await remote.emitter.add_tool("fr_removable")
+                await remote.emitter.emit("notifications/tools/list_changed")
+                found = await _wait_until(
+                    lambda: _tool_present(gateway_tools, "fr-fanout-remove", tool_id)
+                )
+                assert found, "setup: added tool never appeared in the catalog"
+
+                await remote.emitter.remove_tool("fr_removable")
+                await remote.emitter.emit("notifications/tools/list_changed")
+
+                gone = await _wait_until(
+                    lambda: _tool_absent(gateway_tools, "fr-fanout-remove", tool_id)
+                )
+                assert gone, (
+                    "gateway.catalog_search still lists a tool the downstream removed"
+                )
+
+                result = await gateway_tools.invoke(
+                    {"tool_id": tool_id, "arguments": {}}
+                )
+                assert result.ok is False
+                assert result.errors
+        finally:
+            await manager.disconnect_all()
+
+
+async def _tool_present(gateway_tools: GatewayTools, server: str, tool_id: str) -> bool:
+    return tool_id in await _catalog_tool_ids(gateway_tools, server)
+
+
+async def _tool_absent(gateway_tools: GatewayTools, server: str, tool_id: str) -> bool:
+    return tool_id not in await _catalog_tool_ids(gateway_tools, server)
+
+
+# ============================================================================
+# SL-3.3 (FANOUT) — EC-FANOUT-6: no self-deadlock.
+#
+# `_reconcile_server_catalog` must be scheduled with `asyncio.create_task`,
+# never awaited inline from the dispatch path: `_index_capabilities` awaits
+# `_send_request`, and that future is resolved by the very read loop
+# (`_read_sse`) that received the notification. An inline await would freeze
+# that loop permanently -- it would be waiting on a future only its own next
+# iteration could resolve.
+#
+# The unrelated request MUST go to the same downstream whose read loop
+# handled the notification. The loops are per-connection, so a request to a
+# *different* server would stay unaffected by a broken (deadlocked) server's
+# loop either way, and would not exercise this hazard at all.
+# ============================================================================
+
+
+@pytest.mark.asyncio
+class TestRemoteSelfDeadlock:
+    async def test_unrelated_request_to_same_downstream_completes_after_notification(
+        self,
+    ) -> None:
+        manager = ClientManager()
+        try:
+            async with run_fake_remote(
+                alloc_port(), expected_auth_value=AUTH_VALUE
+            ) as remote:
+                errors = await manager.connect_server(
+                    _config(
+                        "fr-deadlock",
+                        remote.mcp_url,
+                        headers={"Authorization": AUTH_VALUE},
+                    )
+                )
+                assert errors == []
+                gateway_tools = GatewayTools(
+                    client_manager=manager, policy_manager=PolicyManager()
+                )
+
+                await remote.emitter.add_tool("fr_dyn_deadlock")
+                await remote.emitter.emit("notifications/tools/list_changed")
+
+                # Issue the unrelated request immediately, while the reconcile
+                # the notification just triggered may still be in flight, to
+                # the SAME downstream. A deadlocked read loop would never
+                # resolve this -- bound it so a real deadlock fails this test
+                # with a timeout instead of hanging the suite.
+                result = await asyncio.wait_for(
+                    gateway_tools.invoke(
+                        {
+                            "tool_id": "fr-deadlock::fr_echo",
+                            "arguments": {"text": "still-alive"},
+                        }
+                    ),
+                    timeout=5.0,
+                )
+                assert result.ok is True, result.errors
+                content = result.result["content"]  # type: ignore[index]
+                assert content[0]["text"] == "fr-echo:still-alive"
+        finally:
+            await manager.disconnect_all()

--- a/tests/runtime/test_downstream_stdio.py
+++ b/tests/runtime/test_downstream_stdio.py
@@ -1,0 +1,180 @@
+"""SL-3 (FANOUT) — EC-FANOUT-1/2/3/9: catalog freshness on the stdio dispatch
+path, proven through `gateway.catalog_search` and `gateway.invoke` -- never
+merely through "a notification arrived."
+
+`tests/runtime/test_emitter_harness.py` (SL-2) already proves the emitter's
+frames reach `ClientManager._handle_stdout_line`; that is necessary but not
+sufficient evidence the gateway is actually usable afterwards. A
+forward-to-sink implementation that never re-indexes would also make SL-2's
+tests pass, because they only spy on the raw line reaching the dispatch
+function. This file is the other half: after a real downstream emission, a
+tool the fake stdio server ADDED is returned by `gateway.catalog_search` and
+answers a real `gateway.invoke` call, and a tool it REMOVED is gone from
+both -- backed by `ClientManager.get_tool`/`get_all_tools` (the index,
+`self._tools`), never by peeking at `manager._tools` directly from the test.
+
+`tests/runtime/test_downstream_remote.py` is this file's remote-transport
+twin; EC-FANOUT-3 requires both to pass independently, neither may be
+skipped.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+import pytest
+
+from pmcp.client.manager import ClientManager
+from pmcp.policy.policy import PolicyManager
+from pmcp.tools.handlers import GatewayTools
+
+from tests.runtime.fake_stdio_server import build_fake_stdio_downstream
+from tests.runtime.harness import alloc_port
+
+
+async def _catalog_tool_ids(gateway_tools: GatewayTools, server: str) -> set[str]:
+    """The tool_ids `gateway.catalog_search` currently returns for `server`,
+    with no text query -- a query is optional (`CatalogSearchInput.query`),
+    and the server filter alone is enough to scope this to one downstream."""
+    output = await gateway_tools.catalog_search(
+        {"filters": {"server": server}, "limit": 100}
+    )
+    return {card.tool_id for card in output.results}
+
+
+async def _wait_until(
+    predicate: Callable[[], Awaitable[bool]],
+    *,
+    attempts: int = 50,
+    interval: float = 0.05,
+) -> bool:
+    """Poll an async predicate until it is True or `attempts` is exhausted.
+    Returns the last observed value, so a failing assertion shows what the
+    catalog actually held rather than just "timed out"."""
+    result = False
+    for _ in range(attempts):
+        result = await predicate()
+        if result:
+            return True
+        await asyncio.sleep(interval)
+    return result
+
+
+@pytest.mark.asyncio
+class TestStdioDownstreamNotificationCatalogFreshness:
+    async def test_downstream_notification_added_tool_is_searchable_and_invocable(
+        self,
+    ) -> None:
+        """EC-FANOUT-1/9, stdio half of EC-FANOUT-3: a tool ADDED by the
+        downstream after connect is returned by `gateway.catalog_search`, and
+        `gateway.invoke` resolves it through the index and dispatches a real
+        downstream call -- proof the index actually moved, not just that a
+        notification was received.
+
+        `fake_stdio_server.py` (SL-2, owned by that lane, not editable here)
+        deliberately implements only `initialize` and `tools/list` for real
+        -- its own docstring states resources/prompts get a "method not
+        found" response and is silent on `tools/call`, which turns out to
+        get the same treatment. So the downstream call itself always fails
+        here; what proves reconciliation is *which* error comes back.
+        `gateway.invoke` resolves `tool_id` through `ClientManager.get_tool`
+        BEFORE it ever calls the downstream (`handlers.py` — the E301 branch
+        is reached only when the registry lookup misses); a lookup miss
+        would short-circuit to E301_TOOL_NOT_FOUND without a downstream
+        round trip at all. Getting back E302 (downstream execution failed)
+        instead of E301 (not found) is the proof the tool was actually in
+        the reconciled index."""
+        name = "stdio-fanout-add"
+        downstream = build_fake_stdio_downstream(name, control_port=alloc_port())
+        manager = ClientManager()
+        try:
+            errors = await manager.connect_server(downstream.config)
+            assert errors == []
+            gateway_tools = GatewayTools(
+                client_manager=manager, policy_manager=PolicyManager()
+            )
+            tool_id = f"{name}::sf_dyn"
+
+            # Baseline: the fake stdio server starts with an empty catalog,
+            # so the tool must not be findable before the mutation + emit.
+            assert tool_id not in await _catalog_tool_ids(gateway_tools, name)
+
+            await downstream.emitter.add_tool("sf_dyn", description="dynamic")
+            await downstream.emitter.emit("notifications/tools/list_changed")
+
+            found = await _wait_until(
+                lambda: _tool_present(gateway_tools, name, tool_id)
+            )
+            assert found, "gateway.catalog_search never reflected the added tool"
+
+            result = await gateway_tools.invoke(
+                {"tool_id": tool_id, "arguments": {"text": "hi"}}
+            )
+            assert result.ok is False, (
+                "unexpectedly succeeded -- fake_stdio_server has no tools/call "
+                "handler, so a real success here would be surprising"
+            )
+            errors_joined = " ".join(result.errors or [])
+            assert '"code":"E301"' not in errors_joined, (
+                f"gateway.invoke returned E301_TOOL_NOT_FOUND for a tool the "
+                f"catalog just reported present -- the index was not actually "
+                f"updated: {result.errors}"
+            )
+            assert '"code":"E302"' in errors_joined, (
+                f"expected a downstream dispatch failure (E302), got: {result.errors}"
+            )
+
+        finally:
+            await manager.disconnect_all()
+
+    async def test_downstream_notification_removed_tool_disappears_from_catalog_and_invoke(
+        self,
+    ) -> None:
+        """EC-FANOUT-2, stdio half of EC-FANOUT-3: the flip side. A tool the
+        downstream REMOVES is gone from both `gateway.catalog_search` and
+        `gateway.invoke` after the server announces the change."""
+        name = "stdio-fanout-remove"
+        downstream = build_fake_stdio_downstream(name, control_port=alloc_port())
+        manager = ClientManager()
+        try:
+            errors = await manager.connect_server(downstream.config)
+            assert errors == []
+            gateway_tools = GatewayTools(
+                client_manager=manager, policy_manager=PolicyManager()
+            )
+            tool_id = f"{name}::sf_removable"
+
+            await downstream.emitter.add_tool("sf_removable")
+            await downstream.emitter.emit("notifications/tools/list_changed")
+            found = await _wait_until(
+                lambda: _tool_present(gateway_tools, name, tool_id)
+            )
+            assert found, "setup: added tool never appeared in the catalog"
+
+            await downstream.emitter.remove_tool("sf_removable")
+            await downstream.emitter.emit("notifications/tools/list_changed")
+
+            gone = await _wait_until(lambda: _tool_absent(gateway_tools, name, tool_id))
+            assert gone, (
+                "gateway.catalog_search still lists a tool the downstream removed"
+            )
+
+            result = await gateway_tools.invoke({"tool_id": tool_id, "arguments": {}})
+            assert result.ok is False
+            errors_joined = " ".join(result.errors or [])
+            assert '"code":"E301"' in errors_joined, (
+                f"expected E301_TOOL_NOT_FOUND for a tool the downstream removed, "
+                f"got: {result.errors}"
+            )
+
+        finally:
+            await manager.disconnect_all()
+
+
+async def _tool_present(gateway_tools: GatewayTools, server: str, tool_id: str) -> bool:
+    return tool_id in await _catalog_tool_ids(gateway_tools, server)
+
+
+async def _tool_absent(gateway_tools: GatewayTools, server: str, tool_id: str) -> bool:
+    return tool_id not in await _catalog_tool_ids(gateway_tools, server)

--- a/tests/runtime/test_emitter_harness.py
+++ b/tests/runtime/test_emitter_harness.py
@@ -1,0 +1,353 @@
+"""SL-2.1 (FANOUT) — pins IF-0-FANOUT-2's shape and proves the emitter
+reaches the gateway's dispatch, on both transports independently.
+
+This module owns the emitter contract, not the reconciliation behaviour
+built on it -- SL-1's scheduler may not exist yet (SL-1 and SL-2 are
+parallel-safe, neither depends on the other), so "reaches the dispatch"
+here means "the frame is fed into the exact function that would recognise
+it": `ClientManager._handle_stdout_line` (stdio) and the per-message loop
+inside `ClientManager._read_sse` (remote). Both already exist on `main` --
+today they silently drop a notification (no `id`, no `else` branch) rather
+than reconciling it, so this test does not assert reconciliation; SL-3
+(`tests/runtime/test_downstream_remote.py`,
+`tests/runtime/test_downstream_stdio.py`) asserts the catalog is actually
+refreshed, once SL-1 lands.
+
+`_read_sse` has no extracted per-message handler to spy on directly (unlike
+`_handle_stdout_line`, which already is one) -- it's one monolithic
+`async for message in read_stream:` loop. So the remote-side proof wraps
+`read_stream` itself: an async generator that records each message as it
+passes through, then re-yields it unchanged into the real `_read_sse`. The
+real dispatch loop still consumes the exact same message; the wrapper only
+observes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest import mock
+
+import pytest
+
+from pmcp.client.manager import ClientManager
+from pmcp.types import RemoteMcpServerConfig, ResolvedServerConfig
+
+from tests.runtime.fake_remote import (
+    DownstreamEmitter,
+    build_fake_remote_app,
+    run_fake_remote,
+)
+from tests.runtime.fake_stdio_server import StdioEmitter, build_fake_stdio_downstream
+from tests.runtime.harness import alloc_port
+
+AUTH_VALUE = "Bearer emitter-harness-token"
+
+
+def _remote_config(name: str, url: str) -> ResolvedServerConfig:
+    return ResolvedServerConfig(
+        name=name,
+        source="custom",
+        config=RemoteMcpServerConfig(
+            type="streamable-http", url=url, headers={"Authorization": AUTH_VALUE}
+        ),
+    )
+
+
+def _spy_read_sse():
+    """Patch target + call recorder for `ClientManager._read_sse`. Returns
+    `(patcher, calls)`; `calls` accumulates each message's JSON-alias dict
+    form, in the exact shape `_read_sse` itself decodes it to
+    (`manager.py:1981`)."""
+    calls: list[dict[str, object]] = []
+    original = ClientManager._read_sse
+
+    async def spy(self: ClientManager, name: str, managed: object, read_stream: object):
+        async def _tap() -> object:
+            async for message in read_stream:  # type: ignore[attr-defined]
+                if not isinstance(message, Exception):
+                    calls.append(
+                        message.message.model_dump(
+                            by_alias=True, mode="json", exclude_none=True
+                        )
+                    )
+                yield message
+
+        return await original(self, name, managed, _tap())
+
+    return mock.patch.object(ClientManager, "_read_sse", spy), calls
+
+
+def _spy_handle_stdout_line():
+    """Patch target + call recorder for `ClientManager._handle_stdout_line`.
+    `calls` accumulates each raw line's decoded JSON, exactly as
+    `_handle_stdout_line` itself parses it (`manager.py:1765`)."""
+    calls: list[dict[str, object]] = []
+    original = ClientManager._handle_stdout_line
+
+    def spy(
+        self: ClientManager, name: str, managed: object, line: bytes, now: float
+    ) -> None:
+        calls.append(json.loads(line.decode()))
+        return original(self, name, managed, line, now)
+
+    return mock.patch.object(ClientManager, "_handle_stdout_line", spy), calls
+
+
+class TestIF0Fanout2Shape:
+    """Pins the emitter API's shape before SL-3 codes against it."""
+
+    def test_remote_emitter_satisfies_downstream_emitter_protocol(self) -> None:
+        app = build_fake_remote_app(expected_auth_value=AUTH_VALUE)
+        assert isinstance(app.state.fake_remote_emitter, DownstreamEmitter)
+
+    def test_stdio_emitter_satisfies_downstream_emitter_protocol(self) -> None:
+        downstream = build_fake_stdio_downstream(
+            "shape-check", control_port=alloc_port()
+        )
+        assert isinstance(downstream.emitter, StdioEmitter)
+        assert isinstance(downstream.emitter, DownstreamEmitter)
+
+    def test_emitter_methods_are_the_documented_three(self) -> None:
+        for method_name in ("add_tool", "remove_tool", "emit"):
+            assert callable(getattr(DownstreamEmitter, method_name))
+
+
+@pytest.mark.asyncio
+class TestRemoteEmitterReachesDispatch:
+    async def test_add_tool_then_emit_reaches_read_sse(self) -> None:
+        manager = ClientManager()
+        patcher, calls = _spy_read_sse()
+        try:
+            async with run_fake_remote(
+                alloc_port(), expected_auth_value=AUTH_VALUE
+            ) as remote:
+                with patcher:
+                    errors = await manager.connect_server(
+                        _remote_config("fr-emit-add", remote.mcp_url)
+                    )
+                    assert errors == []
+
+                    await remote.emitter.add_tool("fr_dyn", description="dynamic")
+                    await remote.emitter.emit("notifications/tools/list_changed")
+
+                    for _ in range(50):
+                        if any(
+                            c.get("method") == "notifications/tools/list_changed"
+                            for c in calls
+                        ):
+                            break
+                        await asyncio.sleep(0.05)
+        finally:
+            await manager.disconnect_all()
+
+        matches = [
+            c for c in calls if c.get("method") == "notifications/tools/list_changed"
+        ]
+        assert matches, f"emitted notification never reached _read_sse: {calls}"
+
+    async def test_emit_alone_reaches_read_sse(self) -> None:
+        """Storm-suppression precondition: `emit()` with no prior catalog
+        mutation still reaches the dispatch."""
+        manager = ClientManager()
+        patcher, calls = _spy_read_sse()
+        try:
+            async with run_fake_remote(
+                alloc_port(), expected_auth_value=AUTH_VALUE
+            ) as remote:
+                with patcher:
+                    errors = await manager.connect_server(
+                        _remote_config("fr-emit-noop", remote.mcp_url)
+                    )
+                    assert errors == []
+
+                    await remote.emitter.emit("notifications/tools/list_changed")
+
+                    for _ in range(50):
+                        if calls:
+                            break
+                        await asyncio.sleep(0.05)
+        finally:
+            await manager.disconnect_all()
+
+        assert any(c.get("method") == "notifications/tools/list_changed" for c in calls)
+
+    async def test_unrecognised_method_reaches_read_sse(self) -> None:
+        """EC-FANOUT-5's no-op case starts here: the harness must be able to
+        put an unrecognised `notifications/*` method on the wire at all."""
+        manager = ClientManager()
+        patcher, calls = _spy_read_sse()
+        try:
+            async with run_fake_remote(
+                alloc_port(), expected_auth_value=AUTH_VALUE
+            ) as remote:
+                with patcher:
+                    errors = await manager.connect_server(
+                        _remote_config("fr-emit-unknown", remote.mcp_url)
+                    )
+                    assert errors == []
+
+                    await remote.emitter.emit("notifications/something_unrecognised")
+
+                    for _ in range(50):
+                        if calls:
+                            break
+                        await asyncio.sleep(0.05)
+        finally:
+            await manager.disconnect_all()
+
+        assert any(
+            c.get("method") == "notifications/something_unrecognised" for c in calls
+        )
+
+    async def test_remove_tool_then_emit_reaches_read_sse(self) -> None:
+        manager = ClientManager()
+        patcher, calls = _spy_read_sse()
+        try:
+            async with run_fake_remote(
+                alloc_port(), expected_auth_value=AUTH_VALUE
+            ) as remote:
+                with patcher:
+                    errors = await manager.connect_server(
+                        _remote_config("fr-emit-remove", remote.mcp_url)
+                    )
+                    assert errors == []
+
+                    await remote.emitter.add_tool("fr_removable")
+                    await remote.emitter.remove_tool("fr_removable")
+                    await remote.emitter.emit("notifications/tools/list_changed")
+
+                    for _ in range(50):
+                        if calls:
+                            break
+                        await asyncio.sleep(0.05)
+        finally:
+            await manager.disconnect_all()
+
+        assert any(c.get("method") == "notifications/tools/list_changed" for c in calls)
+
+
+@pytest.mark.asyncio
+class TestStdioEmitterReachesDispatch:
+    async def test_add_tool_then_emit_reaches_handle_stdout_line(self) -> None:
+        downstream = build_fake_stdio_downstream(
+            "stdio-emit-add", control_port=alloc_port()
+        )
+        manager = ClientManager()
+        patcher, calls = _spy_handle_stdout_line()
+        try:
+            with patcher:
+                errors = await manager.connect_server(downstream.config)
+                assert errors == []
+
+                await downstream.emitter.add_tool("stdio_dyn", description="dynamic")
+                await downstream.emitter.emit("notifications/tools/list_changed")
+
+                for _ in range(50):
+                    if any(
+                        c.get("method") == "notifications/tools/list_changed"
+                        for c in calls
+                    ):
+                        break
+                    await asyncio.sleep(0.05)
+        finally:
+            await manager.disconnect_all()
+
+        matches = [
+            c for c in calls if c.get("method") == "notifications/tools/list_changed"
+        ]
+        assert matches, (
+            f"emitted notification never reached _handle_stdout_line: {calls}"
+        )
+
+    async def test_emit_alone_reaches_handle_stdout_line(self) -> None:
+        downstream = build_fake_stdio_downstream(
+            "stdio-emit-noop", control_port=alloc_port()
+        )
+        manager = ClientManager()
+        patcher, calls = _spy_handle_stdout_line()
+        try:
+            with patcher:
+                errors = await manager.connect_server(downstream.config)
+                assert errors == []
+
+                await downstream.emitter.emit("notifications/tools/list_changed")
+
+                for _ in range(50):
+                    if any(
+                        c.get("method") == "notifications/tools/list_changed"
+                        for c in calls
+                    ):
+                        break
+                    await asyncio.sleep(0.05)
+        finally:
+            await manager.disconnect_all()
+
+        assert any(c.get("method") == "notifications/tools/list_changed" for c in calls)
+
+    async def test_unrecognised_method_reaches_handle_stdout_line(self) -> None:
+        downstream = build_fake_stdio_downstream(
+            "stdio-emit-unknown", control_port=alloc_port()
+        )
+        manager = ClientManager()
+        patcher, calls = _spy_handle_stdout_line()
+        try:
+            with patcher:
+                errors = await manager.connect_server(downstream.config)
+                assert errors == []
+
+                await downstream.emitter.emit("notifications/something_unrecognised")
+
+                for _ in range(50):
+                    if any(
+                        c.get("method") == "notifications/something_unrecognised"
+                        for c in calls
+                    ):
+                        break
+                    await asyncio.sleep(0.05)
+        finally:
+            await manager.disconnect_all()
+
+        assert any(
+            c.get("method") == "notifications/something_unrecognised" for c in calls
+        )
+
+    async def test_remove_tool_then_emit_reaches_handle_stdout_line(self) -> None:
+        downstream = build_fake_stdio_downstream(
+            "stdio-emit-remove", control_port=alloc_port()
+        )
+        manager = ClientManager()
+        patcher, calls = _spy_handle_stdout_line()
+        try:
+            with patcher:
+                errors = await manager.connect_server(downstream.config)
+                assert errors == []
+
+                await downstream.emitter.add_tool("stdio_removable")
+                await downstream.emitter.remove_tool("stdio_removable")
+                await downstream.emitter.emit("notifications/tools/list_changed")
+
+                for _ in range(50):
+                    if any(
+                        c.get("method") == "notifications/tools/list_changed"
+                        for c in calls
+                    ):
+                        break
+                    await asyncio.sleep(0.05)
+        finally:
+            await manager.disconnect_all()
+
+        assert any(c.get("method") == "notifications/tools/list_changed" for c in calls)
+
+    async def test_remove_unknown_tool_raises(self) -> None:
+        downstream = build_fake_stdio_downstream(
+            "stdio-emit-remove-unknown", control_port=alloc_port()
+        )
+        manager = ClientManager()
+        try:
+            errors = await manager.connect_server(downstream.config)
+            assert errors == []
+            with pytest.raises(RuntimeError):
+                await downstream.emitter.remove_tool("does-not-exist")
+        finally:
+            await manager.disconnect_all()

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -35,6 +35,7 @@ from pmcp.remote_auth import MissingRemoteHeaderAuthError
 from pmcp.types import (
     LocalMcpServerConfig,
     McpTaskInfo,
+    McpTaskRecord,
     PromptInfo,
     RemoteMcpServerConfig,
     ResourceInfo,
@@ -3905,7 +3906,507 @@ class TestDownstreamReconcileScheduler:
             manager = ClientManager()
             managed = self._managed("srv")
             manager._clients["srv"] = managed
+            self._wire(manager, {})
             assert (
                 manager._handle_downstream_notification("srv", managed, method) is True
             ), method
             await manager._cancel_background_tasks()
+
+    # ---- SL-1.3: the coalesced scheduler --------------------------------
+
+    @staticmethod
+    async def _drain(manager: ClientManager, timeout: float = 5.0) -> None:
+        """Wait until no reconcile is in flight."""
+
+        async def _wait() -> None:
+            while manager._reconcile_tasks:
+                await asyncio.sleep(0.005)
+
+        await asyncio.wait_for(_wait(), timeout)
+
+    def _wire(
+        self,
+        manager: ClientManager,
+        state: dict[str, list[str]],
+        gate: asyncio.Event | None = None,
+    ) -> list[str]:
+        """Replace `_send_request` with a listing stub driven by `state`, and
+        return the list that records every method it was asked for.
+
+        `state` maps "tools"/"resources"/"prompts" to the identifier names the
+        downstream server currently reports, so a test mutates `state` to
+        simulate the downstream catalog moving underneath the gateway.
+        """
+        calls: list[str] = []
+
+        async def fake_send(
+            managed: ManagedClient,
+            method: str,
+            params: dict[str, Any],
+            *args: Any,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            calls.append(method)
+            if gate is not None:
+                await gate.wait()
+            if method == "tools/list":
+                return {
+                    "tools": [
+                        {"name": n, "inputSchema": {}} for n in state.get("tools", [])
+                    ]
+                }
+            if method == "resources/list":
+                return {
+                    "resources": [
+                        {"uri": f"mem://{n}"} for n in state.get("resources", [])
+                    ]
+                }
+            if method == "prompts/list":
+                return {"prompts": [{"name": n} for n in state.get("prompts", [])]}
+            return {}
+
+        manager._send_request = fake_send  # type: ignore[method-assign]
+        return calls
+
+    @pytest.mark.asyncio
+    async def test_reconcile_is_spawned_and_not_awaited_in_the_dispatch_path(
+        self,
+    ) -> None:
+        """The handler must return *before* the reconcile's `tools/list` resolves.
+
+        This encodes the self-deadlock hazard directly. `_index_capabilities`
+        awaits `_send_request` (manager.py `:1292`) and those futures are
+        resolved by the very read loop that received the notification --
+        `pending.future.set_result` at `:1791` (stdio) and `:2010` (SSE). Here
+        the stand-in for that loop is the test body: it releases the gate only
+        after the handler has returned. An implementation that awaited the
+        reconcile inline could never reach that release, and this test would
+        time out rather than fail with a diff.
+        """
+        manager = ClientManager()
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        gate = asyncio.Event()
+        state = {"tools": ["alpha"]}
+        calls = self._wire(manager, state, gate)
+
+        assert (
+            manager._handle_downstream_notification(
+                "srv", managed, "notifications/tools/list_changed"
+            )
+            is True
+        )
+        # Give the spawned task room to start and block on the gate.
+        for _ in range(10):
+            await asyncio.sleep(0)
+        assert calls == ["tools/list"], "reconcile did not start"
+        assert "srv::alpha" not in manager._tools, (
+            "reconcile completed inline; it must not have, the gate is still shut"
+        )
+
+        gate.set()
+        await self._drain(manager)
+        assert "srv::alpha" in manager._tools
+
+    @pytest.mark.asyncio
+    async def test_reconcile_coalesces_to_one_in_flight_task_per_server(self) -> None:
+        """A storm of notifications during an in-flight reconcile collapses to a
+        single re-run, not one task per notification."""
+        manager = ClientManager()
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        gate = asyncio.Event()
+        calls = self._wire(manager, {"tools": ["alpha"]}, gate)
+
+        for _ in range(5):
+            manager._handle_downstream_notification(
+                "srv", managed, "notifications/tools/list_changed"
+            )
+            await asyncio.sleep(0)
+        # Only the first reconcile has issued a listing; it is still gated.
+        assert calls.count("tools/list") == 1
+        assert len(manager._reconcile_tasks) == 1
+
+        gate.set()
+        await self._drain(manager)
+        # The four later notifications collapsed into exactly one re-run.
+        assert calls.count("tools/list") == 2
+
+    @pytest.mark.asyncio
+    async def test_reconcile_coalescing_is_per_server_not_global(self) -> None:
+        """Two servers reconcile independently; one does not swallow the other."""
+        manager = ClientManager()
+        for name in ("one", "two"):
+            managed = self._managed(name)
+            manager._clients[name] = managed
+        calls = self._wire(manager, {"tools": ["alpha"]})
+
+        for name in ("one", "two"):
+            manager._handle_downstream_notification(
+                name, manager._clients[name], "notifications/tools/list_changed"
+            )
+        assert len(manager._reconcile_tasks) == 2
+        await self._drain(manager)
+
+        assert calls.count("tools/list") == 2
+        assert "one::alpha" in manager._tools
+        assert "two::alpha" in manager._tools
+
+    @pytest.mark.asyncio
+    async def test_reconcile_publishes_once_for_the_kind_that_changed(self) -> None:
+        """A downstream that adds a tool produces exactly one `note_tools_changed`
+        -- not one per index mutation -- and nothing for the untouched kinds."""
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        state: dict[str, list[str]] = {
+            "tools": ["alpha"],
+            "resources": ["r1"],
+            "prompts": ["p1"],
+        }
+        self._wire(manager, state)
+
+        # Prime the catalog as connect-time indexing would, then start counting.
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        sink.tools = sink.resources = sink.prompts = 0
+
+        state["tools"] = ["alpha", "beta"]
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+
+        assert "srv::beta" in manager._tools
+        assert (sink.tools, sink.resources, sink.prompts) == (1, 0, 0)
+
+    @pytest.mark.asyncio
+    async def test_reconcile_publishes_nothing_when_identifier_sets_match(self) -> None:
+        """Reconciliation over a catalog that did not move publishes nothing, even
+        though `_remove_server_indexes` and `_index_*` both call `note_*`
+        unconditionally."""
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        self._wire(
+            manager, {"tools": ["alpha"], "resources": ["r1"], "prompts": ["p1"]}
+        )
+
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        sink.tools = sink.resources = sink.prompts = 0
+
+        for _ in range(3):
+            manager._handle_downstream_notification(
+                "srv", managed, "notifications/tools/list_changed"
+            )
+            await self._drain(manager)
+
+        assert "srv::alpha" in manager._tools
+        assert (sink.tools, sink.resources, sink.prompts) == (0, 0, 0)
+
+    @pytest.mark.asyncio
+    async def test_reconcile_publishes_on_rename_that_preserves_the_count(self) -> None:
+        """The count-diffing trap: one tool renamed leaves the count identical, so
+        only an identifier-set comparison detects it."""
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        state: dict[str, list[str]] = {"tools": ["alpha", "beta"]}
+        self._wire(manager, state)
+
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        sink.tools = sink.resources = sink.prompts = 0
+
+        state["tools"] = ["alpha", "gamma"]  # same count, different set
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+
+        assert set(manager._tools) == {"srv::alpha", "srv::gamma"}
+        assert sink.tools == 1
+
+    @pytest.mark.asyncio
+    async def test_reconcile_removes_entries_the_downstream_dropped(self) -> None:
+        """`_index_*` only adds or overwrites, so reconciliation must pair a removal
+        with the re-index or a dropped tool lingers forever."""
+        manager = ClientManager()
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        state: dict[str, list[str]] = {"tools": ["alpha", "beta"]}
+        self._wire(manager, state)
+
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        assert set(manager._tools) == {"srv::alpha", "srv::beta"}
+
+        state["tools"] = ["alpha"]
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        assert set(manager._tools) == {"srv::alpha"}
+
+    @pytest.mark.asyncio
+    async def test_reconcile_failure_leaves_the_catalog_intact(self) -> None:
+        """A downstream that emits `list_changed` and then fails `tools/list` must
+        not leave the catalog half-removed, and must publish nothing."""
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        state: dict[str, list[str]] = {"tools": ["alpha"], "prompts": ["p1"]}
+        self._wire(manager, state)
+
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        before_tools = dict(manager._tools)
+        before_prompts = dict(manager._prompts)
+        assert before_tools and before_prompts
+        sink.tools = sink.resources = sink.prompts = 0
+
+        async def failing_send(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            raise ConnectionError("downstream went away mid-reconcile")
+
+        manager._send_request = failing_send  # type: ignore[method-assign]
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+
+        assert manager._tools == before_tools
+        assert manager._prompts == before_prompts
+        assert (sink.tools, sink.resources, sink.prompts) == (0, 0, 0)
+
+    @pytest.mark.asyncio
+    async def test_reconcile_preserves_tracked_task_records(self) -> None:
+        """Reconciliation must not evict the server's in-flight `McpTaskRecord`s.
+
+        `_remove_server_indexes` drops them, which is right for a disconnect and
+        wrong for a `list_changed` — the downstream's tasks did not go anywhere.
+        """
+        manager = ClientManager()
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        self._wire(manager, {"tools": ["alpha"]})
+        record = McpTaskRecord(
+            server_name="srv",
+            tool_id="srv::alpha",
+            task_id="t-1",
+            status="working",
+        )
+        manager._tasks[("srv", "t-1")] = record
+
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+
+        assert manager._tasks.get(("srv", "t-1")) is record
+
+    @pytest.mark.asyncio
+    async def test_reconcile_is_a_noop_when_the_server_is_gone(self) -> None:
+        """A server disconnected between the notification and the reconcile must
+        not be re-indexed down a dead connection."""
+        manager = ClientManager()
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        calls = self._wire(manager, {"tools": ["alpha"]})
+        manager._clients.pop("srv")
+
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+
+        assert calls == []
+        assert manager._tools == {}
+
+    @pytest.mark.asyncio
+    async def test_reconcile_does_not_spin_when_the_server_answers_with_a_storm(
+        self,
+    ) -> None:
+        """A downstream that emits `list_changed` in reply to the very
+        `tools/list` reconciliation issues would drive the re-run loop forever.
+
+        Coalescing alone does not bound this -- it bounds *concurrency*, and this
+        loop is sequential. The re-run debounce is what bounds it, so this test
+        asserts a hard ceiling on reconciles in a fixed window rather than a
+        specific count.
+        """
+        manager = ClientManager()
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        calls: list[str] = []
+
+        async def storm_send(
+            managed_arg: ManagedClient,
+            method: str,
+            params: dict[str, Any],
+            *args: Any,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            calls.append(method)
+            if method == "tools/list":
+                # The server answers the listing by announcing another change.
+                manager._handle_downstream_notification(
+                    "srv", managed_arg, "notifications/tools/list_changed"
+                )
+                return {"tools": [{"name": "alpha", "inputSchema": {}}]}
+            return {}
+
+        manager._send_request = storm_send  # type: ignore[method-assign]
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await asyncio.sleep(0.6)
+        spins = calls.count("tools/list")
+
+        # Cancel the (deliberately endless) loop before asserting.
+        await manager._cancel_background_tasks()
+
+        # Without the debounce this is thousands. With it, ~1 + 0.6/0.25.
+        assert spins <= 6, f"reconcile loop is spinning: {spins} passes in 0.6s"
+        assert spins >= 1
+
+    # ---- SL-1.6: both dispatch paths, and typed errors ------------------
+
+    @pytest.mark.asyncio
+    async def test_stdio_dispatch_path_reaches_the_reconcile_scheduler(self) -> None:
+        """`_handle_stdout_line` must recognise a notification. It has no `id`, so
+        it falls through the pending-request gate with nothing to resolve."""
+        manager = ClientManager()
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        self._wire(manager, {"tools": ["alpha"]})
+
+        line = json.dumps(
+            {"jsonrpc": "2.0", "method": "notifications/tools/list_changed"}
+        ).encode()
+        manager._handle_stdout_line("srv", managed, line, time.time())
+        await self._drain(manager)
+
+        assert "srv::alpha" in manager._tools
+
+    @pytest.mark.asyncio
+    async def test_sse_dispatch_path_reaches_the_reconcile_scheduler(self) -> None:
+        """The `_read_sse` loop must recognise a notification, and must survive it:
+        a raise inside that loop is caught by its blanket `except Exception`, which
+        marks the server ERROR and reconnects."""
+        manager = ClientManager()
+        managed = self._managed("srv")
+        managed.is_remote = True
+        manager._clients["srv"] = managed
+        self._wire(manager, {"tools": ["alpha"]})
+        manager._schedule_reconnect = MagicMock()  # type: ignore[method-assign]
+
+        def _frame(payload: dict[str, Any]) -> Any:
+            frame = MagicMock()
+            frame.message.model_dump.return_value = payload
+            return frame
+
+        async def stream() -> Any:
+            yield _frame(
+                {"jsonrpc": "2.0", "method": "notifications/tools/list_changed"}
+            )
+            yield _frame({"jsonrpc": "2.0", "method": "notifications/message"})
+
+        await manager._read_sse("srv", managed, stream())
+        await self._drain(manager)
+
+        assert "srv::alpha" in manager._tools
+
+    @pytest.mark.asyncio
+    async def test_stdio_dispatch_preserves_downstream_error_code_and_data(
+        self,
+    ) -> None:
+        """A JSON-RPC error keeps `code` and `data` alongside `message`, and `str()`
+        stays exactly the message so `gateway.invoke`'s E302 mapping is unchanged."""
+        from pmcp.client.manager import DownstreamError
+
+        manager = ClientManager()
+        managed = self._managed("srv")
+        fut: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+        now = time.time()
+        managed.pending_requests[7] = PendingRequest(
+            request_id=7,
+            server_name="srv",
+            tool_id="srv::alpha",
+            started_at=now,
+            last_heartbeat=now,
+            timeout_ms=30000,
+            future=fut,
+        )
+        line = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 7,
+                "error": {
+                    "code": -32602,
+                    "message": "Invalid params",
+                    "data": {"field": "path"},
+                },
+            }
+        ).encode()
+
+        manager._handle_stdout_line("srv", managed, line, time.time())
+
+        err = fut.exception()
+        assert isinstance(err, DownstreamError)
+        assert err.code == -32602
+        assert err.data == {"field": "path"}
+        assert str(err) == "Invalid params"
+
+    @pytest.mark.asyncio
+    async def test_sse_dispatch_preserves_downstream_error_code_and_data(self) -> None:
+        """The same, through the remote dispatch path."""
+        from pmcp.client.manager import DownstreamError
+
+        manager = ClientManager()
+        managed = self._managed("srv")
+        managed.is_remote = True
+        manager._clients["srv"] = managed
+        manager._schedule_reconnect = MagicMock()  # type: ignore[method-assign]
+        fut: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+        now = time.time()
+        managed.pending_requests[9] = PendingRequest(
+            request_id=9,
+            server_name="srv",
+            tool_id="srv::alpha",
+            started_at=now,
+            last_heartbeat=now,
+            timeout_ms=30000,
+            future=fut,
+        )
+
+        async def stream() -> Any:
+            frame = MagicMock()
+            frame.message.model_dump.return_value = {
+                "jsonrpc": "2.0",
+                "id": 9,
+                "error": {"code": -32000, "message": "boom", "data": ["a", "b"]},
+            }
+            yield frame
+
+        await manager._read_sse("srv", managed, stream())
+
+        err = fut.exception()
+        assert isinstance(err, DownstreamError)
+        assert err.code == -32000
+        assert err.data == ["a", "b"]
+        assert str(err) == "boom"

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -5120,6 +5120,128 @@ class TestReconcileMalformedEntryResilience:
         assert manager._tools == {} and manager._resources == {}
         assert manager._prompts == {}
 
+    # ---- F1: a listing nobody could parse is a failed listing -----------
+
+    @pytest.mark.asyncio
+    async def test_all_malformed_relist_preserves_the_prior_catalog(self) -> None:
+        """Offered entries, none of them parseable, over a *populated* catalog.
+
+        The per-entry guard handles one bad entry among good ones; this is the
+        corner where every entry is bad. Counting that as an answer would remove
+        the prior entries, index nothing and publish the removal -- a false
+        "those tools are gone" built out of "we could not read the answer".
+        `test_index_of_only_malformed_entries_publishes_nothing` cannot catch it:
+        it indexes into an empty catalog, so it has nothing to lose.
+        """
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        self._wire_listings(manager, {"tools": [{"name": "alpha", "inputSchema": {}}]})
+
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        assert set(manager._tools) == {"srv::alpha"}
+        published_while_priming = sink.tools
+
+        self._wire_listings(
+            manager,
+            {"tools": [{"name": "bad", "inputSchema": "not-a-dict"}]},
+        )
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+
+        assert set(manager._tools) == {"srv::alpha"}, (
+            "a listing whose every entry was unparseable wiped the prior catalog"
+        )
+        assert sink.tools == published_while_priming, (
+            "published a removal for entries we merely failed to read"
+        )
+
+    @pytest.mark.asyncio
+    async def test_all_malformed_relist_leaves_the_other_kinds_alone(self) -> None:
+        """Per kind, still. Tools unreadable must not hold back an honest
+        resources answer arriving in the same reconcile."""
+        manager = ClientManager()
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        self._wire_listings(
+            manager,
+            {
+                "tools": [{"name": "alpha", "inputSchema": {}}],
+                "resources": [{"uri": "mem://old"}],
+            },
+        )
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        assert set(manager._tools) == {"srv::alpha"}
+
+        self._wire_listings(
+            manager,
+            {
+                "tools": [{"name": "bad", "inputSchema": "not-a-dict"}],
+                "resources": [{"uri": "mem://new"}],
+            },
+        )
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+
+        assert set(manager._tools) == {"srv::alpha"}
+        assert set(manager._resources) == {"srv::mem://new"}
+
+    @pytest.mark.asyncio
+    async def test_explicitly_empty_relist_still_clears_and_publishes(self) -> None:
+        """The boundary of the rule above: *no* entries offered is an answer --
+        the server emptied the kind -- and must clear and publish. Preserving
+        here would strand entries the downstream has explicitly disowned."""
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        self._wire_listings(manager, {"tools": [{"name": "alpha", "inputSchema": {}}]})
+
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        assert set(manager._tools) == {"srv::alpha"}
+        published_while_priming = sink.tools
+
+        self._wire_listings(manager, {"tools": []})
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+
+        assert manager._tools == {}
+        assert sink.tools == published_while_priming + 1
+
+    def test_partly_malformed_relist_still_replaces_the_kind(self) -> None:
+        """Mixed listings keep the per-entry semantics: some entries parsed, so
+        the kind answered and is replaced wholesale by what parsed."""
+        manager = ClientManager()
+        manager._index_tools("srv", [{"name": "gone", "inputSchema": {}}])
+
+        assert (
+            manager._index_tools(
+                "srv",
+                [
+                    {"name": "bad", "inputSchema": "not-a-dict"},
+                    {"name": "kept", "inputSchema": {}},
+                ],
+            )
+            == 1
+        )
+        assert "srv::kept" in manager._tools
+
     # ---- D6: the suppression counter's `finally` ------------------------
 
     @pytest.mark.asyncio

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -27,6 +27,7 @@ from pmcp.client.manager import (
     _extract_tags,
     _infer_risk_hint,
     _remote_headers,
+    _required_identity,
     _terminate_process_tree,
     _truncate_description,
 )
@@ -5288,3 +5289,299 @@ class TestReconcileMalformedEntryResilience:
 
         assert manager._catalog_suppressed == {}
         assert not manager._catalog_publishing_suppressed("srv")
+
+
+class TestUnreadableListingIsNotAnEmptyOne:
+    """FANOUT repair G1/G2: the two remaining routes by which "we could not read
+    this" became "it is gone".
+
+    `TestReconcileMalformedEntryResilience` covers the listing that *arrived*
+    and could not be parsed. These cover the two steps on either side of it: a
+    reply whose required collection never arrived readably at all (G1), and an
+    entry that arrived carrying no identity (G2). Both used to be laundered into
+    a valid-looking answer by a defaulting `.get` -- `result.get(kind, [])` and
+    `entry.get(identity, "")` -- and published as a removal.
+    """
+
+    _managed = staticmethod(TestReconcileMalformedEntryResilience._managed)
+    _drain = staticmethod(TestReconcileMalformedEntryResilience._drain)
+
+    @staticmethod
+    def _wire_raw(manager: ClientManager, replies: dict[str, Any]) -> None:
+        """Stub `_send_request` with whole `result` objects, not per-kind entry
+        lists.
+
+        `TestReconcileMalformedEntryResilience._wire_listings` always wraps what
+        it is given as `{kind: list(entries)}`, so it can express a malformed
+        *entry* but never a malformed *reply* -- the absent collection and the
+        non-list collection under test here are both unreachable through it.
+        """
+
+        async def fake_send(
+            managed: ManagedClient,
+            method: str,
+            params: dict[str, Any],
+            *args: Any,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            kind = method.split("/")[0]
+            return cast(dict[str, Any], replies.get(kind, {kind: []}))
+
+        manager._send_request = fake_send  # type: ignore[method-assign]
+
+    async def _prime_and_relist(
+        self, kind: str, primed: list[dict[str, Any]], relisted: Any
+    ) -> tuple[ClientManager, _RecordingSink, int]:
+        """Index a real catalog for `kind`, then re-list it with `relisted`.
+
+        `primed` is a well-formed entry list and is wrapped for you; `relisted`
+        is the whole `result` object, unwrapped, because the malformed replies
+        under test are exactly the ones that cannot be expressed as an entry
+        list.
+
+        Priming over a *populated* catalog is the whole point: every one of
+        these defects is invisible against an empty one, because there is
+        nothing there to falsely remove.
+        """
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        notification = f"notifications/{kind}/list_changed"
+
+        self._wire_raw(manager, {kind: {kind: primed}})
+        manager._handle_downstream_notification("srv", managed, notification)
+        await self._drain(manager)
+        published_while_priming = cast(int, getattr(sink, kind))
+
+        self._wire_raw(manager, {kind: relisted})
+        manager._handle_downstream_notification("srv", managed, notification)
+        await self._drain(manager)
+        return manager, sink, published_while_priming
+
+    # ---- G1: an absent collection is not an explicit empty one ----------
+
+    @pytest.mark.asyncio
+    async def test_absent_tools_collection_preserves_and_publishes_nothing(
+        self,
+    ) -> None:
+        """`result: {}` -- the reply is missing the collection the protocol
+        requires. `result.get("tools", [])` turned that into `[]`, which the
+        classifier read as "the server answered and it is empty", so the prior
+        tools were cleared and a removal published. Two different meanings,
+        one outcome.
+        """
+        manager, sink, primed_publishes = await self._prime_and_relist(
+            "tools", [{"name": "alpha", "inputSchema": {}}], {}
+        )
+
+        assert set(manager._tools) == {"srv::alpha"}, (
+            "a reply missing its required `tools` field was read as an empty "
+            "catalog and wiped the prior tools"
+        )
+        assert sink.tools == primed_publishes, (
+            "published a removal for a reply we could not read"
+        )
+
+    @pytest.mark.asyncio
+    async def test_explicitly_empty_tools_collection_still_clears_and_publishes(
+        self,
+    ) -> None:
+        """The other side of the same line, restated here rather than left to
+        `test_explicitly_empty_relist_still_clears_and_publishes`: this pins the
+        *distinction*, so a fix that preserved both would fail here even though
+        the G1 test above would pass.
+        """
+        manager, sink, primed_publishes = await self._prime_and_relist(
+            "tools", [{"name": "alpha", "inputSchema": {}}], {"tools": []}
+        )
+
+        assert manager._tools == {}
+        assert sink.tools == primed_publishes + 1
+
+    @pytest.mark.asyncio
+    async def test_absent_collection_preserves_resources_and_prompts_too(
+        self,
+    ) -> None:
+        """The same `.get(kind, [])` served all three kinds; resources and
+        prompts reached it by a different line and must be fixed by the same
+        rule."""
+        resources, _, _ = await self._prime_and_relist(
+            "resources", [{"uri": "mem://r1"}], {}
+        )
+        prompts, _, _ = await self._prime_and_relist("prompts", [{"name": "p1"}], {})
+
+        assert set(resources._resources) == {"srv::mem://r1"}
+        assert set(prompts._prompts) == {"srv::p1"}
+
+    # ---- G3: a non-list where a list is expected ------------------------
+
+    @pytest.mark.asyncio
+    async def test_tools_collection_as_an_empty_mapping_preserves(self) -> None:
+        """The fifth trigger. `list({})` is `[]`, so an object where the
+        protocol requires an array was coerced into a perfectly valid-looking
+        "the kind is empty" answer -- and cleared and published exactly like
+        G1, one step further along.
+        """
+        manager, sink, primed_publishes = await self._prime_and_relist(
+            "tools", [{"name": "alpha", "inputSchema": {}}], {"tools": {}}
+        )
+
+        assert set(manager._tools) == {"srv::alpha"}
+        assert sink.tools == primed_publishes
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "collection",
+        [
+            pytest.param({"a": 1}, id="non-empty-mapping"),
+            pytest.param("abc", id="string"),
+            pytest.param(7, id="number"),
+        ],
+    )
+    async def test_tools_collection_as_other_non_lists_preserves(
+        self, collection: Any
+    ) -> None:
+        """These were preserved before the fix too, but only by accident: `list()`
+        coerced them into entries (a mapping's keys, a string's characters)
+        which then all happened to fail parsing, so the all-malformed rule
+        caught them. `7` did not even get that far -- it raised `TypeError`.
+        Pin the outcome so it stops depending on that chain.
+        """
+        manager, sink, primed_publishes = await self._prime_and_relist(
+            "tools", [{"name": "alpha", "inputSchema": {}}], {"tools": collection}
+        )
+
+        assert set(manager._tools) == {"srv::alpha"}
+        assert sink.tools == primed_publishes
+
+    @pytest.mark.asyncio
+    async def test_a_null_collection_costs_only_its_own_kind(self) -> None:
+        """`{"tools": null}` used to raise `TypeError` out of
+        `_fetch_server_listings` -- before resources and prompts were ever
+        classified -- so one malformed kind aborted the whole reconcile and an
+        honest resources answer arriving in the same pass was thrown away.
+        Per kind, still.
+        """
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+
+        self._wire_raw(
+            manager,
+            {
+                "tools": {"tools": [{"name": "alpha", "inputSchema": {}}]},
+                "resources": {"resources": [{"uri": "mem://old"}]},
+            },
+        )
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        assert set(manager._tools) == {"srv::alpha"}
+
+        self._wire_raw(
+            manager,
+            {
+                "tools": {"tools": None},
+                "resources": {"resources": [{"uri": "mem://new"}]},
+            },
+        )
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+
+        assert set(manager._tools) == {"srv::alpha"}
+        assert set(manager._resources) == {"srv::mem://new"}, (
+            "an unreadable tools listing swallowed an honest resources answer"
+        )
+
+    # ---- G2: an entry with no identity is not an entry -------------------
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("kind", "primed", "store_attr", "primed_id"),
+        [
+            pytest.param(
+                "resources", [{"uri": "mem://r1"}], "_resources", "srv::mem://r1"
+            ),
+            pytest.param("prompts", [{"name": "p1"}], "_prompts", "srv::p1"),
+        ],
+    )
+    async def test_empty_entry_objects_do_not_invent_an_identity(
+        self, kind: str, primed: list[dict[str, Any]], store_attr: str, primed_id: str
+    ) -> None:
+        """`resource.get("uri", "")` and `prompt.get("name", "")` made `{}`
+        parse successfully as an entry whose identity is `srv::`. It then
+        replaced the real entry and the change was published -- a catalog entry
+        the downstream never offered and the MCP models would reject.
+
+        With the identity required, `{}` fails to parse, which routes it into
+        the per-entry skip and -- since nothing else parsed -- into the
+        all-malformed preserve-prior rule.
+        """
+        manager, sink, primed_publishes = await self._prime_and_relist(
+            kind, primed, {kind: [{}]}
+        )
+
+        store = cast(dict[str, Any], getattr(manager, store_attr))
+        assert set(store) == {primed_id}
+        assert f"srv::{''}" not in store, "synthesized a bogus `srv::` identity"
+        assert getattr(sink, kind) == primed_publishes
+
+    @pytest.mark.asyncio
+    async def test_an_empty_string_tool_name_is_not_an_identity_either(self) -> None:
+        """Tools reached the same place by a different route. `tool["name"]`
+        does not default, so a *missing* name already raised -- but a name of
+        `""` sailed through and indexed as `srv::`, replacing the real tool.
+        Requiring a non-empty string closes both at once.
+        """
+        manager, sink, primed_publishes = await self._prime_and_relist(
+            "tools",
+            [{"name": "alpha", "inputSchema": {}}],
+            {"tools": [{"name": "", "inputSchema": {}}]},
+        )
+
+        assert set(manager._tools) == {"srv::alpha"}
+        assert sink.tools == primed_publishes
+
+    @pytest.mark.asyncio
+    async def test_an_identity_less_entry_costs_only_itself(self) -> None:
+        """The per-entry semantics are unchanged by the stricter identity: an
+        entry with none is skipped, and a good entry beside it is still indexed
+        and published. Without this, "fail to parse" could be over-applied into
+        a rule that preserves whenever *any* entry is bad.
+        """
+        manager, sink, primed_publishes = await self._prime_and_relist(
+            "resources",
+            [{"uri": "mem://r1"}],
+            {"resources": [{}, {"uri": "mem://r2"}]},
+        )
+
+        assert set(manager._resources) == {"srv::mem://r2"}
+        assert sink.resources == primed_publishes + 1
+
+    @pytest.mark.asyncio
+    async def test_entries_that_are_not_objects_are_skipped_not_indexed(self) -> None:
+        """A listing of bare strings. Each entry fails to parse rather than
+        raising out of the parser, and with none of them parseable the kind is
+        preserved."""
+        manager, sink, primed_publishes = await self._prime_and_relist(
+            "tools", [{"name": "alpha", "inputSchema": {}}], {"tools": ["a string", 3]}
+        )
+
+        assert set(manager._tools) == {"srv::alpha"}
+        assert sink.tools == primed_publishes
+
+    def test_required_identity_rejects_every_non_identity(self) -> None:
+        """The helper directly, so the rule is pinned independently of the three
+        parsers that call it."""
+        assert _required_identity({"name": "ok"}, "name") == "ok"
+        for entry in ({}, {"name": ""}, {"name": None}, {"name": 3}, {"name": ["a"]}):
+            with pytest.raises((TypeError, ValueError)):
+                _required_identity(entry, "name")
+        for entry in ("a string", 3, None, ["a"]):
+            with pytest.raises(TypeError):
+                _required_identity(entry, "name")

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -4964,3 +4964,205 @@ class TestDownstreamNotificationBehaviouralGuarantees:
         assert err.code == -32000
         assert err.data == {"retry_after_ms": 500}
         assert str(err) == "downstream unavailable"
+
+
+class TestReconcileMalformedEntryResilience:
+    """FANOUT repair D5/D6: a malformed downstream entry must cost only itself,
+    and the suppression counter must always unwind.
+
+    Before FANOUT a downstream could not trigger a re-index mid-session, so a
+    malformed entry could at worst fail a connect. Now `list_changed` re-enters
+    the indexers at any time, and the apply block removes before it re-indexes
+    -- so an entry that raises mid-apply takes the server's *previous* catalog
+    with it, permanently, with a healthy read loop and no reconnect to heal it.
+    """
+
+    @staticmethod
+    def _managed(name: str) -> ManagedClient:
+        status = ServerStatus(name=name, status=ServerStatusEnum.ONLINE, tool_count=0)
+        managed = ManagedClient(config=MagicMock(), process=MagicMock(), status=status)
+        managed.config.name = name
+        return managed
+
+    @staticmethod
+    async def _drain(manager: ClientManager, timeout: float = 5.0) -> None:
+        async def _wait() -> None:
+            while manager._reconcile_tasks:
+                await asyncio.sleep(0.005)
+
+        await asyncio.wait_for(_wait(), timeout)
+
+    @staticmethod
+    def _wire_listings(
+        manager: ClientManager, listings: dict[str, list[dict[str, Any]]]
+    ) -> None:
+        """Stub `_send_request` with raw per-kind payloads, malformed entries
+        included -- `TestDownstreamReconcileScheduler._wire` only ever emits
+        well-formed ones, which is precisely what this class must not do."""
+
+        async def fake_send(
+            managed: ManagedClient,
+            method: str,
+            params: dict[str, Any],
+            *args: Any,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            kind = method.split("/")[0]
+            return {kind: list(listings.get(kind, []))}
+
+        manager._send_request = fake_send  # type: ignore[method-assign]
+
+    # ---- D5: per-entry resilience ---------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_malformed_tool_is_skipped_without_losing_the_prior_catalog(
+        self,
+    ) -> None:
+        """One unparseable tool must not cost the other tools, and must never
+        cost the tools that were already indexed.
+
+        The malformed entry is deliberately *first*: with it last, the entries
+        ahead of it would already have been re-added before the raise and the
+        wipe would be invisible. First, it raises with the removal done and
+        nothing re-added -- the lead's reproduction, `after: []`.
+        """
+        manager = ClientManager()
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        self._wire_listings(manager, {"tools": [{"name": "alpha", "inputSchema": {}}]})
+
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        assert set(manager._tools) == {"srv::alpha"}
+
+        # `inputSchema` as a string reaches `_schema_dialect`, which calls
+        # `.get` on it -- an AttributeError raised mid-apply.
+        self._wire_listings(
+            manager,
+            {
+                "tools": [
+                    {"name": "bad", "inputSchema": "not-a-dict"},
+                    {"name": "alpha", "inputSchema": {}},
+                    {"name": "beta", "inputSchema": {}},
+                ]
+            },
+        )
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+
+        assert set(manager._tools) == {"srv::alpha", "srv::beta"}, (
+            "one malformed entry wiped the server's catalog"
+        )
+
+    @pytest.mark.asyncio
+    async def test_malformed_resource_and_prompt_entries_are_skipped(self) -> None:
+        """The same guarantee for the other two kinds, whose indexers construct
+        pydantic models just as directly."""
+        manager = ClientManager()
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        self._wire_listings(
+            manager,
+            {
+                "resources": [
+                    {"uri": ["not", "a", "string"]},
+                    {"uri": "mem://good"},
+                ],
+                "prompts": [
+                    {"name": "bad", "arguments": ["not-a-mapping"]},
+                    {"name": "good"},
+                ],
+            },
+        )
+
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/resources/list_changed"
+        )
+        await self._drain(manager)
+
+        assert set(manager._resources) == {"srv::mem://good"}
+        assert set(manager._prompts) == {"srv::good"}
+
+    def test_index_tools_guard_is_per_entry_not_per_call(self) -> None:
+        """Called directly, not through reconciliation: a single `try` wrapped
+        around the whole loop would still lose every entry *after* the bad one,
+        so pin that entries on both sides of it survive."""
+        manager = ClientManager()
+
+        indexed = manager._index_tools(
+            "srv",
+            [
+                {"name": "before", "inputSchema": {}},
+                {"name": "bad", "inputSchema": "not-a-dict"},
+                {"name": "after", "inputSchema": {}},
+            ],
+        )
+
+        assert indexed == 2
+        assert set(manager._tools) == {"srv::before", "srv::after"}
+
+    def test_index_of_only_malformed_entries_publishes_nothing(self) -> None:
+        """Nothing was indexed, so there is nothing to announce -- a note here
+        would wake every subscriber for a catalog that did not move."""
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+
+        assert manager._index_tools("srv", [{"name": "b", "inputSchema": "x"}]) == 0
+        assert manager._index_resources("srv", [{"uri": ["nope"]}]) == 0
+        assert (
+            manager._index_prompts("srv", [{"name": "b", "arguments": ["nope"]}]) == 0
+        )
+        assert (sink.tools, sink.resources, sink.prompts) == (0, 0, 0)
+        assert manager._tools == {} and manager._resources == {}
+        assert manager._prompts == {}
+
+    # ---- D6: the suppression counter's `finally` ------------------------
+
+    @pytest.mark.asyncio
+    async def test_suppression_counter_unwinds_on_the_success_path(self) -> None:
+        """A leaked entry would leave that server's sink suppressed forever:
+        subscribed clients silently stop seeing its catalog changes, with no
+        error anywhere to point at."""
+        manager = ClientManager()
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        self._wire_listings(manager, {"tools": [{"name": "alpha", "inputSchema": {}}]})
+
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+
+        assert manager._tools, "reconcile did not run; the assertion below is vacuous"
+        assert manager._catalog_suppressed == {}
+        assert not manager._catalog_publishing_suppressed("srv")
+
+    @pytest.mark.asyncio
+    async def test_suppression_counter_unwinds_when_the_apply_block_raises(
+        self,
+    ) -> None:
+        """The failure must be injected *inside* the apply block. A failed fetch
+        returns before the counter is ever incremented, so it would leave this
+        test green even with the decrement deleted.
+        """
+        manager = ClientManager()
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        self._wire_listings(manager, {"tools": [{"name": "alpha", "inputSchema": {}}]})
+
+        def boom(*args: Any, **kwargs: Any) -> None:
+            raise RuntimeError("apply blew up after the counter went up")
+
+        manager._remove_server_indexes = boom  # type: ignore[method-assign]
+
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+
+        assert manager._catalog_suppressed == {}
+        assert not manager._catalog_publishing_suppressed("srv")

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -4284,6 +4284,211 @@ class TestDownstreamReconcileScheduler:
         assert spins <= 6, f"reconcile loop is spinning: {spins} passes in 0.6s"
         assert spins >= 1
 
+    # ---- SL-fix: fetch-first atomicity, per-kind isolation, content ------
+
+    @pytest.mark.asyncio
+    async def test_reconcile_never_hides_a_live_tool_from_a_concurrent_read(
+        self,
+    ) -> None:
+        """A `gateway.invoke` arriving mid-reconcile must still resolve a tool the
+        downstream still has.
+
+        Reconciliation is a spawned background task, so an ordinary production
+        interleaving puts a lookup between its awaits. A remove-then-refetch
+        order leaves the catalog *empty* for that server across three downstream
+        round trips, and a concurrent invoke gets a spurious tool-not-found for a
+        tool that exists. The poller below stands in for that traffic: it reads
+        the catalog on every event-loop tick for the whole pass, so any await
+        inside the mutation window gives it a chance to observe the hole.
+        """
+        manager = ClientManager()
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        gate = asyncio.Event()
+        state: dict[str, list[str]] = {
+            "tools": ["alpha"],
+            "resources": ["r1"],
+            "prompts": ["p1"],
+        }
+        self._wire(manager, state, gate)
+
+        # Prime the catalog as connect-time indexing would, ungated.
+        gate.set()
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        assert "srv::alpha" in manager._tools
+        gate.clear()
+
+        misses = 0
+        stop = asyncio.Event()
+
+        async def poll() -> None:
+            nonlocal misses
+            while not stop.is_set():
+                if "srv::alpha" not in manager._tools:
+                    misses += 1
+                await asyncio.sleep(0)
+
+        poller = asyncio.create_task(poll())
+        state["tools"] = ["alpha", "beta"]
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        # Let the reconcile reach its gated downstream request, with the poller
+        # reading the catalog on every tick while it sits there.
+        for _ in range(20):
+            await asyncio.sleep(0)
+        gate.set()
+        await self._drain(manager)
+        stop.set()
+        await poller
+
+        assert "srv::beta" in manager._tools, "the reconcile did not land"
+        assert misses == 0, (
+            f"a concurrent read saw srv::alpha missing {misses} times during "
+            "reconciliation -- the catalog must never be emptied across an await"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reconcile_leaves_a_kind_whose_listing_failed_untouched(self) -> None:
+        """`resources/list` failing while `tools/list` succeeds must not publish a
+        removal of resources the server still has.
+
+        `_index_capabilities` swallows resources/prompts listing failures on
+        purpose -- a server that does not implement them is normal -- so those
+        failures never reach the reconcile's abort path. Removing all three kinds
+        up front therefore turns "we could not ask" into "they are gone", and
+        publishes that false removal. Each kind has to be handled independently:
+        a kind whose listing failed is left exactly as it was and is not
+        published, while a kind that succeeded still reconciles normally.
+        """
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        state: dict[str, list[str]] = {
+            "tools": ["alpha"],
+            "resources": ["r1"],
+            "prompts": ["p1"],
+        }
+        self._wire(manager, state)
+
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        before_resources = dict(manager._resources)
+        before_prompts = dict(manager._prompts)
+        assert before_resources and before_prompts
+        sink.tools = sink.resources = sink.prompts = 0
+
+        healthy_send = manager._send_request
+
+        async def resources_down(
+            managed_arg: ManagedClient,
+            method: str,
+            params: dict[str, Any],
+            *args: Any,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            if method == "resources/list":
+                raise ConnectionError("resources/list is down")
+            return await healthy_send(managed_arg, method, params, *args, **kwargs)
+
+        manager._send_request = resources_down  # type: ignore[method-assign]
+        state["tools"] = ["alpha", "beta"]
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+
+        assert manager._resources == before_resources, (
+            "a kind whose listing failed was dropped from the catalog"
+        )
+        assert sink.resources == 0, (
+            "a false resources removal was published for a listing that failed"
+        )
+        # The kinds that did answer still reconciled.
+        assert "srv::beta" in manager._tools
+        assert sink.tools == 1
+        assert manager._prompts == before_prompts
+        assert sink.prompts == 0
+
+    @pytest.mark.asyncio
+    async def test_reconcile_publishes_a_content_change_under_a_stable_name(
+        self,
+    ) -> None:
+        """A tool whose description or schema changed under the same name is a real
+        catalog change and must publish.
+
+        Comparing identifier *sets* catches adds, removes, and renames and misses
+        this entirely -- yet it is the common case for a server that re-lists
+        after editing a tool in place. The comparison has to be over the entries
+        themselves.
+        """
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        entry: dict[str, Any] = {
+            "name": "alpha",
+            "description": "first",
+            "inputSchema": {"type": "object", "properties": {}},
+        }
+
+        async def one_tool(
+            managed_arg: ManagedClient,
+            method: str,
+            params: dict[str, Any],
+            *args: Any,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            if method == "tools/list":
+                return {"tools": [dict(entry)]}
+            return {}
+
+        manager._send_request = one_tool  # type: ignore[method-assign]
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        assert set(manager._tools) == {"srv::alpha"}
+        sink.tools = sink.resources = sink.prompts = 0
+
+        # Same name, new description: the identifier set is unchanged.
+        entry["description"] = "second"
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        assert manager._tools["srv::alpha"].description == "second"
+        assert sink.tools == 1, (
+            "a changed description under an unchanged tool name published nothing"
+        )
+
+        # Same name, same description, new input schema.
+        entry["inputSchema"] = {
+            "type": "object",
+            "properties": {"q": {"type": "string"}},
+        }
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        assert manager._tools["srv::alpha"].input_schema == entry["inputSchema"]
+        assert sink.tools == 2, (
+            "a changed input schema under an unchanged tool name published nothing"
+        )
+
+        # A re-list with nothing changed still publishes nothing.
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        assert sink.tools == 2
+
     # ---- SL-1.6: both dispatch paths, and typed errors ------------------
 
     @pytest.mark.asyncio

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -3798,3 +3798,114 @@ class TestReadStdoutFailureSurfacing:
         assert status.status == ServerStatusEnum.ERROR
         assert status.last_error is not None
         assert "pipe gone" in status.last_error
+
+
+class _RecordingSink:
+    """Counts `CatalogEventSink` publishes so a test can assert on the exact
+    number, not merely that something fired."""
+
+    def __init__(self) -> None:
+        self.tools = 0
+        self.resources = 0
+        self.prompts = 0
+
+    def note_tools_changed(self) -> None:
+        self.tools += 1
+
+    def note_resources_changed(self) -> None:
+        self.resources += 1
+
+    def note_prompts_changed(self) -> None:
+        self.prompts += 1
+
+    async def flush(self) -> None:
+        pass
+
+
+class TestDownstreamReconcileScheduler:
+    """FANOUT SL-1: the downstream-notification contract (IF-0-FANOUT-1) and the
+    coalesced reconcile scheduler behind it.
+
+    Owned by lane SL-1 inside a file lane SL-3 owns; kept to this one class, and
+    deliberately avoiding the `-k` patterns SL-3.2 claims (`unchanged_catalog`,
+    `unknown_notification`, `typed_downstream_error`).
+    """
+
+    @staticmethod
+    def _managed(name: str) -> ManagedClient:
+        status = ServerStatus(name=name, status=ServerStatusEnum.ONLINE, tool_count=0)
+        managed = ManagedClient(config=MagicMock(), process=MagicMock(), status=status)
+        managed.config.name = name
+        return managed
+
+    # ---- SL-1.1: IF-0-FANOUT-1 shape ------------------------------------
+
+    def test_reconcile_contract_entry_point_has_frozen_signature(self) -> None:
+        """IF-0-FANOUT-1's entry point exists, is synchronous (both dispatch paths
+        call it, and the stdio one is not a coroutine), and takes the frozen
+        `(name, managed, method)` parameters."""
+        import inspect
+
+        handler = ClientManager._handle_downstream_notification
+        assert not inspect.iscoroutinefunction(handler), (
+            "must be sync: _handle_stdout_line is a plain def"
+        )
+        assert list(inspect.signature(handler).parameters) == [
+            "self",
+            "name",
+            "managed",
+            "method",
+        ]
+
+    def test_reconcile_contract_docstring_states_the_four_guarantees(self) -> None:
+        """The freeze is the docstring as much as the signature: SL-3 writes tests
+        against this text on day 1."""
+        import inspect
+
+        doc = inspect.getdoc(ClientManager._handle_downstream_notification) or ""
+        for fragment in (
+            "notifications/tools/list_changed",
+            "notifications/resources/list_changed",
+            "notifications/prompts/list_changed",
+        ):
+            assert fragment in doc, f"method mapping missing {fragment!r}"
+        lowered = doc.lower()
+        assert "reconcile" in lowered and "publish" in lowered
+        assert "no-op" in lowered or "no op" in lowered
+
+    @pytest.mark.asyncio
+    async def test_reconcile_contract_unrecognised_method_is_a_silent_noop(
+        self,
+    ) -> None:
+        """An unrecognised `notifications/*` neither raises, nor publishes, nor
+        schedules anything — it returns False. A raise here would tear down the
+        SSE read loop through its blanket `except Exception`."""
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+
+        assert (
+            manager._handle_downstream_notification(
+                "srv", managed, "notifications/message"
+            )
+            is False
+        )
+        assert (sink.tools, sink.resources, sink.prompts) == (0, 0, 0)
+        assert not manager._background_tasks
+
+    @pytest.mark.asyncio
+    async def test_reconcile_contract_recognised_methods_are_accepted(self) -> None:
+        """Each of the three `list_changed` methods is recognised and returns True."""
+        for method in (
+            "notifications/tools/list_changed",
+            "notifications/resources/list_changed",
+            "notifications/prompts/list_changed",
+        ):
+            manager = ClientManager()
+            managed = self._managed("srv")
+            manager._clients["srv"] = managed
+            assert (
+                manager._handle_downstream_notification("srv", managed, method) is True
+            ), method
+            await manager._cancel_background_tasks()

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -4410,3 +4410,352 @@ class TestDownstreamReconcileScheduler:
         assert err.code == -32000
         assert err.data == ["a", "b"]
         assert str(err) == "boom"
+
+
+class TestDownstreamNotificationBehaviouralGuarantees:
+    """FANOUT SL-3.2: storm suppression, the resources/prompts kinds, the
+    unrecognised-method no-op, and typed downstream errors on both dispatch
+    paths.
+
+    Test names here are chosen to match the `-k` patterns the roadmap's
+    acceptance criteria pin (EC-FANOUT-4, EC-FANOUT-5, EC-FANOUT-7).
+    `TestDownstreamReconcileScheduler` above (SL-1's own tests) deliberately
+    avoids those substrings so this lane could claim them without renaming
+    anything -- see that class's docstring. This class duplicates the small
+    `_managed`/`_wire`/`_drain` helpers rather than reaching into that
+    class's internals, so neither lane's tests depend on the other's shape.
+    """
+
+    @staticmethod
+    def _managed(name: str) -> ManagedClient:
+        status = ServerStatus(name=name, status=ServerStatusEnum.ONLINE, tool_count=0)
+        managed = ManagedClient(config=MagicMock(), process=MagicMock(), status=status)
+        managed.config.name = name
+        return managed
+
+    @staticmethod
+    async def _drain(manager: ClientManager, timeout: float = 5.0) -> None:
+        """Wait until no reconcile is in flight."""
+
+        async def _wait() -> None:
+            while manager._reconcile_tasks:
+                await asyncio.sleep(0.005)
+
+        await asyncio.wait_for(_wait(), timeout)
+
+    def _wire(self, manager: ClientManager, state: dict[str, list[str]]) -> list[str]:
+        """Same shape as `TestDownstreamReconcileScheduler._wire`, without the
+        gating hook that class's deadlock test needs -- none of this class's
+        tests need to pause a reconcile mid-flight."""
+        calls: list[str] = []
+
+        async def fake_send(
+            managed: ManagedClient,
+            method: str,
+            params: dict[str, Any],
+            *args: Any,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            calls.append(method)
+            if method == "tools/list":
+                return {
+                    "tools": [
+                        {"name": n, "inputSchema": {}} for n in state.get("tools", [])
+                    ]
+                }
+            if method == "resources/list":
+                return {
+                    "resources": [
+                        {"uri": f"mem://{n}"} for n in state.get("resources", [])
+                    ]
+                }
+            if method == "prompts/list":
+                return {"prompts": [{"name": n} for n in state.get("prompts", [])]}
+            return {}
+
+        manager._send_request = fake_send  # type: ignore[method-assign]
+        return calls
+
+    # ---- EC-FANOUT-4: storm suppression -----------------------------------
+
+    @pytest.mark.asyncio
+    async def test_unchanged_catalog_publishes_nothing_across_a_notification_storm(
+        self,
+    ) -> None:
+        """A downstream that emits `list_changed` repeatedly with nothing
+        actually different in its catalog must publish exactly zero events,
+        even though `_remove_server_indexes`/`_index_*` call `note_*`
+        unconditionally on every pass -- the suppress-while-churning rule is
+        what stands between this and a spam storm reaching subscribers."""
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        self._wire(
+            manager, {"tools": ["alpha"], "resources": ["r1"], "prompts": ["p1"]}
+        )
+
+        # Prime the catalog, as connect-time indexing would.
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/tools/list_changed"
+        )
+        await self._drain(manager)
+        sink.tools = sink.resources = sink.prompts = 0
+
+        # A burst of ten notifications, the catalog never actually moving.
+        for _ in range(10):
+            manager._handle_downstream_notification(
+                "srv", managed, "notifications/tools/list_changed"
+            )
+        await self._drain(manager)
+
+        assert (sink.tools, sink.resources, sink.prompts) == (0, 0, 0)
+        assert set(manager._tools) == {"srv::alpha"}
+
+    # ---- EC-FANOUT-5: resources/prompts kinds and the unknown no-op -------
+
+    @pytest.mark.asyncio
+    async def test_resources_list_changed_reconciles_and_publishes_only_resources(
+        self,
+    ) -> None:
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        state: dict[str, list[str]] = {
+            "tools": ["alpha"],
+            "resources": ["r1"],
+            "prompts": ["p1"],
+        }
+        self._wire(manager, state)
+
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/resources/list_changed"
+        )
+        await self._drain(manager)
+        sink.tools = sink.resources = sink.prompts = 0
+
+        state["resources"] = ["r1", "r2"]
+        assert (
+            manager._handle_downstream_notification(
+                "srv", managed, "notifications/resources/list_changed"
+            )
+            is True
+        )
+        await self._drain(manager)
+
+        assert "srv::mem://r2" in manager._resources
+        assert (sink.tools, sink.resources, sink.prompts) == (0, 1, 0)
+
+    @pytest.mark.asyncio
+    async def test_prompts_list_changed_reconciles_and_publishes_only_prompts(
+        self,
+    ) -> None:
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        state: dict[str, list[str]] = {
+            "tools": ["alpha"],
+            "resources": ["r1"],
+            "prompts": ["p1"],
+        }
+        self._wire(manager, state)
+
+        manager._handle_downstream_notification(
+            "srv", managed, "notifications/prompts/list_changed"
+        )
+        await self._drain(manager)
+        sink.tools = sink.resources = sink.prompts = 0
+
+        state["prompts"] = ["p1", "p2"]
+        assert (
+            manager._handle_downstream_notification(
+                "srv", managed, "notifications/prompts/list_changed"
+            )
+            is True
+        )
+        await self._drain(manager)
+
+        assert "srv::p2" in manager._prompts
+        assert (sink.tools, sink.resources, sink.prompts) == (0, 0, 1)
+
+    @pytest.mark.asyncio
+    async def test_unknown_notification_is_a_noop_on_stdio_dispatch_and_does_not_kill_the_read_loop(
+        self,
+    ) -> None:
+        """An unrecognised `notifications/*` on the stdio path must not raise,
+        must not schedule a reconcile, and must not stop the next line -- a
+        real request/response pair -- from being processed normally right
+        after it."""
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+
+        unknown_line = json.dumps(
+            {"jsonrpc": "2.0", "method": "notifications/message"}
+        ).encode()
+        manager._handle_stdout_line("srv", managed, unknown_line, time.time())
+
+        assert not manager._reconcile_tasks
+        assert (sink.tools, sink.resources, sink.prompts) == (0, 0, 0)
+
+        # The read loop must still be alive to process a normal response.
+        fut: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+        now = time.time()
+        managed.pending_requests[42] = PendingRequest(
+            request_id=42,
+            server_name="srv",
+            tool_id="srv::alpha",
+            started_at=now,
+            last_heartbeat=now,
+            timeout_ms=30000,
+            future=fut,
+        )
+        response_line = json.dumps(
+            {"jsonrpc": "2.0", "id": 42, "result": {"ok": True}}
+        ).encode()
+        manager._handle_stdout_line("srv", managed, response_line, time.time())
+
+        assert fut.done()
+        assert fut.result() == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_unknown_notification_is_a_noop_on_sse_dispatch_and_does_not_kill_the_read_loop(
+        self,
+    ) -> None:
+        """The same, through `_read_sse`: that loop's blanket `except
+        Exception` would tear the connection down and force a reconnect if
+        the handler ever raised on an unrecognised method. This proves it
+        doesn't, by letting a real response frame flow right after it, in the
+        same stream, and resolve normally."""
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        managed.is_remote = True
+        manager._clients["srv"] = managed
+        manager._schedule_reconnect = MagicMock()  # type: ignore[method-assign]
+
+        fut: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+        now = time.time()
+        managed.pending_requests[43] = PendingRequest(
+            request_id=43,
+            server_name="srv",
+            tool_id="srv::alpha",
+            started_at=now,
+            last_heartbeat=now,
+            timeout_ms=30000,
+            future=fut,
+        )
+
+        def _frame(payload: dict[str, Any]) -> Any:
+            frame = MagicMock()
+            frame.message.model_dump.return_value = payload
+            return frame
+
+        async def stream() -> Any:
+            yield _frame({"jsonrpc": "2.0", "method": "notifications/message"})
+            yield _frame({"jsonrpc": "2.0", "id": 43, "result": {"ok": True}})
+
+        await manager._read_sse("srv", managed, stream())
+
+        assert not manager._reconcile_tasks
+        assert (sink.tools, sink.resources, sink.prompts) == (0, 0, 0)
+        assert fut.done()
+        assert fut.result() == {"ok": True}
+
+    # ---- EC-FANOUT-7: typed downstream errors, both dispatch paths --------
+
+    @pytest.mark.asyncio
+    async def test_typed_downstream_error_preserves_code_and_data_on_stdio_dispatch(
+        self,
+    ) -> None:
+        """`code`/`data` survive alongside `message`, and `str()` stays
+        exactly the downstream message -- `gateway.invoke` maps every
+        exception to E302 through `str(e)`, so nothing about that mapping
+        may change here."""
+        from pmcp.client.manager import DownstreamError
+
+        manager = ClientManager()
+        managed = self._managed("srv")
+        fut: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+        now = time.time()
+        managed.pending_requests[11] = PendingRequest(
+            request_id=11,
+            server_name="srv",
+            tool_id="srv::alpha",
+            started_at=now,
+            last_heartbeat=now,
+            timeout_ms=30000,
+            future=fut,
+        )
+        line = json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": 11,
+                "error": {
+                    "code": -32601,
+                    "message": "Method not found",
+                    "data": {"method": "tools/frobnicate"},
+                },
+            }
+        ).encode()
+
+        manager._handle_stdout_line("srv", managed, line, time.time())
+
+        err = fut.exception()
+        assert isinstance(err, DownstreamError)
+        assert err.code == -32601
+        assert err.data == {"method": "tools/frobnicate"}
+        assert str(err) == "Method not found"
+
+    @pytest.mark.asyncio
+    async def test_typed_downstream_error_preserves_code_and_data_on_sse_dispatch(
+        self,
+    ) -> None:
+        """The same guarantee, through the remote dispatch path."""
+        from pmcp.client.manager import DownstreamError
+
+        manager = ClientManager()
+        managed = self._managed("srv")
+        managed.is_remote = True
+        manager._clients["srv"] = managed
+        manager._schedule_reconnect = MagicMock()  # type: ignore[method-assign]
+        fut: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+        now = time.time()
+        managed.pending_requests[12] = PendingRequest(
+            request_id=12,
+            server_name="srv",
+            tool_id="srv::alpha",
+            started_at=now,
+            last_heartbeat=now,
+            timeout_ms=30000,
+            future=fut,
+        )
+
+        def _frame(payload: dict[str, Any]) -> Any:
+            frame = MagicMock()
+            frame.message.model_dump.return_value = payload
+            return frame
+
+        async def stream() -> Any:
+            yield _frame(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 12,
+                    "error": {
+                        "code": -32000,
+                        "message": "downstream unavailable",
+                        "data": {"retry_after_ms": 500},
+                    },
+                }
+            )
+
+        await manager._read_sse("srv", managed, stream())
+
+        err = fut.exception()
+        assert isinstance(err, DownstreamError)
+        assert err.code == -32000
+        assert err.data == {"retry_after_ms": 500}
+        assert str(err) == "downstream unavailable"


### PR DESCRIPTION
Executes **FANOUT**, phase 3 of `specs/phase-plans-v12.md`, per `plans/phase-plan-v12-FANOUT.md`. Closes v11's explicitly deferred item. **Draft — SL-2 and SL-3 still to land.**

## The problem

`subscriptions/listen` publishes the *gateway's own* catalog changes. It did **not** proxy a *downstream server's* `notifications/*` upward, so a downstream server adding a tool at runtime was invisible to subscribed clients.

Those notifications were reaching the gateway and being **dropped**: a JSON-RPC notification has no `id`, so it failed the `msg_id is not None and msg_id in managed.pending_requests` gate and fell through with no `else` branch — in **both** dispatch paths.

## Why this is reconciliation, not forwarding

The catalog is index-backed: `gateway.invoke` resolves via `get_tool` → `self._tools`, populated only by `_index_tools`. Forwarding a notification straight to the sink would tell a client "refetch" and hand it the **old** catalog, with a removed tool still invocable. The panel caught that at roadmap review.

So: a downstream `list_changed` schedules a per-server **re-index**, and the existing index mutators publish for free. Reconcile first, publish second.

## Three hazards, each verified before implementation

**Self-deadlock — immediate, not occasional.** `_index_capabilities` awaits `_send_request`, whose futures are resolved by the very read loop that received the notification (`set_result` at `:1791` / `:2010`). Reconciling inline makes the loop await a future only it can resolve. Reconciliation is `asyncio.create_task`, never awaited from dispatch, coalesced to one in-flight pass per server with a re-run flag.

**Storm on an unchanged catalog.** The `note_*` calls in `_index_*` and `_remove_server_indexes` are **unconditional**, so a naive remove-then-reindex publishes on *every* notification. The sink is suppressed during reconciliation via a depth counter, and the catalog compared before/after by **identifier sets** per kind — comparing counts would miss a rename.

**Two dispatch paths, not one.** `_handle_stdout_line` (stdio) and the SSE loop both wired. Both `TODO(post-P3B)` markers replaced so JSON-RPC `error` `code`/`data` survive to the `ClientManager` boundary.

Also handles a plan edge case: a downstream that announces a change then fails `tools/list` **rolls back** rather than leaving the catalog half-removed.

## An honest disclosure from the lane

SL-1 flagged that its rollback writes are a catalog mutation the existing publisher-coverage AST guard doesn't model — it doesn't see `dict.update`. I verified that: the guard exists, passes here, and genuinely has that blind spot. The lane correctly declined to widen a file it doesn't own. Worth a follow-up.

## Plan gap, recorded

SL-1's owned files were `manager.py` only, but it needed somewhere for its RED tests. I authorized `tests/test_client_manager.py` in the dispatch brief and it stayed contained to two clearly-named additions so SL-3 can work alongside. That is a gap in the plan's owned-files split, not lane drift — the docs lane will amend the roadmap.

## Verification so far

- `pytest -q` → **2604 passed, 3 skipped, 0 failed** (baseline 2585)
- `ruff check .`, `ruff format --check src/ tests/`, `mypy src` — clean
- Parent-tree leakage check clean; no file deletions

## Still to come

**SL-2** — two-transport emitter harness, including a new stdio fake server (today's harness is HTTP-only, so the stdio path has no emitter).
**SL-3** — behavioural tests asserting the *catalog* changed, on both transports.
**SL-docs** — CHANGELOG and roadmap amendments.

I will panel this before calling the phase done.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790102139&installation_model_id=427051&pr_number=172&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F172&signature=e33ef1972dde33841eaf1f5ac8d106e922be793986c89865a07e5d0d159562cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->