### PR TITLE
chore: v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-08-24
+
 ### Fixed
 - **Catalog listings are now read to the end.** `tools/list`, `resources/list`
   and `prompts/list` were sent once with no cursor and whatever came back was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   failure is still a connect error. That matches how connect already treats a
   first page whose every entry is unparseable, but such a server sits at zero
   tools until a downstream notification or a refresh reconciles it.
-
+- **A downstream server's JSON-RPC `error` object no longer loses its `code`
+  and `data`.** Both dispatch paths kept only `message`, discarding the rest
+  of the `error` member. `ClientManager` now raises a typed `DownstreamError`
+  carrying `code` and `data` alongside `message`. Scoped to the
+  `ClientManager` boundary — `gateway.invoke` still maps every exception to
+  `E302` through `str(e)`, which is byte-identical to the old message, so no
+  `gateway.*` output changes; surfacing `code`/`data` to MCP clients is
+  tracked separately.
 
 ### Added
 - **A downstream server's own `notifications/tools/list_changed`,
@@ -133,16 +140,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   HTTP/SSE (`_read_sse`) previously shared the same silent-drop, and both now
   dispatch through the same reconcile path. Unrecognised `notifications/*`
   methods (progress, logging) remain a no-op, as before.
-
-### Fixed
-- **A downstream server's JSON-RPC `error` object no longer loses its `code`
-  and `data`.** Both dispatch paths kept only `message`, discarding the rest
-  of the `error` member. `ClientManager` now raises a typed `DownstreamError`
-  carrying `code` and `data` alongside `message`. Scoped to the
-  `ClientManager` boundary — `gateway.invoke` still maps every exception to
-  `E302` through `str(e)`, which is byte-identical to the old message, so no
-  `gateway.*` output changes; surfacing `code`/`data` to MCP clients is
-  tracked separately.
 
 ### Changed
 - **`version_checker.compare_versions(current, latest, package_type)` is now the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "2.2.1"
+version = "2.3.0"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "2.2.1"
+__version__ = "2.3.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "2.2.1"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release cut for 2.3.0. Version bump only — no source behaviour changes in this PR.

Ships three pieces already merged to main and unreleased:

- **TRISTATE** (#170, closes #164) — `compare_versions` is now the sole version-classification path, returning `newer` / `not_newer` / `incomparable`. `is_version_newer` and `are_versions_comparable` are deleted, not deprecated, so the fail-closed collapse that shipped three times is unrepresentable rather than merely detectable.
- **FANOUT** (#172) — a downstream server's own `notifications/*/list_changed` now reaches subscribed clients, via reconcile-then-publish rather than raw forwarding.
- **Pagination** (#174, closes #173) — `tools/list` / `resources/list` / `prompts/list` follow `nextCursor` to the end. A downstream with more entries than its page size no longer has the rest silently missing.

`Added` + `Changed` entries make this a minor bump.

Files: `pyproject.toml`, `src/pmcp/__init__.py`, `uv.lock`, and the `CHANGELOG.md` version header dated 2026-08-24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbREMUsxgJ8TDBLpJ56PWb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790130140&installation_model_id=427051&pr_number=176&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F176&signature=cda1455992ea3050cc11f406da92edc5f8e511b28defef625b8fd4350f4a912e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->