### PR TITLE
chore: v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-08-25
+
 ### Fixed
 - **A cached description is now checked against the package that is actually
   configured, not just against its version.** All three refresh sites —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "2.3.0"
+version = "2.4.0"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "2.3.0"
+__version__ = "2.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "2.3.0"
+version = "2.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release cut for 2.4.0. Version bump only — no source behaviour changes in this PR.

Ships **v12 UPDPATH** (#179), already merged to main and unreleased. v12 is now complete: TRISTATE and FANOUT shipped in 2.3.0, UPDPATH ships here.

## What's in it

- **Description freshness is gated on package identity.** Cached descriptions were paired with a server config by *name* and freshness decided on *version* alone, at three sites — so swapping the configured package at an equal version served the wrong package's tool descriptions indefinitely. An unknown side means "cannot confirm identity", which resolves to **refresh**, never to "cannot compare, so skip the check".
- **Cached entries carry a `package_type`.** A bare name cannot tell npm `foo` from pypi `foo`, and both produce orderable release versions so `compare_versions` never reports them incomparable. A cache written before this release has no type, reads as unknown, and refreshes once. No cache-format bump.
- **`pmcp refresh --check-versions` honours `--cache-dir`** — it computed the path and then dropped it.
- **`--check-versions` splits its report.** A server whose package cannot be classified (`node /opt/srv.js`) is reported as *unconfirmable* rather than stale, and without the `--force` remedy that would never settle it.
- **The probe-window environment contract is documented and pinned**, both halves: a config-driven change (including a rotated manifest credential) is **refused**; a genuinely ambient variable is **live at spawn**.

Closes #165 and #162 as part of the phase.

## Why minor, not patch

Three user-visible behaviour changes: `--check-versions` output shape, `refresh_all` dropping an unclassifiable entry when regeneration fails, and a one-time refresh for pre-2.4 caches. All documented under `### Changed`.

## Known limitation, shipped knowingly

**#180** — `detect_package_type` collapses distinct packages for `registry:port/image` and `npm exec pkg` forms, so the identity gate can falsely confirm for those command shapes. Pre-existing; it only became consequential once package names were compared. The parser backs every version lookup in the codebase, so re-parsing it deserves its own plan rather than being appended to a release cut.

## Verification

The release-note extraction was dry-run with the workflow's own awk: 70 lines, two unique `###` headings, terminates cleanly before the 2.3.0 section — no duplicate-heading bleed.

Files: `pyproject.toml`, `src/pmcp/__init__.py`, `uv.lock`, and the `CHANGELOG.md` version header dated 2026-08-25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbREMUsxgJ8TDBLpJ56PWb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790238974&installation_model_id=427051&pr_number=181&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F181&signature=98831af0d82bc45f4bf00cc4017c34703d60f6a528878eabcfaf1ca256886c25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->