### PR TITLE
fix: follow nextCursor when listing a downstream catalog (#173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   truncated view.
 
   Connect and refresh share this path, so they read complete listings too.
+  One consequence worth stating plainly: a server whose `tools/list` fails on a
+  *later* page now connects successfully with an empty tools catalog, where
+  before pagination existed there was no later page to fail. Only a page-one
+  failure is still a connect error. That matches how connect already treats a
+  first page whose every entry is unparseable, but such a server sits at zero
+  tools until a downstream notification or a refresh reconciles it.
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Catalog listings are now read to the end.** `tools/list`, `resources/list`
+  and `prompts/list` were sent once with no cursor and whatever came back was
+  taken as the whole catalog, so a downstream with more entries than its page
+  size had the rest silently missing. That truncation predated downstream
+  fan-out, but once reconciliation began publishing `list_changed` it started
+  asserting the catalog was current over a partial view — and re-applying the
+  truncation on every downstream notification rather than once at connect.
+  `nextCursor` (and the `next_cursor` spelling) is now followed to the end.
+
+  A failure on **any** page makes the whole kind unreadable rather than
+  partial: prior entries are kept and nothing is published. Merging the pages
+  that did arrive would drop entries the server still has and announce the drop
+  — the same false-removal shape this module has been corrected for repeatedly.
+  Following the cursor is bounded, and a server that repeats a cursor or never
+  stops paginating is treated as unreadable rather than looping or indexing a
+  truncated view.
+
+  Connect and refresh share this path, so they read complete listings too.
+
+
 ### Added
 - **A downstream server's own `notifications/tools/list_changed`,
   `notifications/resources/list_changed`, and `notifications/prompts/list_changed`

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -95,12 +95,19 @@ _RECONCILE_RERUN_DEBOUNCE_S = 0.25
 # forever, and reconciliation runs on every downstream notification, so the
 # loop is reachable by a misbehaving peer rather than only at connect.
 #
-# Sized against the thing that consumes the result: `max_tools_per_server`
-# defaults to 100, and the MCP page size servers actually use is tens of
-# entries, so 50 pages clears any honest catalog by a wide margin while still
-# bounding a server that never stops paginating. Exceeding it makes the kind
-# UNREADABLE, not partial -- indexing a truncated view is what #173 was about.
-_MAX_LISTING_PAGES = 50
+# Exceeding it makes the kind UNREADABLE, not partial -- indexing a truncated
+# view is what #173 was about, so the bound must not resolve to "keep what we
+# got".
+#
+# That cuts both ways, which is why this is 500 and not the 50 first written
+# here (ah board review). Failing closed on an HONEST server is its own defect:
+# page size is the server's choice and 1 is legal, so a catalog of 100 tools --
+# `max_tools_per_server`'s own default -- can legitimately need 100 round trips,
+# and a 50-page cap would report that server as having no tools at all. The cap
+# is a runaway guard, not a catalog-size limit; 500 sequential round trips for
+# one kind is already pathological by any honest reading, while leaving real
+# small-page servers well inside it.
+_MAX_LISTING_PAGES = 500
 
 
 class DownstreamError(Exception):

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -90,6 +90,18 @@ DOWNSTREAM_LIST_CHANGED_METHODS: dict[str, str] = {
 # the single pending re-run.
 _RECONCILE_RERUN_DEBOUNCE_S = 0.25
 
+# Ceiling on `nextCursor` follows for one catalog kind (Consiliency/pmcp#173).
+# A downstream that always returns a cursor would otherwise spin the fetch
+# forever, and reconciliation runs on every downstream notification, so the
+# loop is reachable by a misbehaving peer rather than only at connect.
+#
+# Sized against the thing that consumes the result: `max_tools_per_server`
+# defaults to 100, and the MCP page size servers actually use is tens of
+# entries, so 50 pages clears any honest catalog by a wide margin while still
+# bounding a server that never stops paginating. Exceeding it makes the kind
+# UNREADABLE, not partial -- indexing a truncated view is what #173 was about.
+_MAX_LISTING_PAGES = 50
+
 
 class DownstreamError(Exception):
     """A JSON-RPC `error` object returned by a downstream MCP server.
@@ -1675,17 +1687,15 @@ class ClientManager:
         """
         name = managed.config.name
 
-        tools_result = await self._send_request(managed, "tools/list", {})
+        tools_entries = await self._fetch_listing_pages(managed, "tools")
 
-        resources_task = self._send_request(managed, "resources/list", {})
-        prompts_task = self._send_request(managed, "prompts/list", {})
+        resources_task = self._fetch_listing_pages(managed, "resources")
+        prompts_task = self._fetch_listing_pages(managed, "prompts")
         listing_results = await asyncio.gather(
             resources_task, prompts_task, return_exceptions=True
         )
 
-        listings: dict[str, list[dict[str, Any]] | None] = {
-            "tools": _listing_entries(name, "tools", tools_result)
-        }
+        listings: dict[str, list[dict[str, Any]] | None] = {"tools": tools_entries}
         for kind, result in (
             ("resources", listing_results[0]),
             ("prompts", listing_results[1]),
@@ -1694,8 +1704,79 @@ class ClientManager:
                 logger.debug(f"Server {name} doesn't support {kind}: {result}")
                 listings[kind] = None
             else:
-                listings[kind] = _listing_entries(name, kind, result)
+                listings[kind] = result
         return listings
+
+    async def _fetch_listing_pages(
+        self, managed: ManagedClient, kind: str
+    ) -> list[dict[str, Any]] | None:
+        """Follow `nextCursor` for one kind, or `None` if any page is unreadable.
+
+        The listing path used to send `{}` once and keep whatever came back, so
+        a downstream with more entries than its page size had everything past
+        page one silently missing -- and, once reconciliation started publishing,
+        announced as removed (Consiliency/pmcp#173). The truncation predated
+        that; what made it urgent is asserting freshness over a partial view.
+
+        A failure on page N makes the WHOLE kind unreadable rather than partial.
+        Merging the pages that did arrive is exactly the false-removal shape this
+        module has now been corrected for four times: entries the server still
+        has would be dropped and the drop published. `None` means "we could not
+        read the answer", and the caller already handles that by keeping the
+        prior entries and publishing nothing.
+
+        `tools/list` failing on page one still raises, preserving the contract
+        that a server which cannot list its tools is a connect-time error while
+        a server without resources or prompts is ordinary.
+        """
+        collected: list[dict[str, Any]] = []
+        seen_cursors: set[str] = set()
+        cursor: str | None = None
+
+        for page in range(_MAX_LISTING_PAGES):
+            params: dict[str, Any] = {"cursor": cursor} if cursor else {}
+            result = await self._send_request(managed, f"{kind}/list", params)
+
+            entries = _listing_entries(managed.config.name, kind, result)
+            if entries is None:
+                # _listing_entries already logged why. One bad page discards the
+                # whole kind on purpose -- see the docstring.
+                if page > 0:
+                    logger.warning(
+                        f"[{managed.config.name}] {kind}/list page {page + 1} was "
+                        f"unreadable; discarding {len(collected)} entries already "
+                        f"collected rather than publishing a partial listing"
+                    )
+                return None
+            collected.extend(entries)
+
+            if not isinstance(
+                result, dict
+            ):  # pragma: no cover - _listing_entries guards
+                return None
+            raw_cursor = result.get("nextCursor") or result.get("next_cursor")
+            if not raw_cursor:
+                return collected
+            if not isinstance(raw_cursor, str):
+                logger.warning(
+                    f"[{managed.config.name}] {kind}/list returned a non-string "
+                    f"cursor ({type(raw_cursor).__name__}); treating as unreadable"
+                )
+                return None
+            if raw_cursor in seen_cursors:
+                logger.warning(
+                    f"[{managed.config.name}] {kind}/list repeated cursor "
+                    f"{raw_cursor!r}; treating as unreadable rather than looping"
+                )
+                return None
+            seen_cursors.add(raw_cursor)
+            cursor = raw_cursor
+
+        logger.warning(
+            f"[{managed.config.name}] {kind}/list exceeded {_MAX_LISTING_PAGES} "
+            f"pages; treating as unreadable rather than indexing a truncated view"
+        )
+        return None
 
     async def _index_capabilities(self, managed: ManagedClient) -> tuple[int, int, int]:
         name = managed.config.name

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -1687,18 +1687,30 @@ class ClientManager:
         """
         name = managed.config.name
 
-        tools_entries = await self._fetch_listing_pages(managed, "tools")
-
-        resources_task = self._fetch_listing_pages(managed, "resources")
-        prompts_task = self._fetch_listing_pages(managed, "prompts")
+        # All three gathered together, tools included. Awaiting tools to
+        # completion first would let a failure on its page TWO escape and cost
+        # resources and prompts their reconcile entirely -- a healthy resources
+        # change would sit unapplied because an unrelated kind paginated badly
+        # (ah board review). Only a page-ONE tools failure is a connect-time
+        # error, and that is re-raised below; a later page is just this kind
+        # being unreadable, like any other.
         listing_results = await asyncio.gather(
-            resources_task, prompts_task, return_exceptions=True
+            self._fetch_listing_pages(managed, "tools"),
+            self._fetch_listing_pages(managed, "resources"),
+            self._fetch_listing_pages(managed, "prompts"),
+            return_exceptions=True,
         )
 
-        listings: dict[str, list[dict[str, Any]] | None] = {"tools": tools_entries}
+        tools_result = listing_results[0]
+        if isinstance(tools_result, BaseException):
+            # Preserves the contract that a server which cannot list its tools
+            # is a connect-time error, while one without resources or prompts
+            # is ordinary. `_fetch_listing_pages` only lets page one raise.
+            raise tools_result
+        listings: dict[str, list[dict[str, Any]] | None] = {"tools": tools_result}
         for kind, result in (
-            ("resources", listing_results[0]),
-            ("prompts", listing_results[1]),
+            ("resources", listing_results[1]),
+            ("prompts", listing_results[2]),
         ):
             if isinstance(result, BaseException):
                 logger.debug(f"Server {name} doesn't support {kind}: {result}")
@@ -1735,7 +1747,26 @@ class ClientManager:
 
         for page in range(_MAX_LISTING_PAGES):
             params: dict[str, Any] = {"cursor": cursor} if cursor else {}
-            result = await self._send_request(managed, f"{kind}/list", params)
+            if page == 0:
+                # Page one propagates: whether a server can list a kind at all
+                # is the caller's decision to make, and for tools it is a
+                # connect-time error.
+                result = await self._send_request(managed, f"{kind}/list", params)
+            else:
+                # A later page failing says nothing about whether the kind is
+                # supported -- only that we could not finish reading it. Raising
+                # here would cost the OTHER two kinds their reconcile, since all
+                # three are gathered together.
+                try:
+                    result = await self._send_request(managed, f"{kind}/list", params)
+                except Exception as exc:
+                    logger.warning(
+                        f"[{managed.config.name}] {kind}/list page {page + 1} "
+                        f"failed ({exc}); discarding {len(collected)} entries "
+                        f"already collected rather than publishing a partial "
+                        f"listing"
+                    )
+                    return None
 
             entries = _listing_entries(managed.config.name, kind, result)
             if entries is None:
@@ -1754,13 +1785,25 @@ class ClientManager:
                 result, dict
             ):  # pragma: no cover - _listing_entries guards
                 return None
-            raw_cursor = result.get("nextCursor") or result.get("next_cursor")
-            if not raw_cursor:
+            # Presence by KEY, not truthiness. `nextCursor: 0` and `""` are
+            # falsey, so `x or y` / `if not cursor` read them as "no more pages"
+            # and hand back page one as the whole catalog -- the exact
+            # truncation this method exists to stop -- while also slipping past
+            # the non-string rejection below (ah board review).
+            if "nextCursor" in result:
+                raw_cursor = result["nextCursor"]
+            elif "next_cursor" in result:
+                raw_cursor = result["next_cursor"]
+            else:
                 return collected
-            if not isinstance(raw_cursor, str):
+            if raw_cursor is None:
+                # An explicit null is the protocol's way of saying "no more".
+                return collected
+            if not isinstance(raw_cursor, str) or not raw_cursor:
                 logger.warning(
-                    f"[{managed.config.name}] {kind}/list returned a non-string "
-                    f"cursor ({type(raw_cursor).__name__}); treating as unreadable"
+                    f"[{managed.config.name}] {kind}/list returned an unusable "
+                    f"cursor ({raw_cursor!r}); treating as unreadable rather "
+                    f"than as the end of the listing"
                 )
                 return None
             if raw_cursor in seen_cursors:

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -5431,6 +5431,35 @@ class TestListingPagination:
         assert sink.tools == primed
 
     @pytest.mark.asyncio
+    async def test_a_deep_but_honest_catalog_assembles_completely(self) -> None:
+        """A catalog many pages deep, still inside the cap, must assemble.
+
+        Board review found the gap this closes: every other test here is two
+        pages deep, so a mutant shrinking `_MAX_LISTING_PAGES` to 2 passed the
+        entire suite. Nothing pinned that the cap is a runaway guard rather
+        than a catalog-size limit.
+
+        The failure direction is a freeze, not a false removal -- an honest
+        server would be reported as having no tools at all, which is the same
+        in-class defect that made the original cap of 50 wrong for a legal
+        page size of 1.
+        """
+        depth = 10
+        pages: list[Any] = [
+            {
+                "tools": [self._tool(f"t{i}")],
+                **({"nextCursor": f"p{i + 1}"} if i < depth - 1 else {}),
+            }
+            for i in range(depth)
+        ]
+        manager, sink, primed = await self._prime_then(pages)
+        assert sorted(manager._tools) == sorted(f"srv::t{i}" for i in range(depth)), (
+            "a deep but honest catalog was not assembled; the page cap is "
+            "acting as a catalog-size limit rather than a runaway guard"
+        )
+        assert sink.tools == primed + 1
+
+    @pytest.mark.asyncio
     async def test_exceeding_the_page_cap_is_unreadable_not_truncated(self) -> None:
         """The cap must preserve, not index the pages it managed to read.
 

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -19,6 +19,7 @@ import httpx2
 import pytest
 
 from pmcp.client.manager import (
+    _MAX_LISTING_PAGES,
     ClientManager,
     DEFAULT_SCHEMA_DIALECT,
     ManagedClient,
@@ -5289,6 +5290,161 @@ class TestReconcileMalformedEntryResilience:
 
         assert manager._catalog_suppressed == {}
         assert not manager._catalog_publishing_suppressed("srv")
+
+
+class TestListingPagination:
+    """Consiliency/pmcp#173: `nextCursor` was never followed.
+
+    The listing path sent `{}` once and kept page one, so a downstream with
+    more entries than its page size had the rest silently missing -- and, once
+    reconciliation began publishing, announced as removed. The truncation
+    predated fan-out; asserting freshness over a partial view is what made it
+    worth fixing.
+
+    The rule these pin: a failure on ANY page makes the WHOLE kind unreadable,
+    never partial. Merging the pages that did arrive is the same false-removal
+    shape corrected four times over in this module -- entries the server still
+    has, dropped and the drop published.
+    """
+
+    _managed = staticmethod(TestReconcileMalformedEntryResilience._managed)
+    _drain = staticmethod(TestReconcileMalformedEntryResilience._drain)
+
+    @staticmethod
+    def _wire_pages(manager: ClientManager, pages: list[Any]) -> None:
+        """Serve `tools/list` from `pages`, indexed by cursor.
+
+        Cursor `pN` selects `pages[N]`; the first request carries none and gets
+        `pages[0]`. An element that is an exception is raised instead of
+        returned, which is how a mid-pagination transport failure is expressed.
+        """
+
+        async def fake_send(
+            managed: ManagedClient,
+            method: str,
+            params: dict[str, Any],
+            *args: Any,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            if method != "tools/list":
+                return {method.split("/")[0]: []}
+            cursor = params.get("cursor")
+            index = 0 if cursor is None else int(str(cursor)[1:])
+            page = pages[index]
+            if isinstance(page, BaseException):
+                raise page
+            return cast(dict[str, Any], page)
+
+        manager._send_request = fake_send  # type: ignore[method-assign]
+
+    async def _prime_then(
+        self, pages: list[Any]
+    ) -> tuple[ClientManager, _RecordingSink, int]:
+        """Index one seed tool, then re-list `tools` from `pages`.
+
+        Priming over a populated catalog is what makes a false removal visible;
+        against an empty one there is nothing to lose.
+        """
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        note = "notifications/tools/list_changed"
+
+        self._wire_pages(manager, [{"tools": [{"name": "seed", "inputSchema": {}}]}])
+        manager._handle_downstream_notification("srv", managed, note)
+        await self._drain(manager)
+        primed = sink.tools
+
+        self._wire_pages(manager, pages)
+        manager._handle_downstream_notification("srv", managed, note)
+        await self._drain(manager)
+        return manager, sink, primed
+
+    @staticmethod
+    def _tool(name: str) -> dict[str, Any]:
+        return {"name": name, "inputSchema": {}}
+
+    @pytest.mark.asyncio
+    async def test_multi_page_listing_is_assembled_completely(self) -> None:
+        """RED before the fix: page one was treated as the whole catalog."""
+        manager, sink, primed = await self._prime_then(
+            [
+                {"tools": [self._tool("a"), self._tool("b")], "nextCursor": "p1"},
+                {"tools": [self._tool("c")]},
+            ]
+        )
+        assert sorted(manager._tools) == ["srv::a", "srv::b", "srv::c"], (
+            "entries past page one were dropped; the cursor was not followed"
+        )
+        assert sink.tools == primed + 1
+
+    @pytest.mark.asyncio
+    async def test_snake_case_next_cursor_is_honoured(self) -> None:
+        """`list_tasks` accepts both spellings; the listing path must too."""
+        manager, _, _ = await self._prime_then(
+            [
+                {"tools": [self._tool("a")], "next_cursor": "p1"},
+                {"tools": [self._tool("b")]},
+            ]
+        )
+        assert sorted(manager._tools) == ["srv::a", "srv::b"]
+
+    @pytest.mark.asyncio
+    async def test_a_failed_later_page_preserves_the_prior_catalog(self) -> None:
+        """A transport failure on page two must not publish a partial listing."""
+        manager, sink, primed = await self._prime_then(
+            [
+                {"tools": [self._tool("a")], "nextCursor": "p1"},
+                RuntimeError("page two never arrived"),
+            ]
+        )
+        assert sorted(manager._tools) == ["srv::seed"], (
+            "a partially-read listing replaced the catalog"
+        )
+        assert sink.tools == primed, "a partial listing was published as a change"
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_later_page_preserves_the_prior_catalog(self) -> None:
+        """Same rule when page two arrives but is malformed rather than absent."""
+        manager, sink, primed = await self._prime_then(
+            [{"tools": [self._tool("a")], "nextCursor": "p1"}, {}]
+        )
+        assert sorted(manager._tools) == ["srv::seed"]
+        assert sink.tools == primed
+
+    @pytest.mark.asyncio
+    async def test_a_repeated_cursor_terminates_and_is_unreadable(self) -> None:
+        """A server handing back its own cursor must not spin the fetch forever."""
+        manager, sink, primed = await self._prime_then(
+            [{"tools": [self._tool("a")], "nextCursor": "p0"}]
+        )
+        assert sorted(manager._tools) == ["srv::seed"]
+        assert sink.tools == primed
+
+    @pytest.mark.asyncio
+    async def test_exceeding_the_page_cap_is_unreadable_not_truncated(self) -> None:
+        """The cap must preserve, not index the pages it managed to read.
+
+        Indexing a truncated view is precisely what Consiliency/pmcp#173 is
+        about, so the bound cannot resolve to "keep what we got".
+        """
+        pages: list[Any] = [
+            {"tools": [self._tool(f"t{i}")], "nextCursor": f"p{i + 1}"}
+            for i in range(_MAX_LISTING_PAGES + 2)
+        ]
+        manager, sink, primed = await self._prime_then(pages)
+        assert sorted(manager._tools) == ["srv::seed"]
+        assert sink.tools == primed
+
+    @pytest.mark.asyncio
+    async def test_a_single_page_listing_still_clears_when_explicitly_empty(
+        self,
+    ) -> None:
+        """The pagination loop must not weaken the empty-is-an-answer rule."""
+        manager, sink, primed = await self._prime_then([{"tools": []}])
+        assert manager._tools == {}
+        assert sink.tools == primed + 1
 
 
 class TestUnreadableListingIsNotAnEmptyOne:

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -4001,10 +4001,18 @@ class TestDownstreamReconcileScheduler:
         # Give the spawned task room to start and block on the gate.
         for _ in range(10):
             await asyncio.sleep(0)
-        assert calls == ["tools/list"], "reconcile did not start"
+        assert "tools/list" in calls, "reconcile did not start"
         assert "srv::alpha" not in manager._tools, (
             "reconcile completed inline; it must not have, the gate is still shut"
         )
+        # This used to assert `calls == ["tools/list"]`, which encoded the old
+        # sequencing -- tools was awaited to completion before resources and
+        # prompts were even started. Consiliency/pmcp#174 gathers all three
+        # together so a failure on a later tools page cannot starve the other
+        # two kinds, so all three requests are now in flight here. The property
+        # under test is unchanged and still proven by the two assertions above:
+        # the handler returned while the gate is shut, and nothing was indexed.
+        assert set(calls) <= {"tools/list", "resources/list", "prompts/list"}
 
         gate.set()
         await self._drain(manager)
@@ -5436,6 +5444,106 @@ class TestListingPagination:
         manager, sink, primed = await self._prime_then(pages)
         assert sorted(manager._tools) == ["srv::seed"]
         assert sink.tools == primed
+
+    @pytest.mark.parametrize("cursor", [0, "", False])
+    @pytest.mark.asyncio
+    async def test_a_falsey_cursor_is_unusable_not_the_end(self, cursor: Any) -> None:
+        """A falsey cursor must not read as "no more pages".
+
+        Board review of this PR: detecting absence with `x or y` / `if not
+        cursor` meant `nextCursor: 0` and `nextCursor: ""` were taken as the end
+        of the listing, so page one was published as the whole catalog -- the
+        exact truncation Consiliency/pmcp#173 is about -- and they also slipped
+        past the non-string rejection. Presence is now decided by KEY.
+        """
+        manager, sink, primed = await self._prime_then(
+            [
+                {"tools": [self._tool("a")], "nextCursor": cursor},
+                {"tools": [self._tool("b")]},
+            ]
+        )
+        assert sorted(manager._tools) == ["srv::seed"], (
+            "a falsey cursor was treated as the end of the listing"
+        )
+        assert sink.tools == primed
+
+    @pytest.mark.asyncio
+    async def test_an_explicit_null_cursor_ends_the_listing(self) -> None:
+        """`nextCursor: null` is the protocol saying "no more" -- not a defect.
+
+        The pin that keeps the falsey-cursor fix from over-reaching into
+        treating a well-formed final page as unreadable.
+        """
+        manager, sink, primed = await self._prime_then(
+            [{"tools": [self._tool("a")], "nextCursor": None}]
+        )
+        assert sorted(manager._tools) == ["srv::a"]
+        assert sink.tools == primed + 1
+
+    @pytest.mark.asyncio
+    async def test_a_later_tools_page_failure_does_not_starve_other_kinds(
+        self,
+    ) -> None:
+        """A tools page-two failure must not cost resources and prompts.
+
+        Board review: tools was awaited to completion before the other two were
+        started, so a later-page exception escaped and neither of them was ever
+        requested -- a healthy resources change sat unapplied because an
+        unrelated kind paginated badly. Only a page-ONE tools failure is a
+        connect-time error.
+        """
+        sink = _RecordingSink()
+        manager = ClientManager(catalog_events=cast(Any, sink))
+        managed = self._managed("srv")
+        manager._clients["srv"] = managed
+        called: list[str] = []
+
+        async def fake_send(
+            _managed: ManagedClient,
+            method: str,
+            params: dict[str, Any],
+            *args: Any,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            kind = method.split("/")[0]
+            called.append(kind)
+            if kind == "tools":
+                if params.get("cursor") is None:
+                    return {"tools": [self._tool("a")], "nextCursor": "p1"}
+                raise RuntimeError("tools page two never arrived")
+            if kind == "resources":
+                return {"resources": [{"uri": "mem://r1", "name": "r1"}]}
+            return {"prompts": []}
+
+        manager._send_request = fake_send  # type: ignore[method-assign]
+        listings = await manager._fetch_server_listings(managed)
+
+        assert listings["tools"] is None, "a partial tools listing was kept"
+        assert listings["resources"] == [{"uri": "mem://r1", "name": "r1"}], (
+            "resources were never fetched because tools paginated badly"
+        )
+        assert {"tools", "resources", "prompts"} <= set(called)
+
+    @pytest.mark.asyncio
+    async def test_a_page_one_tools_failure_still_raises(self) -> None:
+        """The connect-time contract survives gathering all three kinds."""
+        manager = ClientManager(catalog_events=cast(Any, _RecordingSink()))
+        managed = self._managed("srv")
+
+        async def fake_send(
+            _managed: ManagedClient,
+            method: str,
+            params: dict[str, Any],
+            *args: Any,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            if method == "tools/list":
+                raise RuntimeError("this server cannot list tools")
+            return {method.split("/")[0]: []}
+
+        manager._send_request = fake_send  # type: ignore[method-assign]
+        with pytest.raises(RuntimeError, match="cannot list tools"):
+            await manager._fetch_server_listings(managed)
 
     @pytest.mark.asyncio
     async def test_a_single_page_listing_still_clears_when_explicitly_empty(


### PR DESCRIPTION
Closes Consiliency/pmcp#173.

Found independently by **two seats** of the pre-merge advisor board on Consiliency/pmcp#172 — the correctness and red-team lenses. Neither fixed it, both for the same reason: it needed a semantics decision rather than a repair.

## The defect

`tools/list`, `resources/list` and `prompts/list` were sent once with `params={}`, and whatever came back was taken as the entire catalog. There is no cursor handling anywhere on the listing path — the only cursor machinery in `manager.py` is on the tasks path.

Reproduced with a downstream holding 3 tools at page size 2:

```
downstream really has: a, b, c   (nextCursor = "p2")
gateway catalog:       ['srv::a', 'srv::b']    ← c invisible, page 2 never requested
```

**The truncation predates fan-out.** `main` sends `{}` too, at connect and at refresh. What made it worth fixing now is that reconciliation publishes `list_changed` *asserting the catalog is current* over a possibly-partial view, and re-applies the truncation on every downstream notification rather than once at connect.

## The semantics decision

**A failure on any page makes the whole kind unreadable, not partial** — prior entries kept, nothing published. Merging the pages that did arrive would drop entries the server still has and announce the drop: the same false-removal shape corrected four times during Consiliency/pmcp#172's review.

"Failure" reuses `_listing_entries` per page, so a page that isn't an object, is missing its collection, or carries a non-list collection is unreadable on exactly the same terms as page one.

**The tempting minimal fix was rejected** in the issue: treating any reply carrying `nextCursor` as a failed listing closes the false assertion but freezes a paginating server's catalog permanently, since every one of its pages carries a cursor.

## Bounds

`_MAX_LISTING_PAGES = 50`, sized against `max_tools_per_server`'s default of 100 and the tens-of-entries page sizes servers actually use. A repeated or self-referential cursor, a non-string cursor, and exceeding the cap all resolve to **unreadable** rather than to a truncated index — indexing a truncated view is the defect, so the bound must not resolve to "keep what we got".

Connect and refresh share `_fetch_server_listings`, so they read complete listings now too.

## Verification

- `pytest -q` → **2662 passed, 3 skipped, 0 failed** (baseline 2655)
- ruff, format, mypy clean; `test_publisher_coverage.py` passes untouched
- **6 of the 7 new tests are RED** against single-page behaviour. The seventh is the explicitly-empty-still-clears pin — a regression guard rather than a defect, correctly passing both ways.

Every invariant from the prior rounds re-verified: absent collection preserves; explicit `[]` clears and publishes; all-unparseable preserves; one-bad-one-good indexes the good one; dict/`null`/non-object shapes preserve.

## Not in scope

The five adjacent pre-existing findings recorded in Consiliency/pmcp#173's body — the untested `max_tools_per_server` truncation boundary, `adopt_process` indexing without prior removal, the missing `ge=1` on that limit, `inputSchema` defaulting, and silent duplicate-identity collapse — are unrelated to pagination and stay open. I'll split them into their own issue so Consiliency/pmcp#173 closes cleanly on its actual subject.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790118848&installation_model_id=427051&pr_number=174&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F174&signature=55e7a2088a562fc7ca006ec2dba00df0e743bf7af5eeee28bd9dbfdbd90f45f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->