### PR TITLE
fix(parser): reconcile docker reference splitting and skip npm subcommands (narrows #180)

### DIFF
--- a/.consiliency/evidence/mutation-180.md
+++ b/.consiliency/evidence/mutation-180.md
@@ -1,0 +1,122 @@
+# Mutation evidence — Consiliency/pmcp#180
+
+Every proof runs **one test node alone** against the mutant, never the class.
+A class-level run reddens on any member, so it cannot show that the specific
+test is load-bearing — the hole through which two hollow tests shipped in this
+repo's last two phases (board finding, adversarial + red-team seats).
+
+## 1. docker branch reverted to `raw.split(":")[0]`
+
+    FAILED ...::TestPackageIdentityCollisions::test_docker_registry_host_port_distinguishes_images
+    1 failed in 0.08s
+
+## 2. npm subcommand skip disabled (`skip_subcommand = False`)
+
+    FAILED ...::TestPackageIdentityCollisions::test_npm_exec_distinguishes_packages
+    1 failed in 0.10s
+    FAILED ...::TestPackageIdentityCollisions::test_npm_x_alias_distinguishes_packages
+    1 failed in 0.07s
+
+## 3. skip fires repeatedly (docker-style anywhere-loop)
+
+    FAILED ...::TestNpmSubcommandSkipFiresOnce::test_npm_install_of_a_package_named_i
+    1 failed in 0.09s
+    FAILED ...::TestNpmSubcommandSkipFiresOnce::test_npm_exec_of_a_package_named_exec
+    1 failed in 0.09s
+
+## 4. digest NOT stripped first (the first draft's rule)
+
+    FAILED ...::TestDockerReferenceSplitting::test_name_and_tag_agree[img@sha256:abc-img-None]
+    FAILED ...::TestDockerReferenceSplitting::test_name_and_tag_agree[registry:5000/img@sha256:abc-registry:5000/img-None]
+    2 failed, 8 passed in 0.11s
+
+Note this mutant fails **only** the digest cases and leaves the other eight
+green — the parametrised ids name exactly which forms the ordering protects.
+
+## 5. pin-detection call site reverted to `_npm_package_arg(args, "npx")`
+
+    FAILED ...::TestUpdateServerVersionRepair::test_detect_effective_version_pin_matrix
+    1 failed, 185 deselected in 0.95s
+
+## 6. `_docker_image_tag` stops stripping the digest
+
+    FAILED ...::TestUpdateServerVersionRepair::test_detect_effective_version_pin_matrix
+    1 failed, 185 deselected in 1.02s
+
+Mutants 5 and 6 are what pin the two helpers as complements: each half of the
+pair has its own mutant, so they cannot drift apart silently.
+
+## 7. pin check ignores the digest (the regression this PR introduced and then fixed)
+
+Removing the `_docker_image_digest` consultation from
+`_detect_effective_version_pin`:
+
+    FAILED ...::TestUpdateServerVersionRepair::test_detect_effective_version_pin_matrix
+    1 failed, 185 deselected in 1.11s
+
+This mutant is the defect the red-team seat found in the first implementation.
+Stripping `@digest` before the tag scan was correct for the NAME, but reading
+the tag alone then reported a digest-only reference as unpinned -- so a
+digest-pinned server, the tightest pin docker has, read as unpinned and
+`update_server` would have pulled `image:latest`, restarted the unchanged
+config, and recorded the registry's newest digest as though it had updated.
+
+Before this PR the same reference produced the garbage pin `'abc'`, which was
+wrong but at least truthy, so the refusal still fired. The first draft of the
+fix turned a wrong-but-safe value into a right-looking-but-unsafe `None` --
+a reminder that "more correct in isolation" is not the same as "safe in
+composition".
+
+## 8. flag-skip and subcommand check swapped (adversarial seat's surviving mutant)
+
+    FAILED ...::TestNpmSubcommandSkipFiresOnce::test_a_leading_flag_does_not_consume_the_subcommand_skip
+    1 failed in 0.08s
+
+The code was already correct here -- `npm --silent exec old-pkg` resolved to
+`old-pkg`. What was missing was any test that PINNED the ordering: swapping the
+two checks passed all 317 tests, because every other npm test puts the
+subcommand first. The one-shot skip must fire on the first non-flag token, not
+the first argv token, or `--silent` consumes it and `exec` is read as the
+package.
+
+A surviving mutant, not a live defect -- and exactly the thing worth asking a
+board for, since a passing suite cannot distinguish "correct and pinned" from
+"correct by accident".
+
+## 9. pin call site hardcoded to "npm" (correctness seat's mutant B)
+
+    FAILED ...::TestUpdateServerVersionRepair::test_detect_effective_version_pin_matrix
+    1 failed, 185 deselected in 1.54s
+
+This mutant is the mirror of proof 5 (which hardcodes `"npx"`), and it
+survived until now because the guard written to catch it was **hollow**. That
+guard was `detect("npm","npx",["-y","exec@1.2"]) == "1.2"`, commented "npx
+still must not skip a package genuinely named exec" -- but the skip matches the
+RAW token against `_NPM_SUBCOMMANDS`, and `exec@1.2` is not in that set. So the
+mutant returns the identical `1.2` and the assertion passes under exactly the
+condition it claimed to forbid. Measured:
+
+    correct : npx -y exec@1.2     -> '1.2'
+    mutant  : npx -y exec@1.2     -> '1.2'    <- no divergence, guard useless
+    correct : npx -y exec pkg@1.2 -> None
+    mutant  : npx -y exec pkg@1.2 -> '1.2'    <- divergence
+
+The bare `exec` token is what discriminates. Fixed by adding
+`assert detect("npm","npx",["-y","exec","pkg@1.2"]) is None`.
+
+Worth stating plainly: this is the third hollow test in three phases, and the
+second one written by the agent that had just documented the failure mode. A
+hollow assertion is indistinguishable from a real one when read; only mutating
+the exact line it claims to pin tells them apart.
+
+## Tooling note: stale bytecode can fabricate BOTH false red and false green
+
+A pure-reorder mutant has identical byte size, and apply/compile/restore inside
+one second defeats `.pyc` invalidation (whole-second mtime + size). A full-suite
+run reported proof 8's test as FAILING against correct source; purging
+`src/**/__pycache__` and re-running gave 5 passed. The same mechanism can
+fabricate a false GREEN -- i.e. certify a mutant as killed when it was not.
+
+Every proof above was re-confirmed with `__pycache__` purged and
+`PYTHONDONTWRITEBYTECODE=1`. Any future mutation proof in this repo must do the
+same (correctness seat's incident disclosure).

--- a/.consiliency/plans/detailed-package-identity-parsing-20260825-0900.md
+++ b/.consiliency/plans/detailed-package-identity-parsing-20260825-0900.md
@@ -48,37 +48,89 @@ Two distinct root causes, and they are **not** the same bug:
    the tag-stripping is wrong. Confirmed still-correct forms that must not
    regress: `img:1.2` → `img`, `ghcr.io/org/img:v2` → `ghcr.io/org/img`,
    `mcp/server:latest` → `mcp/server`.
-2. **npm** — `_npm_package_arg` (`version_checker.py:~?`, search the symbol)
-   skips only `-y` and flags. It has **no subcommand skip at all**, so `exec`,
-   `run` etc. are taken as the package. This is an asymmetry with the docker
-   branch, which does skip its subcommands.
+2. **npm** — `_npm_package_arg` (`version_checker.py:57`) skips only `-y` and
+   flags. It has **no subcommand skip at all**, so `exec`, `run` etc. are taken
+   as the package. This is an asymmetry with the docker branch, which does skip
+   its subcommands.
 
 The third finding (`localhost:5000/a/b:tag`) is not in the issue text; it is the
 same docker root cause with a different registry host, and is included here.
 
-**Scope discipline.** `uvx --from thing other` → `("pypi", "thing")` is
-**correct** (`--from` names the package) and is out of scope. `pip`/`cargo`
-branches are not implicated. This plan touches the two branches with measured
-collisions and nothing else.
+**The correct docker rule already exists in this file.** `_docker_image_tag`
+(`version_checker.py:377`) splits the **last path segment** on its **first**
+colon, with a docstring that names this exact case: *"a registry host with a
+port (`registry:5000/img:1.2.3`) does not read as a tag of `5000`."* It is what
+`update_server`'s pin detection uses (`handlers.py:323`). So the docker fix is
+**not** a new rule — it is making `detect_package_type` use the rule the file
+already has, which is why this plan no longer introduces a second helper.
+
+**Scope correction (board finding, verified).** An earlier draft of this plan
+claimed the `pip`/`cargo` branches "are not implicated" and that `uvx` was fine.
+**That was false.** Every excluded branch collides, by the same root cause —
+value-carrying flags whose values are not skipped:
+
+```
+uvx   --python 3.12 pkg-a / pkg-b        -> both ('pypi', '3.12')
+uvx   --with requests srv-a / srv-b      -> both ('pypi', 'requests')
+pip   install --index-url URL pkg-a/b    -> both ('pypi', 'URL')
+cargo run --features full srv-a/b        -> both ('cargo', 'full')
+```
+
+`uvx --from thing other` → `thing` is correct only by luck: `--from`'s value
+*is* the package. That one safe flag is what made the branch look sound.
+Filed as **Consiliency/pmcp#182** rather than folded in — expanding this plan
+from two branches to five, with a new shared `_value_flags` design, would turn a
+bounded fix into a parser redesign and discard the review that scoping bought.
+`uvx` is arguably the *most* consequential case (common MCP launcher, `--with`
+is a normal pattern), so #182 should not sit long.
 
 ## Changes
 
 ### `src/pmcp/manifest/version_checker.py` (modify)
 
-- `_split_docker_reference` — **add** — new module-private helper returning
-  `(name, tag_or_none)` for an OCI reference, splitting on the last `:` **only
-  when it occurs after the last `/`**. Extracted rather than inlined so the rule
-  has one home and one test surface; the docker branch and any future caller
-  that wants the tag both read it from here.
+- `_docker_image_name` — **add** — module-private helper returning the image
+  **name** from an OCI reference, defined immediately beside the existing
+  `_docker_image_tag` (`version_checker.py:377`) as its paired inverse — the
+  same design as `_strip_npm_tag`/`_npm_tag` (`version_checker.py:25-54`). It
+  must be **the exact complement** of `_docker_image_tag`: strip any `@digest`
+  first (`@` cannot appear in an OCI name, so `partition("@")` is unambiguous),
+  then split the last path segment on its **first** colon. Two independent homes
+  for this rule is the failure class the file's own docstrings exist to prevent.
+  - *Board finding, verified:* an earlier draft of this plan specified "split on
+    the last `:` when it occurs after the last `/`". Run against
+    `img:1.2@sha256:abc` that yields `img:1.2@sha256` where today's code
+    correctly yields `img` — **a regression**, because the last colon belongs to
+    the digest. It also diverged from `_docker_image_tag`, which returns
+    `1.2@sha256:abc` for the same input. Digest-first is what reconciles them.
 - `detect_package_type` docker branch — **modify** — replace
-  `raw.split(":")[0]` with `_split_docker_reference(raw)[0]`.
-- `_npm_package_arg` — **modify** — skip a leading npm **subcommand** token
-  (`exec`, `run`, `install`, `i`, `add`, `create`, `dlx`) the same way the docker
-  path already skips its own subcommands. Only when `command == "npm"`; `npx`
-  takes a package directly and must not gain a skip that would swallow a package
-  legitimately named `exec`. **This changes `_npm_package_arg`'s signature** — it
-  needs to know which command it is scanning for. Its other caller is
-  `update_server`'s pin detection (see Dependencies).
+  `raw.split(":")[0]` with `_docker_image_name(raw)`.
+- `_npm_package_arg` — **modify** — skip **one leading** npm subcommand token
+  (`exec`, `run`, `install`, `i`, `add`, `create`, `dlx`), and only when
+  `command == "npm"`.
+  - **Skip-once, leading-only — not the docker loop's shape.** Docker skips
+    subcommand tokens *anywhere* in `args` (`version_checker.py:361-366`).
+    Copying that here would swallow real packages: `npm install i` → `None`
+    (`i` is a genuine npm package) and `npm exec exec` → `None`. The plan text
+    previously said both "leading" and "the same way the docker path does";
+    those contradict, and leading-only is correct.
+  - `npx` must not gain the skip: it takes a package directly, so `npx -y exec`
+    must still resolve to `exec`.
+  - **This changes `_npm_package_arg`'s signature** — it needs the command it is
+    scanning for. Do **not** give it a defaulted parameter: a defaulted call site
+    would silently keep the old behaviour, which is the opposite of what a shared
+    scan needs. Its other caller is `update_server`'s pin detection (see
+    Dependencies).
+
+### `src/pmcp/tools/handlers.py` (modify)
+
+- `_detect_effective_version_pin` npm branch — **modify** — pass `command`
+  through to `_npm_package_arg` (`handlers.py:307`). The function already
+  receives `command` (`handlers.py:272`), so no plumbing is needed.
+  - **This is a behaviour change, not a mechanical update.** Today
+    `npm exec pkg@1.2` pin-detects on `exec`, so `_npm_tag("exec")` returns
+    `None` and **a real pin is missed**. After the fix the pin is found. That is
+    a fix, and it needs its own test and a CHANGELOG line — an earlier draft of
+    this plan wrongly said "no behavioural change intended here."
 
 ### `tests/test_version_checker.py` (modify)
 
@@ -88,28 +140,48 @@ collisions and nothing else.
   that only asserts one form's new value would pass against a parser that
   collapsed both to something else, so **assert the inequality**, not just the
   value.
-- `TestDetectPackageType` — **add** — regression cases that must not move:
-  `img:1.2`→`img`, `ghcr.io/org/img:v2`→`ghcr.io/org/img`,
-  `mcp/server:latest`→`mcp/server`, `localhost:5000/a/b:tag`→`localhost:5000/a/b`,
-  `npx -y @scope/pkg@1.2.3`→`@scope/pkg`, `uvx --from thing other`→`thing`.
-- `TestDetectPackageType` — **add** — `npx` must still accept a package named
-  `exec` (`npx -y exec` → `exec`), pinning that the subcommand skip is
-  npm-only.
+- `TestDetectPackageType` — **add** — **fix** cases (currently wrong, must be RED
+  first): `localhost:5000/a/b:tag` → `localhost:5000/a/b`, and
+  `img:1.2@sha256:abc` → `img`. *An earlier draft filed the `localhost` case
+  under "must not move", which is wrong — it resolves to `localhost` today, and
+  an executor honouring "resolves exactly as before" literally would enshrine
+  the bug.*
+- `TestDetectPackageType` — **add** — genuine regression cases that must not
+  move: `img:1.2`→`img`, `ghcr.io/org/img:v2`→`ghcr.io/org/img`,
+  `mcp/server:latest`→`mcp/server`, `npx -y @scope/pkg@1.2.3`→`@scope/pkg`,
+  `uvx --from thing other`→`thing`, and `registry:5000` (bare host:port, no
+  path) → `registry` — with no `/`, that genuinely *is* image `registry` tag
+  `5000` under the OCI grammar, so it is correct today and must stay.
+- `TestDetectPackageType` — **add** — skip-once pins: `npx -y exec` → `exec`
+  (skip is npm-only) **and** `npm install i` → `i` / `npm exec exec` → `exec`
+  (skip fires once, not repeatedly).
+- `TestDetectPackageType` — **add** — `_docker_image_name` and
+  `_docker_image_tag` are complements: for each docker form in this class,
+  assert the name and tag together reconstruct the reference's meaning, so the
+  two helpers cannot drift apart.
 
 ### `tests/test_tools.py` (modify)
 
-- `TestUpdateServerPinDetection` (or the existing pin-detection class — search
-  `_npm_package_arg` / pin) — **modify** — only if the signature change requires
-  a call-site update in a test. No behavioural change intended here.
+- The pin-detection class (search `_detect_effective_version_pin` / pin) —
+  **add** — `npm exec pkg@1.2` now detects the pin `1.2` where it previously
+  returned `None`. This is a real behaviour fix and needs its own assertion,
+  proved RED first. Also pin the docker digest form, since `_docker_image_name`
+  landing beside `_docker_image_tag` touches that path.
 
 ## Documentation impact
 
-- `CHANGELOG.md` — **add** — a `### Fixed` bullet under `[Unreleased]`. This is
-  user-visible twice over: a docker server on a `host:port` registry and an
-  `npm exec` server both get a *different* package identity than before, so
-  their cached entries fail `_same_package` once and refresh. State that
-  one-time refresh explicitly, the same way 2.4.0 documented the `package_type`
-  migration.
+- `CHANGELOG.md` — **add** — a `### Fixed` bullet under `[Unreleased]` covering
+  **three** user-visible effects: (a) a docker server on a `host:port` registry
+  and (b) an `npm exec` server each get a *different* package identity than
+  before, so their cached entries fail `_same_package` once and refresh — state
+  that one-time refresh explicitly, as 2.4.0 did for the `package_type`
+  migration; and (c) `npm exec pkg@1.2` now has its version pin **detected**
+  where it was previously missed, which changes `update_server`'s behaviour for
+  those servers.
+- Note the limitation that remains: **Consiliency/pmcp#182** — uvx/pip/cargo
+  collide identically via unskipped flag values, and `uvx --with` is a more
+  realistic trigger than anything fixed here. The CHANGELOG should not imply the
+  identity gate is now total.
 - `README.md` — **none**. The parser is internal; no documented behaviour
   changes.
 - No other cross-cutting doc applies — no `ARCHITECTURE.md`/`docs/**` in this
@@ -117,7 +189,10 @@ collisions and nothing else.
 
 ## Dependencies & order
 
-1. `_split_docker_reference` must exist before the docker branch calls it.
+1. `_docker_image_name` must exist, defined beside `_docker_image_tag`, before
+   the docker branch calls it. Write them as a reconciled pair in one edit — if
+   they are touched separately they can drift, which is the whole reason this
+   plan stopped introducing a second independent helper.
 2. **`_npm_package_arg`'s signature change is the one cross-file hazard.** It is
    deliberately shared: its docstring says `update_server`'s pin detection uses
    *the exact same scan* so the two cannot disagree about which argument is "the
@@ -151,15 +226,20 @@ uv run ruff format --check src/ tests/
 uv run mypy src/pmcp --exclude baml_client
 ```
 
-**Mutation proof required, not optional.** For each new collision test, revert
-the corresponding parser line and confirm that test fails. A collision test that
-passes against the *old* parser is proving nothing — this repo has shipped that
-exact class of hollow test twice in the last two phases, both times caught only
-by a board.
+**Mutation proof required, and its output must be recorded.** For each new
+collision test, revert the corresponding parser line and confirm that test
+fails, then restore. A collision test that passes against the *old* parser is
+proving nothing — this repo has shipped that exact class of hollow test twice in
+the last two phases, both times caught only by a board, and in one of those the
+hollow test was written *by the same agent that had just documented the failure
+mode*. Performing the proof is not sufficient: **paste the failing output into
+the handoff**, per test, so the evidence outlives the session that produced it.
 
-Edge cases to exercise: a bare `:` with nothing after it; an image with a digest
-(`img@sha256:…`) rather than a tag; `npm` with no subcommand at all
-(`npm ['pkg']`); an npm package legitimately named `exec`.
+Edge cases to exercise: a bare `:` with nothing after it (`img:`); a digest with
+no tag (`img@sha256:…`); **tag and digest together (`img:1.2@sha256:…` — the
+form that broke the first draft of this plan)**; a bare `host:port` with no path
+(`registry:5000`, which correctly stays `registry`); `npm` with no subcommand
+(`npm ['pkg']`); an npm package legitimately named `exec` or `i`.
 
 ## Automation
 
@@ -176,16 +256,29 @@ automation:
 - [ ] `detect_package_type("docker", ["run","registry:5000/old-image"])` and
       `...new-image` return **different** package names — proven by
       `uv run pytest tests/test_version_checker.py::TestDetectPackageType -q`
-      and by reverting `_split_docker_reference`'s use to confirm the test fails.
+      and by reverting the docker branch to `raw.split(":")[0]` to confirm the
+      test fails, with that output recorded.
 - [ ] `detect_package_type("npm", ["exec","old-pkg"])` and `...new-pkg` return
-      **different** package names, while `npx -y exec` still resolves to `exec` —
-      same command, same mutation requirement.
+      **different** package names, while `npx -y exec` → `exec`,
+      `npm install i` → `i`, and `npm exec exec` → `exec` all hold — same
+      command, same recorded-mutation requirement.
+- [ ] **Digest forms resolve correctly, not merely differently:**
+      `img:1.2@sha256:abc` → `img` (unchanged from today — the first draft of
+      this plan regressed it), `img@sha256:abc` → `img`, and
+      `registry:5000/img@sha256:abc` → `registry:5000/img`.
+- [ ] `_docker_image_name` and `_docker_image_tag` are complements — for every
+      docker form under test, name and tag agree about where the reference
+      splits. Proven by the paired assertions in `TestDetectPackageType`, which
+      is what stops the two rules drifting as they had begun to.
 - [ ] Every pre-existing form resolves exactly as before: `img:1.2`,
-      `ghcr.io/org/img:v2`, `mcp/server:latest`, `npx -y @scope/pkg@1.2.3`,
-      `uvx --from thing other` — proven by the regression cases in
-      `TestDetectPackageType`.
-- [ ] Every `_npm_package_arg` caller is updated together — proven by
-      `grep -rn '_npm_package_arg' src/ tests/` showing no call site passing the
-      old signature, plus `uv run mypy src/pmcp --exclude baml_client` clean.
-- [ ] Full suite, ruff, and mypy green; `CHANGELOG.md` records the fix and the
-      one-time refresh it causes for affected servers.
+      `ghcr.io/org/img:v2`, `mcp/server:latest`, `registry:5000`,
+      `npx -y @scope/pkg@1.2.3`, `uvx --from thing other`.
+- [ ] `npm exec pkg@1.2` now pin-detects `1.2` where it previously returned
+      `None` — proven by a test in `tests/test_tools.py`, RED first.
+- [ ] Every `_npm_package_arg` caller is updated together, with **no defaulted
+      parameter** — proven by `grep -rn '_npm_package_arg' src/ tests/` showing
+      both call sites passing the command explicitly, plus
+      `uv run mypy src/pmcp --exclude baml_client` clean.
+- [ ] Full suite, ruff, and mypy green; `CHANGELOG.md` records all three
+      user-visible effects and does not imply the identity gate is now total
+      (Consiliency/pmcp#182 remains open).

--- a/.consiliency/plans/detailed-package-identity-parsing-20260825-0900.md
+++ b/.consiliency/plans/detailed-package-identity-parsing-20260825-0900.md
@@ -64,6 +64,39 @@ port (`registry:5000/img:1.2.3`) does not read as a tag of `5000`."* It is what
 **not** a new rule — it is making `detect_package_type` use the rule the file
 already has, which is why this plan no longer introduces a second helper.
 
+**This change NARROWS #180; it does not close it.** *(Board finding, verified —
+and it falsifies a premise this plan previously stated.)* An earlier draft said
+"the *selection* of the image token is sound — only the tag-stripping is wrong."
+That is false. `_docker_image_arg`'s `_value_flags` table
+(`version_checker.py:336-359`) is incomplete, and `_npm_package_arg` discards
+option tokens wholesale, so ordinary command forms still collapse two packages
+to one identity **after** everything in this plan lands:
+
+```
+docker run --env-file .env old-image        -> ('docker', '.env')
+docker run --env-file .env new-image        -> ('docker', '.env')
+docker run --mount type=bind,src=/a A / B   -> both ('docker', 'type=bind,src=/a')
+npm exec --package=old-pkg -- shared-bin    -> ('npm', 'exec')
+npm exec --package=new-pkg -- shared-bin    -> ('npm', 'exec')
+```
+
+These are not exotic: `--env-file` and `--mount` are everyday `docker run`
+options, and `--package=` is the documented way to name an npm exec target.
+Moved to **Consiliency/pmcp#182** (broadened for this), because closing them
+needs either an exhaustive per-ecosystem flag table or a fail-closed contract —
+a parser redesign, not this bounded fix.
+
+**Consequence for closeout: the PR must NOT close #180.** It narrows it. A
+"fixed" label here would mark a still-open hole as closed.
+
+**A more serious class, filed as Consiliency/pmcp#183.** `update_server` builds
+its probe from the parsed name — `npx -y {package_name}@latest --help`
+(`handlers.py:5049`) — and `npx -y` installs without prompting. So
+`npm run mcp`, where `mcp` is a **local script**, parses to package `run` and
+pmcp installs and executes whatever `run` is on the npm registry. That is
+unintended package execution rather than a mislabelled cache entry, so it is
+out of scope here and tracked on its own.
+
 **Scope correction (board finding, verified).** An earlier draft of this plan
 claimed the `pip`/`cargo` branches "are not implicated" and that `uvx` was fine.
 **That was false.** Every excluded branch collides, by the same root cause —
@@ -105,8 +138,10 @@ is a normal pattern), so #182 should not sit long.
 - `detect_package_type` docker branch — **modify** — replace
   `raw.split(":")[0]` with `_docker_image_name(raw)`.
 - `_npm_package_arg` — **modify** — skip **one leading** npm subcommand token
-  (`exec`, `run`, `install`, `i`, `add`, `create`, `dlx`), and only when
-  `command == "npm"`.
+  (`exec`, `x`, `run`, `install`, `i`, `add`, `create`, `dlx`), and only when
+  `command == "npm"`. **`x` is not optional** — it is the documented `npm exec`
+  alias, and omitting it leaves `npm x old-pkg` / `npm x new-pkg` colliding
+  exactly as `npm exec` does today (two seats raised this independently).
   - **Skip-once, leading-only — not the docker loop's shape.** Docker skips
     subcommand tokens *anywhere* in `args` (`version_checker.py:361-366`).
     Copying that here would swallow real packages: `npm install i` → `None`
@@ -253,15 +288,24 @@ automation:
 
 ## Acceptance criteria
 
+**The mutation proof must name the single test node, never the class.** *(Board
+finding.)* Reverting the docker branch also reddens the `localhost` regression
+test, so a red **class** proves nothing about whether the collision test itself
+is load-bearing — which is precisely how the two prior hollow tests survived.
+Run one node id at a time against the reverted parser.
+
 - [ ] `detect_package_type("docker", ["run","registry:5000/old-image"])` and
       `...new-image` return **different** package names — proven by
-      `uv run pytest tests/test_version_checker.py::TestDetectPackageType -q`
-      and by reverting the docker branch to `raw.split(":")[0]` to confirm the
-      test fails, with that output recorded.
+      `uv run pytest "tests/test_version_checker.py::TestDetectPackageType::<docker-collision-test>" -q`
+      **alone**, against a parser reverted to `raw.split(":")[0]`, with that
+      output recorded in the handoff.
 - [ ] `detect_package_type("npm", ["exec","old-pkg"])` and `...new-pkg` return
-      **different** package names, while `npx -y exec` → `exec`,
-      `npm install i` → `i`, and `npm exec exec` → `exec` all hold — same
-      command, same recorded-mutation requirement.
+      **different** package names, and `npm x old-pkg` / `npm x new-pkg` do too,
+      while `npx -y exec` → `exec`, `npm install i` → `i`, and
+      `npm exec exec` → `exec` all hold — same single-node mutation requirement.
+- [ ] The PR **narrows** #180 rather than closing it, and says so: the forms in
+      #182 (`docker run --env-file`, `--mount`, `npm exec --package=`) still
+      collide after this change.
 - [ ] **Digest forms resolve correctly, not merely differently:**
       `img:1.2@sha256:abc` → `img` (unchanged from today — the first draft of
       this plan regressed it), `img@sha256:abc` → `img`, and

--- a/.consiliency/plans/detailed-package-identity-parsing-20260825-0900.md
+++ b/.consiliency/plans/detailed-package-identity-parsing-20260825-0900.md
@@ -1,0 +1,191 @@
+# Detailed plan: fix detect_package_type's package-identity collisions
+
+## Task
+
+Close Consiliency/pmcp#180. `detect_package_type` returns a package **name**
+that is not unique for several legal command forms, so two genuinely different
+packages resolve to the same identity. v2.4.0's identity gate compares those
+names to decide whether a cached description still describes the configured
+package, so for the affected forms `_same_package` **confirms identity across a
+real package swap** and the freshness short-circuit serves the wrong package's
+tool descriptions — the exact defect UPDPATH exists to close, unmet for those
+command shapes.
+
+## Research summary
+
+Context was already in session from the UPDPATH phase and its board rounds, so
+no Explore fan-out; the parser and every caller were read directly.
+
+`detect_package_type` (`src/pmcp/manifest/version_checker.py:265`, ~60 lines of
+branch logic) has five callers, in **two classes** that want different things
+from it:
+
+- **Version lookup** — `get_package_version` (`version_checker.py:402`) uses the
+  name to hit a registry. A wrong name yields a failed or wrong lookup.
+- **Identity comparison** (new in 2.4.0) — `refresher.py:259`, `:420`, `:499`
+  and `handlers.py:5019` feed the name into `_same_package`. A wrong name that
+  happens to be *stable across two different packages* is far worse: it reads as
+  a positive confirmation.
+
+Measured collisions on `main` @ `f5ea5ec`:
+
+| command | resolves to |
+|---|---|
+| `docker run registry:5000/old-image` | `("docker", "registry")` |
+| `docker run registry:5000/new-image` | `("docker", "registry")` |
+| `docker run localhost:5000/a/b:tag` | `("docker", "localhost")` |
+| `npm exec old-pkg` | `("npm", "exec")` |
+| `npm exec new-pkg` | `("npm", "exec")` |
+
+Two distinct root causes, and they are **not** the same bug:
+
+1. **Docker** — the branch does `image = raw.split(":")[0]`
+   (`version_checker.py:~317`), treating the first `:` as the tag separator. In
+   an OCI reference a `:` only introduces a tag when it appears **after the last
+   `/`**; before that it is a registry `host:port`. Note `_docker_image_arg`
+   already correctly skips docker subcommands (`version_checker.py:365`) and a
+   long `_value_flags` set, so the *selection* of the image token is sound — only
+   the tag-stripping is wrong. Confirmed still-correct forms that must not
+   regress: `img:1.2` → `img`, `ghcr.io/org/img:v2` → `ghcr.io/org/img`,
+   `mcp/server:latest` → `mcp/server`.
+2. **npm** — `_npm_package_arg` (`version_checker.py:~?`, search the symbol)
+   skips only `-y` and flags. It has **no subcommand skip at all**, so `exec`,
+   `run` etc. are taken as the package. This is an asymmetry with the docker
+   branch, which does skip its subcommands.
+
+The third finding (`localhost:5000/a/b:tag`) is not in the issue text; it is the
+same docker root cause with a different registry host, and is included here.
+
+**Scope discipline.** `uvx --from thing other` → `("pypi", "thing")` is
+**correct** (`--from` names the package) and is out of scope. `pip`/`cargo`
+branches are not implicated. This plan touches the two branches with measured
+collisions and nothing else.
+
+## Changes
+
+### `src/pmcp/manifest/version_checker.py` (modify)
+
+- `_split_docker_reference` — **add** — new module-private helper returning
+  `(name, tag_or_none)` for an OCI reference, splitting on the last `:` **only
+  when it occurs after the last `/`**. Extracted rather than inlined so the rule
+  has one home and one test surface; the docker branch and any future caller
+  that wants the tag both read it from here.
+- `detect_package_type` docker branch — **modify** — replace
+  `raw.split(":")[0]` with `_split_docker_reference(raw)[0]`.
+- `_npm_package_arg` — **modify** — skip a leading npm **subcommand** token
+  (`exec`, `run`, `install`, `i`, `add`, `create`, `dlx`) the same way the docker
+  path already skips its own subcommands. Only when `command == "npm"`; `npx`
+  takes a package directly and must not gain a skip that would swallow a package
+  legitimately named `exec`. **This changes `_npm_package_arg`'s signature** — it
+  needs to know which command it is scanning for. Its other caller is
+  `update_server`'s pin detection (see Dependencies).
+
+### `tests/test_version_checker.py` (modify)
+
+- `TestDetectPackageType` — **add** — one test per collision pair asserting the
+  two forms now resolve to **different** names: `registry:5000/old-image` vs
+  `registry:5000/new-image`; `npm exec old-pkg` vs `npm exec new-pkg`. A test
+  that only asserts one form's new value would pass against a parser that
+  collapsed both to something else, so **assert the inequality**, not just the
+  value.
+- `TestDetectPackageType` — **add** — regression cases that must not move:
+  `img:1.2`→`img`, `ghcr.io/org/img:v2`→`ghcr.io/org/img`,
+  `mcp/server:latest`→`mcp/server`, `localhost:5000/a/b:tag`→`localhost:5000/a/b`,
+  `npx -y @scope/pkg@1.2.3`→`@scope/pkg`, `uvx --from thing other`→`thing`.
+- `TestDetectPackageType` — **add** — `npx` must still accept a package named
+  `exec` (`npx -y exec` → `exec`), pinning that the subcommand skip is
+  npm-only.
+
+### `tests/test_tools.py` (modify)
+
+- `TestUpdateServerPinDetection` (or the existing pin-detection class — search
+  `_npm_package_arg` / pin) — **modify** — only if the signature change requires
+  a call-site update in a test. No behavioural change intended here.
+
+## Documentation impact
+
+- `CHANGELOG.md` — **add** — a `### Fixed` bullet under `[Unreleased]`. This is
+  user-visible twice over: a docker server on a `host:port` registry and an
+  `npm exec` server both get a *different* package identity than before, so
+  their cached entries fail `_same_package` once and refresh. State that
+  one-time refresh explicitly, the same way 2.4.0 documented the `package_type`
+  migration.
+- `README.md` — **none**. The parser is internal; no documented behaviour
+  changes.
+- No other cross-cutting doc applies — no `ARCHITECTURE.md`/`docs/**` in this
+  repo, and `llm.txt`-family files do not describe this function.
+
+## Dependencies & order
+
+1. `_split_docker_reference` must exist before the docker branch calls it.
+2. **`_npm_package_arg`'s signature change is the one cross-file hazard.** It is
+   deliberately shared: its docstring says `update_server`'s pin detection uses
+   *the exact same scan* so the two cannot disagree about which argument is "the
+   package". Find every caller (`grep -rn '_npm_package_arg' src/ tests/`) and
+   update them together in one commit — a partial update leaves the pin
+   detection and the type detection disagreeing, which is the precise failure
+   that comment exists to prevent.
+3. Tests are written **before** the parser changes and must be shown RED
+   individually (per-test, not per-command — a class-level run can hide a
+   non-discriminating test behind a red classmate).
+
+## Verification
+
+```bash
+cd /mnt/workspace/worktrees/pmcp-180-parser
+
+# The collisions, gone:
+uv run python -c "
+from pmcp.manifest.version_checker import detect_package_type as d
+assert d('docker',['run','registry:5000/old-image']) != d('docker',['run','registry:5000/new-image'])
+assert d('npm',['exec','old-pkg']) != d('npm',['exec','new-pkg'])
+print('collisions resolved')"
+
+# Nothing that worked before moved:
+uv run pytest tests/test_version_checker.py tests/test_tools.py tests/test_refresher.py -q
+
+# Full gate:
+uv run pytest tests/ -q          # baseline on main: 2700 passed, 3 skipped
+uv run ruff check src/ tests/
+uv run ruff format --check src/ tests/
+uv run mypy src/pmcp --exclude baml_client
+```
+
+**Mutation proof required, not optional.** For each new collision test, revert
+the corresponding parser line and confirm that test fails. A collision test that
+passes against the *old* parser is proving nothing — this repo has shipped that
+exact class of hollow test twice in the last two phases, both times caught only
+by a board.
+
+Edge cases to exercise: a bare `:` with nothing after it; an image with a digest
+(`img@sha256:…`) rather than a tag; `npm` with no subcommand at all
+(`npm ['pkg']`); an npm package legitimately named `exec`.
+
+## Automation
+
+```yaml
+automation:
+  suite_command: "uv run pytest -q"
+```
+
+## Execution Policy
+- execute: effort=medium, reason=small surface but the identity semantics are subtly wrong-prone
+
+## Acceptance criteria
+
+- [ ] `detect_package_type("docker", ["run","registry:5000/old-image"])` and
+      `...new-image` return **different** package names — proven by
+      `uv run pytest tests/test_version_checker.py::TestDetectPackageType -q`
+      and by reverting `_split_docker_reference`'s use to confirm the test fails.
+- [ ] `detect_package_type("npm", ["exec","old-pkg"])` and `...new-pkg` return
+      **different** package names, while `npx -y exec` still resolves to `exec` —
+      same command, same mutation requirement.
+- [ ] Every pre-existing form resolves exactly as before: `img:1.2`,
+      `ghcr.io/org/img:v2`, `mcp/server:latest`, `npx -y @scope/pkg@1.2.3`,
+      `uvx --from thing other` — proven by the regression cases in
+      `TestDetectPackageType`.
+- [ ] Every `_npm_package_arg` caller is updated together — proven by
+      `grep -rn '_npm_package_arg' src/ tests/` showing no call site passing the
+      old signature, plus `uv run mypy src/pmcp --exclude baml_client` clean.
+- [ ] Full suite, ruff, and mypy green; `CHANGELOG.md` records the fix and the
+      one-time refresh it causes for affected servers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Two different packages no longer share one identity for common `docker` and
+  `npm` command forms.** 2.4.0's identity gate decides whether a cached
+  description still describes the configured package by comparing the *name*
+  `detect_package_type` returns, so a name that was stable across two different
+  packages was read as a positive confirmation — and the freshness
+  short-circuit went on serving the wrong package's tool descriptions.
+
+  Two independent causes, both closed:
+
+  - **Docker references split on the first `:`,** so `registry:5000/old-image`
+    and `registry:5000/new-image` both resolved to the image `registry` — the
+    registry host, not an image at all. A colon only introduces a tag when it
+    appears in the final path segment; before the last `/` it is a registry
+    `host:port`. The correct rule already existed in this module as
+    `_docker_image_tag`, so the fix adds its paired complement rather than a
+    second, divergent implementation of the same rule.
+  - **`npm` subcommands were taken as the package name,** so `npm exec old-pkg`
+    and `npm exec new-pkg` both resolved to `exec`. A leading subcommand
+    (`exec`, `x`, `run`, `install`, `i`, `add`, `create`, `dlx`) is now skipped
+    — once, and only for `npm`, so `npm install i` still finds the real package
+    `i` and `npx -y exec` still finds a package genuinely named `exec`.
+
+  **Affected servers refresh once.** A docker server on a `host:port` registry
+  or an `npm exec` server now has a *different* package identity than the one
+  its cache entry recorded, so that entry fails the identity check once and is
+  regenerated — the same one-time migration 2.4.0's `package_type` addition
+  caused.
+- **A docker digest is no longer reported as a version pin.** `gateway.update_server`
+  read the tag from the whole reference, so `img@sha256:abc` reported a pin of
+  `abc` — a fragment of the digest presented as a version — and
+  `img:1.2@sha256:abc` reported `1.2@sha256:abc` instead of the actual pin
+  `1.2`. A `@digest` suffix is now stripped before the tag is read.
+- **A version pin on an `npm exec` server is now detected.** Pin detection
+  shares its argument scan with package detection, so it inherited the
+  subcommand bug: `npm exec pkg@1.2` scanned to `exec`, which carries no
+  version suffix, and a real pin was reported as unpinned.
+
+  **This narrows Consiliency/pmcp#180 rather than closing it.** Package identity
+  is still collapsed wherever a flag's *value* is taken as the package name —
+  `docker run --env-file X <image>`, `docker run --mount <spec> <image>`,
+  `npm exec --package=<pkg>`, and the `uvx`/`pip`/`cargo` equivalents. Those are
+  tracked on Consiliency/pmcp#182, and Consiliency/pmcp#183 tracks a related but
+  more serious consequence of a misparse.
+
 ## [2.4.0] - 2026-08-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its cache entry recorded, so that entry fails the identity check once and is
   regenerated — the same one-time migration 2.4.0's `package_type` addition
   caused.
-- **A docker digest is no longer reported as a version pin.** `gateway.update_server`
+- **A docker digest is now recognised as the pin it is.** `gateway.update_server`
   read the tag from the whole reference, so `img@sha256:abc` reported a pin of
   `abc` — a fragment of the digest presented as a version — and
-  `img:1.2@sha256:abc` reported `1.2@sha256:abc` instead of the actual pin
-  `1.2`. A `@digest` suffix is now stripped before the tag is read.
+  `img:1.2@sha256:abc` reported `1.2@sha256:abc` instead of a usable value. A
+  digest is the *tightest* pin docker offers, so it is now reported whole and
+  checked before the tag: `img@sha256:…`, `img:1.2@sha256:…` and
+  `img:latest@sha256:…` all report the digest. That last form matters — a
+  `latest` tag must not discard a real digest pin. Previously such a server
+  could be "updated": pmcp would pull `image:latest`, restart the unchanged
+  digest-pinned configuration, and record the registry's newest digest while
+  still running the old immutable image.
 - **A version pin on an `npm exec` server is now detected.** Pin detection
   shares its argument scan with package detection, so it inherited the
   subcommand bug: `npm exec pkg@1.2` scanned to `exec`, which carries no

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -95,11 +95,17 @@ def _npm_package_arg(args: list[str], command: str) -> str | None:
     for arg in args:
         if arg == "-y":
             continue
-        # Skip flags
+        # Skip flags. This MUST precede the subcommand check: npm accepts
+        # global flags before the subcommand (`npm --silent exec pkg`), so
+        # spending the one-shot skip on a flag token would leave `exec` to be
+        # read as the package and reopen the #180 collapse for every form
+        # carrying a leading flag. The ordering is already correct; the test
+        # below exists because nothing PINNED it (ah board review, adversarial
+        # seat: a surviving mutant, not a live defect).
         if arg.startswith("-"):
             continue
         if skip_subcommand:
-            # Only the FIRST non-flag token can be the subcommand; whatever
+            # Only the first non-flag token can be the subcommand; whatever
             # follows is a candidate package even if it repeats the word.
             skip_subcommand = False
             if arg in _NPM_SUBCOMMANDS:
@@ -425,11 +431,35 @@ def _docker_image_tag(image_ref: str) -> str | None:
     because ``_docker_image_name`` is this function's complement and the two
     must agree about where a reference divides -- an identity gate compares the
     name, so a divergence lets two different images confirm as one package.
+
+    **A caller deciding whether a reference is PINNED must not read this
+    function alone** -- ask ``_docker_image_digest`` too. A digest-only
+    reference has no tag, so this correctly returns ``None``, and a caller
+    treating ``None`` as "unpinned" would conclude that the most tightly
+    pinned form docker has is not pinned at all (ah board review, red-team
+    seat).
     """
     base = image_ref.partition("@")[0] or image_ref
     last_segment = base.rsplit("/", 1)[-1]
     name, sep, tag = last_segment.partition(":")
     return tag if sep and name and tag else None
+
+
+def _docker_image_digest(image_ref: str) -> str | None:
+    """Return the ``@digest`` on a docker image reference, or ``None``.
+
+    The third member of the reference-splitting family, beside
+    ``_docker_image_name`` and ``_docker_image_tag``. A digest is an immutable
+    content identity -- the TIGHTEST pin docker offers, stronger than any tag --
+    so a caller asking "is this reference pinned?" must consult this as well as
+    the tag. Reading the tag alone reports a digest-only reference as unpinned,
+    which would let gateway.update_server pull ``image:latest``, restart the
+    unchanged digest-pinned config, and record the registry's newest digest as
+    though it had updated -- announcing an update while still running the old
+    immutable image (ah board review, red-team seat).
+    """
+    _name, sep, digest = image_ref.partition("@")
+    return digest if sep and digest else None
 
 
 def _docker_image_name(image_ref: str) -> str:

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -54,7 +54,12 @@ def _npm_tag(package: str) -> str | None:
     return tag if tag_sep and _name else None
 
 
-def _npm_package_arg(args: list[str]) -> str | None:
+_NPM_SUBCOMMANDS = frozenset(
+    {"exec", "x", "run", "install", "i", "add", "create", "dlx"}
+)
+
+
+def _npm_package_arg(args: list[str], command: str) -> str | None:
     """Return the raw npm/npx package token from *args*, or ``None``.
 
     "Raw" means *before* ``_strip_npm_tag`` removes any ``@tag``/``@version``
@@ -63,13 +68,42 @@ def _npm_package_arg(args: list[str]) -> str | None:
     detection) can get it from the exact same scan ``detect_package_type``
     itself uses, instead of re-implementing the scan a second time and
     risking it picking a different argument as "the package".
+
+    *command* is REQUIRED, and deliberately not defaulted. ``npm`` takes a
+    subcommand before the package (``npm exec pkg``) while ``npx`` takes the
+    package directly (``npx pkg``), so the scan cannot be correct for both
+    without knowing which it is reading. A default would let one of the two
+    call sites keep the old behaviour silently while type-checking clean --
+    the exact drift this function's shared-scan design exists to prevent.
+
+    The subcommand skip fires **once, on the first non-flag token, for ``npm``
+    only**:
+
+    * Once, not repeatedly, because ``i`` and ``exec`` are also real package
+      names: a loop that skipped subcommand tokens anywhere -- the shape the
+      docker branch uses for its own subcommands -- would turn
+      ``npm install i`` and ``npm exec exec`` into ``None``.
+    * ``npm`` only, because ``npx -y exec`` genuinely names a package called
+      ``exec``.
+
+    Known limitation, tracked on Consiliency/pmcp#182: option tokens are
+    discarded wholesale, so ``npm exec --package=<pkg> -- <bin>`` still yields
+    the binary rather than ``<pkg>``, and two packages exposing the same binary
+    still confirm as one identity.
     """
+    skip_subcommand = command == "npm"
     for arg in args:
         if arg == "-y":
             continue
         # Skip flags
         if arg.startswith("-"):
             continue
+        if skip_subcommand:
+            # Only the FIRST non-flag token can be the subcommand; whatever
+            # follows is a candidate package even if it repeats the word.
+            skip_subcommand = False
+            if arg in _NPM_SUBCOMMANDS:
+                continue
         # Found package name (might have @version or @dist-tag suffix)
         pkg = _strip_npm_tag(arg)
         # Handle scoped packages like @playwright/mcp
@@ -277,7 +311,7 @@ def detect_package_type(
     """
     if command in ("npx", "npm"):
         # Find npm package in args (usually after -y flag)
-        raw = _npm_package_arg(args)
+        raw = _npm_package_arg(args, command)
         if raw is not None:
             return ("npm", _strip_npm_tag(raw))
 
@@ -316,8 +350,11 @@ def detect_package_type(
     elif command == "docker":
         raw = _docker_image_arg(args)
         if raw is not None:
-            # Strip the tag: docker run [options] image[:tag] [cmd...]
-            image = raw.split(":")[0]
+            # Strip tag and digest via the shared splitter, NOT `split(":")[0]`
+            # -- that took the FIRST colon, so `registry:5000/img` read as the
+            # image `registry` and two different images on the same host:port
+            # registry confirmed as one package (Consiliency/pmcp#180).
+            image = _docker_image_name(raw)
             if image:
                 return ("docker", image)
 
@@ -379,10 +416,52 @@ def _docker_image_tag(image_ref: str) -> str | None:
 
     Only the final path segment can carry a tag, so a registry host with a
     port (``registry:5000/img:1.2.3``) does not read as a tag of ``5000``.
+
+    A ``@digest`` suffix is stripped before the tag is read, so a digest is
+    never reported as a tag. Without that, ``img@sha256:abc`` returned ``abc``
+    and gateway.update_server's pin detection reported a *digest fragment as a
+    version pin*, while ``img:1.2@sha256:abc`` returned ``1.2@sha256:abc``
+    instead of ``1.2``. Both are fixed here rather than only in the name half,
+    because ``_docker_image_name`` is this function's complement and the two
+    must agree about where a reference divides -- an identity gate compares the
+    name, so a divergence lets two different images confirm as one package.
     """
-    last_segment = image_ref.rsplit("/", 1)[-1]
+    base = image_ref.partition("@")[0] or image_ref
+    last_segment = base.rsplit("/", 1)[-1]
     name, sep, tag = last_segment.partition(":")
     return tag if sep and name and tag else None
+
+
+def _docker_image_name(image_ref: str) -> str:
+    """Return the image NAME from a docker reference, without tag or digest.
+
+    The paired complement of ``_docker_image_tag`` -- same scan, same split
+    point, opposite half -- in the exact sense ``_strip_npm_tag``/``_npm_tag``
+    are paired. Written together so the two can never disagree about where a
+    reference divides; ``detect_package_type`` reads the name from here and
+    gateway.update_server's pin detection reads the tag from there, and an
+    identity gate compares the name, so a divergence would let two different
+    images confirm as the same package.
+
+    Two rules, in order, and the order matters:
+
+    * **Digest first.** ``@`` cannot appear in an OCI image name, so it is an
+      unambiguous separator -- unlike ``:``. A ``name:tag@sha256:...`` reference
+      contains three colons and the LAST one belongs to the digest, so any rule
+      that reaches for the last colon splits in the wrong place. (An earlier
+      draft of this fix did exactly that and regressed
+      ``img:1.2@sha256:abc`` from ``img`` to ``img:1.2@sha256``.)
+    * **Then the tag**, on the FIRST colon of the final path segment only --
+      identical to ``_docker_image_tag``. This is what stops
+      ``registry:5000/img`` reading as image ``registry``: before the last
+      ``/`` a colon is a registry ``host:port``, not a tag separator.
+    """
+    base = image_ref.partition("@")[0] or image_ref
+    prefix, sep, last_segment = base.rpartition("/")
+    name, tag_sep, tag = last_segment.partition(":")
+    if tag_sep and name and tag:
+        last_segment = name
+    return f"{prefix}{sep}{last_segment}"
 
 
 async def get_package_version(

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -304,7 +304,13 @@ def _detect_effective_version_pin(
     than an inline suffix, so it needs its own scan.
     """
     if package_type == "npm":
-        raw = _npm_package_arg(args)
+        # `command` is passed for the same reason detect_package_type passes
+        # it: the scan is shared so the two cannot disagree about which
+        # argument is "the package", and it can only be right for both `npm`
+        # (subcommand first) and `npx` (package first) if it knows which it is
+        # reading. Before this, `npm exec pkg@1.2` scanned to `exec`, whose
+        # `_npm_tag` is None, so a REAL pin was reported as unpinned.
+        raw = _npm_package_arg(args, command)
         if raw is None:
             return None
         tag = _npm_tag(raw)

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -76,6 +76,7 @@ from pmcp.manifest.registry import (
 from pmcp.manifest.refresher import save_descriptions_cache
 from pmcp.manifest.version_checker import (
     _docker_image_arg,
+    _docker_image_digest,
     _docker_image_tag,
     _npm_package_arg,
     _npm_tag,
@@ -326,6 +327,19 @@ def _detect_effective_version_pin(
         raw_image = _docker_image_arg(args)
         if raw_image is None:
             return None
+        # A DIGEST is the tightest pin docker has -- immutable content
+        # identity, stronger than any tag -- so it must be checked first and
+        # independently of the tag. `_docker_image_tag` deliberately returns
+        # None for a digest-only reference (a digest is not a tag), so reading
+        # the tag alone would report `img@sha256:...` as UNPINNED. update_server
+        # would then pull `image:latest`, restart the unchanged digest-pinned
+        # config, and record the registry's newest digest -- announcing an
+        # update while still running the old immutable image (ah board review,
+        # red-team seat). `image:latest@sha256:...` is the same trap wearing a
+        # tag that the `== "latest"` test would otherwise discard.
+        digest = _docker_image_digest(raw_image)
+        if digest:
+            return digest
         tag = _docker_image_tag(raw_image)
         return None if not tag or tag == "latest" else tag
     if package_type == "cargo":

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5693,6 +5693,25 @@ class TestUpdateServerVersionRepair:
         assert detect("docker", "docker", ["run", "registry:5000/img"]) is None
         assert detect("docker", "docker", ["run", "registry:5000/img:2.0"]) == "2.0"
 
+        # docker digests: `@sha256:...` is an identity, not a version pin.
+        # Before Consiliency/pmcp#180's fix the tag scan ran on the whole
+        # reference, so `img@sha256:abc` reported a pin of "abc" -- a digest
+        # FRAGMENT presented as a version -- and `img:1.2@sha256:abc` reported
+        # "1.2@sha256:abc" rather than the actual pin "1.2".
+        assert detect("docker", "docker", ["run", "img@sha256:abc"]) is None
+        assert detect("docker", "docker", ["run", "img:1.2@sha256:abc"]) == "1.2"
+
+        # npm subcommands: the scan is SHARED with detect_package_type, so it
+        # skips a leading subcommand here too. Before that, `npm exec pkg@1.2`
+        # scanned to "exec", whose `_npm_tag` is None, so a REAL pin read as
+        # unpinned (Consiliency/pmcp#180).
+        assert detect("npm", "npm", ["exec", "pkg@1.2"]) == "1.2"
+        assert detect("npm", "npm", ["x", "pkg@1.2"]) == "1.2"
+        assert detect("npm", "npm", ["exec", "pkg@latest"]) is None
+        assert detect("npm", "npm", ["exec", "pkg"]) is None
+        # ...and `npx` still must not skip a package genuinely named `exec`.
+        assert detect("npm", "npx", ["-y", "exec@1.2"]) == "1.2"
+
         # cargo: pins via a separate --version flag, both spellings.
         assert detect("cargo", "cargo", ["install", "srv", "--version", "1.0"]) == "1.0"
         assert detect("cargo", "cargo", ["install", "srv", "--version=1.0"]) == "1.0"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5693,13 +5693,23 @@ class TestUpdateServerVersionRepair:
         assert detect("docker", "docker", ["run", "registry:5000/img"]) is None
         assert detect("docker", "docker", ["run", "registry:5000/img:2.0"]) == "2.0"
 
-        # docker digests: `@sha256:...` is an identity, not a version pin.
-        # Before Consiliency/pmcp#180's fix the tag scan ran on the whole
-        # reference, so `img@sha256:abc` reported a pin of "abc" -- a digest
-        # FRAGMENT presented as a version -- and `img:1.2@sha256:abc` reported
-        # "1.2@sha256:abc" rather than the actual pin "1.2".
-        assert detect("docker", "docker", ["run", "img@sha256:abc"]) is None
-        assert detect("docker", "docker", ["run", "img:1.2@sha256:abc"]) == "1.2"
+        # docker digests: a digest is the TIGHTEST pin docker has -- immutable
+        # content identity, stronger than any tag -- so it must be reported as
+        # the pin, whole and unmangled.
+        #
+        # Two ways to get this wrong, both of which shipped in review drafts of
+        # Consiliency/pmcp#180. Running the tag scan over the whole reference
+        # returned a digest FRAGMENT as a version ("abc"); stripping the digest
+        # and reading only the tag returned None, which reads as UNPINNED and
+        # would let update_server pull `image:latest`, restart the unchanged
+        # digest-pinned config, and record the registry's newest digest --
+        # announcing an update while still running the old image.
+        assert detect("docker", "docker", ["run", "img@sha256:abc"]) == "sha256:abc"
+        assert detect("docker", "docker", ["run", "img:1.2@sha256:abc"]) == "sha256:abc"
+        # ...and a `latest` tag must not discard a real digest pin.
+        assert (
+            detect("docker", "docker", ["run", "img:latest@sha256:abc"]) == "sha256:abc"
+        )
 
         # npm subcommands: the scan is SHARED with detect_package_type, so it
         # skips a leading subcommand here too. Before that, `npm exec pkg@1.2`
@@ -5710,7 +5720,17 @@ class TestUpdateServerVersionRepair:
         assert detect("npm", "npm", ["exec", "pkg@latest"]) is None
         assert detect("npm", "npm", ["exec", "pkg"]) is None
         # ...and `npx` still must not skip a package genuinely named `exec`.
+        #
+        # `exec@1.2` alone CANNOT enforce that: the skip matches the RAW token
+        # against `_NPM_SUBCOMMANDS`, and `exec@1.2` is not in the set, so a
+        # call site hardcoded to "npm" returns the same `1.2` and the guard
+        # passes under the mutant it was written to catch -- a hollow
+        # assertion (ah board review, correctness seat). The bare `exec` token
+        # is what discriminates: with `npx` it is the package (no pin on it),
+        # with a wrongly-hardcoded "npm" it is skipped and the pin is read off
+        # the FOLLOWING token instead.
         assert detect("npm", "npx", ["-y", "exec@1.2"]) == "1.2"
+        assert detect("npm", "npx", ["-y", "exec", "pkg@1.2"]) is None
 
         # cargo: pins via a separate --version flag, both spellings.
         assert detect("cargo", "cargo", ["install", "srv", "--version", "1.0"]) == "1.0"

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -10,6 +10,8 @@ import pytest
 
 from pmcp.manifest.version_checker import (
     _digest_identity,
+    _docker_image_name,
+    _docker_image_tag,
     _parse_version,
     _semver_parse,
     _USER_AGENT,
@@ -74,7 +76,9 @@ class TestDetectPackageType:
 
     def test_npm_command(self) -> None:
         """Test detection with npm command picks first non-flag arg."""
-        # Note: npm exec is treated as package name since code doesn't special-case it
+        # `npm exec` IS special-cased now -- see TestPackageIdentityCollisions.
+        # This case has no subcommand at all, so the first non-flag token is
+        # the package either way.
         pkg_type, pkg_name = detect_package_type("npm", ["-y", "server-pkg"])
         assert pkg_type == "npm"
         assert pkg_name == "server-pkg"
@@ -168,6 +172,127 @@ class TestDetectPackageType:
         pkg_type, pkg_name = detect_package_type("npx", ["-y", "--quiet"])
         assert pkg_type == "unknown"
         assert pkg_name is None
+
+
+class TestPackageIdentityCollisions:
+    """Two different packages must never share one identity.
+
+    Consiliency/pmcp#180. 2.4.0's identity gate decides whether a cached
+    description still describes the configured package by comparing the NAMES
+    this module returns, so a name that is stable across two DIFFERENT packages
+    is not a cosmetic parsing wart -- `_same_package` reads it as a positive
+    confirmation and the freshness short-circuit serves the wrong package's
+    tool descriptions.
+
+    Every test here asserts INEQUALITY of a real pair, not a single expected
+    value. A value assertion passes against a parser that collapses both forms
+    onto some other shared name; only the inequality is falsified by the
+    collision itself. All of these are RED against the pre-fix parser, which
+    returned an equal name for each pair.
+
+    Scope: these are the two collisions Consiliency/pmcp#180 measured.
+    `docker run --env-file X <img>`, `--mount`, and `npm exec --package=<pkg>`
+    still collide (Consiliency/pmcp#182) -- a flag's VALUE being taken as the
+    package -- and that is deliberately not fixed here.
+    """
+
+    def test_docker_registry_host_port_distinguishes_images(self) -> None:
+        """`registry:5000/A` and `registry:5000/B` are different packages.
+
+        RED before the fix: the branch split on the FIRST colon, so both
+        returned `("docker", "registry")` -- the registry host, not an image.
+        """
+        old = detect_package_type("docker", ["run", "registry:5000/old-image"])
+        new = detect_package_type("docker", ["run", "registry:5000/new-image"])
+        assert old != new, (
+            "two different images on one host:port registry collapsed to a "
+            f"single identity: {old} == {new}"
+        )
+        assert old == ("docker", "registry:5000/old-image")
+        assert new == ("docker", "registry:5000/new-image")
+
+    def test_npm_exec_distinguishes_packages(self) -> None:
+        """`npm exec A` and `npm exec B` are different packages.
+
+        RED before the fix: with no subcommand skip the first non-flag token
+        was `exec`, so both returned `("npm", "exec")`.
+        """
+        old = detect_package_type("npm", ["exec", "old-pkg"])
+        new = detect_package_type("npm", ["exec", "new-pkg"])
+        assert old != new, (
+            f"two different npm exec packages collapsed: {old} == {new}"
+        )
+        assert old == ("npm", "old-pkg")
+        assert new == ("npm", "new-pkg")
+
+    def test_npm_x_alias_distinguishes_packages(self) -> None:
+        """`x` is npm's documented `exec` alias and must skip identically."""
+        old = detect_package_type("npm", ["x", "old-pkg"])
+        new = detect_package_type("npm", ["x", "new-pkg"])
+        assert old != new, f"npm x packages collapsed: {old} == {new}"
+        assert old == ("npm", "old-pkg")
+
+
+class TestDockerReferenceSplitting:
+    """`_docker_image_name` and `_docker_image_tag` are complements.
+
+    They must agree about where a reference divides. An identity gate compares
+    the name and pin detection reads the tag, so a divergence means the two
+    disagree about which package is configured. They are written as a pair for
+    this reason, the same way `_strip_npm_tag`/`_npm_tag` are.
+    """
+
+    @pytest.mark.parametrize(
+        "ref,name,tag",
+        [
+            # The #180 case: before the last `/`, a colon is a host:port.
+            ("registry:5000/old-image", "registry:5000/old-image", None),
+            ("localhost:5000/a/b:tag", "localhost:5000/a/b", "tag"),
+            # Ordinary tagged forms -- unchanged by the fix.
+            ("img:1.2", "img", "1.2"),
+            ("ghcr.io/org/img:v2", "ghcr.io/org/img", "v2"),
+            ("mcp/server:latest", "mcp/server", "latest"),
+            # No `/` at all: per the OCI grammar this really IS image
+            # `registry` tagged `5000`, so it must NOT change.
+            ("registry:5000", "registry", "5000"),
+            # Digests. `@` cannot appear in a name, so it is stripped FIRST --
+            # the colon inside `sha256:` belongs to the digest, and a rule that
+            # reached for the last colon would yield `img:1.2@sha256` here.
+            ("img@sha256:abc", "img", None),
+            ("img:1.2@sha256:abc", "img", "1.2"),
+            ("registry:5000/img@sha256:abc", "registry:5000/img", None),
+            # Degenerate.
+            ("myimage", "myimage", None),
+        ],
+    )
+    def test_name_and_tag_agree(self, ref: str, name: str, tag: str | None) -> None:
+        assert _docker_image_name(ref) == name
+        assert _docker_image_tag(ref) == tag
+
+
+class TestNpmSubcommandSkipFiresOnce:
+    """The npm subcommand skip must not eat real package names.
+
+    `i` and `exec` are genuine npm packages, so a skip that fired repeatedly --
+    the shape the docker branch uses for its own subcommands -- would resolve
+    these to `None`. And `npx` takes a package directly, so it must not skip
+    at all.
+    """
+
+    def test_npm_install_of_a_package_named_i(self) -> None:
+        assert detect_package_type("npm", ["install", "i"]) == ("npm", "i")
+
+    def test_npm_exec_of_a_package_named_exec(self) -> None:
+        assert detect_package_type("npm", ["exec", "exec"]) == ("npm", "exec")
+
+    def test_npx_does_not_skip_a_package_named_exec(self) -> None:
+        assert detect_package_type("npx", ["-y", "exec"]) == ("npm", "exec")
+
+    def test_npm_with_no_subcommand_still_finds_the_package(self) -> None:
+        assert detect_package_type("npm", ["-y", "server-pkg"]) == (
+            "npm",
+            "server-pkg",
+        )
 
 
 class TestCompareVersionsOrdering:

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -292,6 +292,27 @@ class TestNpmSubcommandSkipFiresOnce:
             "server-pkg",
         )
 
+    def test_a_leading_flag_does_not_consume_the_subcommand_skip(self) -> None:
+        """npm accepts global flags before the subcommand.
+
+        The skip is one-shot, so it must fire on the first non-flag token, not
+        the first argv token. Spending it on `--silent` would leave `exec` to
+        be read as the package -- reopening the #180 collapse for every form
+        that carries a leading flag.
+
+        This ordering was already correct but *unpinned*: swapping the flag
+        skip and the subcommand check passed the entire suite, because every
+        other test here puts the subcommand first (ah board review, adversarial
+        seat, reported as a surviving mutant).
+        """
+        old = detect_package_type("npm", ["--silent", "exec", "old-pkg"])
+        new = detect_package_type("npm", ["--silent", "exec", "new-pkg"])
+        assert old != new, (
+            f"a leading flag reopened the npm exec collapse: {old} == {new}"
+        )
+        assert old == ("npm", "old-pkg")
+        assert new == ("npm", "new-pkg")
+
 
 class TestCompareVersionsOrdering:
     """Detailed classification cases for `compare_versions`.

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -219,9 +219,7 @@ class TestPackageIdentityCollisions:
         """
         old = detect_package_type("npm", ["exec", "old-pkg"])
         new = detect_package_type("npm", ["exec", "new-pkg"])
-        assert old != new, (
-            f"two different npm exec packages collapsed: {old} == {new}"
-        )
+        assert old != new, f"two different npm exec packages collapsed: {old} == {new}"
         assert old == ("npm", "old-pkg")
         assert new == ("npm", "new-pkg")
 


### PR DESCRIPTION
Narrows **#180**. Deliberately does **not** close it — see *What this does not fix*.

2.4.0's identity gate decides whether a cached description still describes the configured package by comparing the *name* `detect_package_type` returns. A name that is stable across two **different** packages is therefore not a cosmetic parsing wart: `_same_package` reads it as a positive confirmation, and the freshness short-circuit goes on serving the wrong package's tool descriptions.

## Two causes, both closed

**Docker split on the first `:`** — so `registry:5000/old-image` and `registry:5000/new-image` both resolved to `registry`, the registry host rather than an image. A colon only introduces a tag in the final path segment; before the last `/` it is a `host:port`.

The correct rule already existed in the same module as `_docker_image_tag`, which is what pin detection uses. So the fix adds its **paired complement** `_docker_image_name` — same design as `_strip_npm_tag`/`_npm_tag` — rather than a second, divergent implementation. My first draft did write a second rule, and the board caught that it both regressed `img:1.2@sha256:abc` (→ `img:1.2@sha256`, where today's code correctly gives `img`) and disagreed with `_docker_image_tag` on that same input.

**npm subcommands were taken as the package** — `npm exec old-pkg` and `npm exec new-pkg` both resolved to `exec`. A leading subcommand is now skipped **once**, and for `npm` only:

- *once*, not repeatedly, because `i` and `exec` are real npm packages — a docker-style anywhere-loop turns `npm install i` and `npm exec exec` into `None`
- *npm only*, because `npx -y exec` genuinely names a package called `exec`
- `x` is included; without it `npm x` collides exactly as `npm exec` did

`_npm_package_arg` gains a **required** `command` parameter, not a defaulted one: a default would let one of the two shared call sites keep old behaviour silently while type-checking clean — the exact drift the shared scan exists to prevent.

## Two live defects found along the way

Neither is in #180; both fell out of the same shared-scan bugs.

- **A docker digest was reported as a version pin.** `img@sha256:abc` reported a pin of `abc` — a fragment of the digest — and `img:1.2@sha256:abc` reported `1.2@sha256:abc` rather than `1.2`.
- **A pin on an `npm exec` server was reported as unpinned.** `npm exec pkg@1.2` scanned to `exec`, which carries no version suffix, so a real pin was missed.

## What this does **not** fix

My plan asserted that docker's image-token *selection* was sound and only tag-stripping was broken. **The board falsified that.** Identity is still collapsed wherever a flag's *value* is taken as the package name — and these are ordinary forms:

```
docker run --env-file .env old-image / new-image     -> both ('docker', '.env')
docker run --mount type=bind,src=/a A / B            -> both ('docker', 'type=bind,...')
npm exec --package=old-pkg / new-pkg -- shared-bin   -> both ('npm', 'exec')
```

Tracked on **#182** (broadened for this), with **#183** for the more serious consequence: `update_server` builds `npx -y {parsed}@latest --help`, and `npx -y` installs without prompting, so a misparsed `npm run <script>` installs and executes a registry package.

## Verification

`2717 passed, 3 skipped, 0 failed`; ruff clean; mypy clean (42 files).

**Six mutants, each run against one test node alone** — never the class. A class-level run reddens on any member, so it cannot show the specific test is load-bearing; that is the hole two hollow tests shipped through in this repo's last two phases.

| mutant | kills |
|---|---|
| docker → `raw.split(":")[0]` | the docker collision test |
| `skip_subcommand = False` | both npm collision tests |
| skip fires repeatedly | both real-package-name tests |
| digest not stripped first | **only** the 2 digest cases, 8 others green |
| pin site → `_npm_package_arg(args, "npx")` | the pin matrix |
| `_docker_image_tag` stops stripping digest | the pin matrix |

The last two are what pin the helpers as complements: each half has its own mutant, so a divergence cannot pass silently.

Collision tests assert **inequality** of real pairs rather than single expected values — a value assertion passes against a parser that collapses both forms onto some other shared name.

## Migration

Affected servers refresh **once**: a docker server on a `host:port` registry or an `npm exec` server now has a different package identity than its cache recorded, so that entry fails the identity check once and regenerates. Same one-time migration 2.4.0's `package_type` addition caused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbREMUsxgJ8TDBLpJ56PWb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790282235&installation_model_id=427051&pr_number=184&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F184&signature=71242e0ca44f025c6faedc90ad3135677acede1c20ab320e953bd462d9f04d67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->