### PR TITLE
fix(update): refuse to probe when no package identity is recoverable (closes #183)

### DIFF
--- a/.consiliency/evidence/mutation-183.md
+++ b/.consiliency/evidence/mutation-183.md
@@ -1,0 +1,63 @@
+# Mutation evidence — Consiliency/pmcp#183
+
+Protocol: `src/**/__pycache__` purged and `PYTHONDONTWRITEBYTECODE=1` on every
+apply/restore, per the tooling note in `mutation-180.md`. Stale bytecode
+fabricated a false RED during #184 and can equally fabricate a false GREEN.
+
+## 1. The refusal removed (the #183 defect itself)
+
+    FAILED ...::TestUpdateServerVersionRepair::test_update_server_never_probes_a_script_name
+    1 failed in 2.06s
+
+The test asserts **no probe was executed**, not merely that the parse changed.
+The correctness seat independently reproduced this end-to-end on a copy by
+reverting `version_checker.py` to main, and captured what the defect actually
+produces:
+
+    UpdateServerOutput(ok=True, ...,
+      message="Updated and restarted 'scripted' (npm:mcp); the new version is now active.")
+
+Fabricated success, plus `npx -y mcp@latest` installed and run from the public
+registry. That is the whole issue in one line of output.
+
+## 2. Allowlist reverted to the denylist that shipped first
+
+    FAILED ...::test_a_subcommand_without_a_package_operand_fails_closed[args9]
+    FAILED ...::test_a_subcommand_without_a_package_operand_fails_closed[args10]
+    5 failed, 9 passed, 136 deselected in 0.33s
+
+**This is the mutant that mattered, and the first implementation did not kill
+it.** The original fix denied `run` and `create` only, so everything else fell
+through as an installable package name:
+
+    npm start        -> ('npm', 'start')      -> npx -y start@latest
+    npm test         -> ('npm', 'test')       -> npx -y test@latest
+    npm run-script X -> ('npm', 'run-script') -> npx -y run-script@latest
+    npm init foo     -> ('npm', 'init')       -> npx -y init@latest
+    npm rum mcp      -> ('npm', 'rum')        -> npx -y rum@latest   (a TYPO)
+
+Every one of those names resolves on registry.npmjs.org. All three CLI seats
+plus the correctness seat found this independently and all four recommended the
+same repair: invert to an allowlist.
+
+The design lesson is the reusable part. A denylist **fails open**, which is
+backwards for a fix whose purpose is preventing unintended execution: the cost
+of omitting an entry is arbitrary package execution, while the cost of an
+over-broad allowlist is only that an unusual launch form cannot be
+auto-updated. I had closed the two forms the issue named and left the class
+open -- treating the issue's examples as the specification.
+
+Two related errors worth recording:
+
+* `run-script` is npm's **canonical** command; `run` is the alias. I fixed the
+  alias and missed the real name.
+* `init` is the alias of `create`, and I fixed only `create`.
+
+## Pre-existing tests inverted, not weakened
+
+`test_npm_command` and `test_npm_with_no_subcommand_still_finds_the_package`
+both asserted `npm -y server-pkg` -> `server-pkg`. That is not a legal npm
+invocation (npm requires a subcommand), so those assertions had encoded the
+parser's old permissiveness -- the general form of this very defect. They are
+now inverted, with the reason in their docstrings, rather than the guard being
+relaxed to keep them green.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **`gateway.update_server` no longer installs and executes a registry package
+  derived from a misparsed command.** The update probe is built from the parsed
+  package name — `npx -y {name}@latest --help` — and `npx -y` installs without
+  prompting. A server configured as `npm run mcp` names a **script** in the
+  local `package.json`, not a registry package, but the parser returned it as
+  one, so pmcp fetched and ran whatever occupied that name on the public
+  registry. Short generic script names (`run`, `start`, `dev`, `mcp`) are
+  exactly the kind that can be registered and waited on.
+
+  `npm run <script>` and `npm create <initializer>` now report **no recoverable
+  package identity** rather than a wrong one, and `update_server` refuses on
+  that before constructing any probe — the same rule the identity gate follows:
+  cannot confirm, so do not act on a guess. (`npm create foo` was wrong in a
+  second way: npm resolves it to the package `create-foo`, so `foo` named a
+  different package than the one npm would run.)
+
+  Reaching this required a server configured with an affected form **and** an
+  operator invoking `gateway.update_server` on it; it was not remotely
+  triggerable. `npx -y run` still resolves normally — the refusal is scoped to
+  npm subcommands whose operand is not a package, not to those names.
+
 ### Fixed
 - **Two different packages no longer share one identity for common `docker` and
   `npm` command forms.** 2.4.0's identity gate decides whether a cached

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registry. Short generic script names (`run`, `start`, `dev`, `mcp`) are
   exactly the kind that can be registered and waited on.
 
-  `npm run <script>` and `npm create <initializer>` now report **no recoverable
-  package identity** rather than a wrong one, and `update_server` refuses on
-  that before constructing any probe — the same rule the identity gate follows:
-  cannot confirm, so do not act on a guess. (`npm create foo` was wrong in a
-  second way: npm resolves it to the package `create-foo`, so `foo` named a
-  different package than the one npm would run.)
+  npm package detection is now an **allowlist**: only `exec`, `x`, `install`,
+  `i`, `add` and `dlx` put a registry package in the next position. Every other
+  subcommand — `run`, `start`, `test`, `stop`, `restart`, `run-script`, `init`,
+  `create` — and every misspelling of one reports **no recoverable package
+  identity**, and `update_server` refuses on that before constructing any
+  probe. That is the same rule the identity gate follows: cannot confirm, so do
+  not act on a guess.
+
+  An allowlist rather than a denylist of script runners, because the
+  consequence of being wrong is asymmetric: failing closed costs only the
+  ability to auto-update a server launched by an unusual form, while failing
+  open costs arbitrary package execution. (`npm create foo` also shows why
+  synthesising a name is not safe: npm resolves it to the package `create-foo`,
+  so `foo` names a *different* package than the one npm would run.)
 
   Reaching this required a server configured with an affected form **and** an
   operator invoking `gateway.update_server` on it; it was not remotely

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -54,31 +54,38 @@ def _npm_tag(package: str) -> str | None:
     return tag if tag_sep and _name else None
 
 
-_NPM_SUBCOMMANDS = frozenset(
-    {"exec", "x", "run", "install", "i", "add", "create", "dlx"}
+# npm subcommands whose operand IS a registry package name -- an ALLOWLIST.
+#
+# This is deliberately an allowlist and not a denylist of script-running
+# subcommands, because the consequence of being wrong is asymmetric.
+# gateway.update_server builds its probe from whatever name comes back --
+# `npx -y {name}@latest --help` -- and `npx -y` INSTALLS WITHOUT PROMPTING
+# (Consiliency/pmcp#183). So an unrecognised subcommand that falls through as
+# a package name gets fetched and executed from the public registry.
+#
+# A denylist shipped first and was wrong for exactly that reason (ah board
+# review, red-team seat): with only `run` and `create` denied, `npm start`,
+# `npm test`, `npm stop`, `npm restart`, `npm run-script mcp` and `npm init foo`
+# all still resolved to packages named after the SUBCOMMAND -- and so did
+# typos like `npm rum mcp`. Every npm subcommand that is not listed below, and
+# every misspelling of one, would have been installed and run.
+#
+# Failing closed costs only the ability to auto-update a server launched by an
+# unusual form; failing open costs arbitrary package execution. Adding a
+# subcommand here is a deliberate act that says "the token after this really is
+# a registry package".
+_NPM_SUBCOMMANDS_WITH_A_PACKAGE_OPERAND = frozenset(
+    {"exec", "x", "install", "i", "add", "dlx"}
 )
 
-# npm subcommands whose operand is NOT a registry package name.
-#
-# `npm run <script>` runs a script defined in the local package.json -- the
-# token is a script name, and there is generally no registry package by that
-# name at all. Returning it as a package makes gateway.update_server build
-# `npx -y <script>@latest --help` and, because `npx -y` installs without
-# prompting, INSTALL AND EXECUTE whatever happens to occupy that name on the
-# public registry (Consiliency/pmcp#183). Short generic script names -- `run`,
-# `start`, `dev`, `mcp` -- are exactly the kind an attacker can register and
-# wait on.
-#
-# `npm create <initializer>` is also not a direct name: `npm create foo`
-# resolves to the package `create-foo`, so reporting `foo` names a DIFFERENT
-# package than the one npm would run.
-#
-# For both, the honest answer is that identity cannot be recovered from the
-# command line, which is what `("unknown", None)` means. update_server already
-# refuses cleanly on that (handlers.py, the `package_type == "unknown"` guard)
-# rather than guessing -- the same rule the identity gate follows: cannot
-# confirm -> do not act on a guess.
-_NPM_SUBCOMMANDS_WITHOUT_A_PACKAGE_OPERAND = frozenset({"run", "create"})
+# Retained under its historical name for the skip logic below: the operand of a
+# subcommand NOT in the allowlist is not a package, so identity is
+# unrecoverable and `("unknown", None)` is the honest answer -- the same rule
+# the identity gate follows, cannot confirm -> do not act on a guess.
+# `npm create foo` is a good illustration of why synthesising is not safe
+# either: npm resolves it to the package `create-foo`, so `foo` names a
+# DIFFERENT package than the one npm would run.
+_NPM_SUBCOMMANDS = _NPM_SUBCOMMANDS_WITH_A_PACKAGE_OPERAND
 
 
 def _npm_package_arg(args: list[str], command: str) -> str | None:
@@ -130,15 +137,20 @@ def _npm_package_arg(args: list[str], command: str) -> str | None:
             # Only the first non-flag token can be the subcommand; whatever
             # follows is a candidate package even if it repeats the word.
             skip_subcommand = False
-            if arg in _NPM_SUBCOMMANDS_WITHOUT_A_PACKAGE_OPERAND:
-                # `npm run <script>` / `npm create <initializer>`: whatever
-                # follows is NOT a registry package name, so there is no
-                # package identity to recover here. Say so (None -> "unknown")
-                # instead of handing back a script name that a caller would
-                # install and execute (Consiliency/pmcp#183).
-                return None
-            if arg in _NPM_SUBCOMMANDS:
+            if arg in _NPM_SUBCOMMANDS_WITH_A_PACKAGE_OPERAND:
                 continue
+            # ANY other subcommand -- `run`, `start`, `test`, `init`,
+            # `run-script`, or a typo like `rum` -- does not put a registry
+            # package in the next position, so there is no identity to
+            # recover. Fail CLOSED (None -> "unknown") rather than handing
+            # back a token that gateway.update_server would install and
+            # execute via `npx -y` (Consiliency/pmcp#183).
+            #
+            # Note this refuses the subcommand form even when the FIRST token
+            # is itself a plausible package name: `npm somepkg` is not a legal
+            # npm invocation anyway (npm requires a subcommand), so nothing
+            # real is lost.
+            return None
         # Found package name (might have @version or @dist-tag suffix)
         pkg = _strip_npm_tag(arg)
         # Handle scoped packages like @playwright/mcp

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -58,6 +58,28 @@ _NPM_SUBCOMMANDS = frozenset(
     {"exec", "x", "run", "install", "i", "add", "create", "dlx"}
 )
 
+# npm subcommands whose operand is NOT a registry package name.
+#
+# `npm run <script>` runs a script defined in the local package.json -- the
+# token is a script name, and there is generally no registry package by that
+# name at all. Returning it as a package makes gateway.update_server build
+# `npx -y <script>@latest --help` and, because `npx -y` installs without
+# prompting, INSTALL AND EXECUTE whatever happens to occupy that name on the
+# public registry (Consiliency/pmcp#183). Short generic script names -- `run`,
+# `start`, `dev`, `mcp` -- are exactly the kind an attacker can register and
+# wait on.
+#
+# `npm create <initializer>` is also not a direct name: `npm create foo`
+# resolves to the package `create-foo`, so reporting `foo` names a DIFFERENT
+# package than the one npm would run.
+#
+# For both, the honest answer is that identity cannot be recovered from the
+# command line, which is what `("unknown", None)` means. update_server already
+# refuses cleanly on that (handlers.py, the `package_type == "unknown"` guard)
+# rather than guessing -- the same rule the identity gate follows: cannot
+# confirm -> do not act on a guess.
+_NPM_SUBCOMMANDS_WITHOUT_A_PACKAGE_OPERAND = frozenset({"run", "create"})
+
 
 def _npm_package_arg(args: list[str], command: str) -> str | None:
     """Return the raw npm/npx package token from *args*, or ``None``.
@@ -108,6 +130,13 @@ def _npm_package_arg(args: list[str], command: str) -> str | None:
             # Only the first non-flag token can be the subcommand; whatever
             # follows is a candidate package even if it repeats the word.
             skip_subcommand = False
+            if arg in _NPM_SUBCOMMANDS_WITHOUT_A_PACKAGE_OPERAND:
+                # `npm run <script>` / `npm create <initializer>`: whatever
+                # follows is NOT a registry package name, so there is no
+                # package identity to recover here. Say so (None -> "unknown")
+                # instead of handing back a script name that a caller would
+                # install and execute (Consiliency/pmcp#183).
+                return None
             if arg in _NPM_SUBCOMMANDS:
                 continue
         # Found package name (might have @version or @dist-tag suffix)

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -5038,13 +5038,23 @@ class GatewayTools:
 
         package_type, package_name = detect_package_type(command, args)
         if package_type == "unknown" or not package_name:
+            # Name the actual command line. Without it, a server launched as
+            # `npm run mcp` reads "could not determine package manager" and
+            # then "Supported managers: npm (npx)" -- which looks like a
+            # contradiction, since npm plainly IS supported. The real reason is
+            # narrower: that command line names no *registry package* to update
+            # (a package.json script is not one), so there is nothing for this
+            # tool to fetch (ah board review, correctness seat).
+            invocation = " ".join([command, *args]).strip() if command else ""
+            detail = f" from `{invocation}`" if invocation else ""
             return UpdateServerOutput(
                 ok=False,
                 server=server_name,
                 package_type="unknown",
                 message=(
-                    f"Could not determine package manager for '{server_name}'. "
-                    "Supported managers: npm (npx), pypi (uvx/pip), cargo, docker."
+                    f"Could not determine a registry package to update for "
+                    f"'{server_name}'{detail}. Supported managers: npm (npx), "
+                    "pypi (uvx/pip), cargo, docker."
                 ),
             )
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4839,6 +4839,57 @@ class TestUpdateServerVersionRepair:
         monkeypatch.setattr("pmcp.tools.handlers.load_configs", lambda **_: [])
         return manifest
 
+    @pytest.mark.asyncio
+    async def test_update_server_never_probes_a_script_name(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """`npm run <script>` must not become an installed registry package.
+
+        Consiliency/pmcp#183. `update_server` builds its probe from the parsed
+        package name -- `npx -y {name}@latest --help` -- and `npx -y` installs
+        without prompting. A `npm run mcp` server names a SCRIPT in the local
+        package.json, not a registry package, so parsing it as one made pmcp
+        install and execute whatever occupied that name on the public registry.
+        Short generic script names (`run`, `start`, `dev`, `mcp`) are exactly
+        what an attacker can register and wait on.
+
+        The fix is to recover no identity at all rather than a wrong one:
+        `detect_package_type` returns `("unknown", None)`, which the existing
+        guard refuses on before any probe is constructed. This test asserts the
+        *consequence* -- that nothing is executed -- not merely the parse,
+        because the parse being right is only useful if it reaches the refusal.
+        """
+        manifest = self._make_manifest_with_playwright(monkeypatch)
+        manifest.servers["scripted"] = ServerConfig(
+            name="scripted",
+            description="Runs a package.json script",
+            keywords=[],
+            install={},
+            command="npm",
+            args=["run", "mcp"],
+            requires_api_key=False,
+        )
+        gt = GatewayTools(
+            client_manager=MockClientManager(),  # type: ignore
+            policy_manager=PolicyManager(),
+        )
+
+        probes: list[list[str]] = []
+
+        async def _record_probe(cmd, env=None):
+            probes.append(cmd)
+            return (True, "ok")
+
+        monkeypatch.setattr(gt, "_run_update_probe_command", _record_probe)
+
+        result = await gt.update_server({"server_name": "scripted"})
+
+        assert result.ok is False
+        assert probes == [], (
+            "update_server executed a probe built from a package.json SCRIPT "
+            f"name -- `npx -y mcp@latest` would install from the registry: {probes}"
+        )
+
     def _make_cache(self, version: str = "0.1.0") -> DescriptionsCache:
         return DescriptionsCache(
             generated_at="2024-01-01T00:00:00",

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4885,6 +4885,11 @@ class TestUpdateServerVersionRepair:
         result = await gt.update_server({"server_name": "scripted"})
 
         assert result.ok is False
+        # The refusal must name the command line. Without it the message reads
+        # "could not determine package manager ... Supported managers: npm" --
+        # a contradiction from the user's side, since npm IS supported. The
+        # real reason is that this command line names no registry package.
+        assert "npm run mcp" in result.message
         assert probes == [], (
             "update_server executed a probe built from a package.json SCRIPT "
             f"name -- `npx -y mcp@latest` would install from the registry: {probes}"

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -292,6 +292,47 @@ class TestNpmSubcommandSkipFiresOnce:
             "server-pkg",
         )
 
+    def test_npm_run_names_a_script_not_a_package(self) -> None:
+        """`npm run <script>` has no recoverable package identity.
+
+        Consiliency/pmcp#183. The operand is a script in the local
+        package.json, so there is generally no registry package by that name.
+        Returning it as one made gateway.update_server build
+        `npx -y <script>@latest --help` -- and `npx -y` installs without
+        prompting, so pmcp installed and executed whatever occupied that name
+        on the public registry.
+
+        `("unknown", None)` is the honest answer, and update_server already
+        refuses on it before constructing any probe.
+        """
+        assert detect_package_type("npm", ["run", "mcp"]) == ("unknown", None)
+        assert detect_package_type("npm", ["run", "start"]) == ("unknown", None)
+        # ...including when a global flag precedes the subcommand.
+        assert detect_package_type("npm", ["--silent", "run", "mcp"]) == (
+            "unknown",
+            None,
+        )
+
+    def test_npm_create_operand_is_not_the_package_npm_would_run(self) -> None:
+        """`npm create foo` resolves to the package `create-foo`, not `foo`.
+
+        Reporting `foo` names a DIFFERENT package than the one npm runs, which
+        is the same wrong-identity hazard as the script case.
+        """
+        assert detect_package_type("npm", ["create", "foo"]) == ("unknown", None)
+
+    def test_npx_can_still_run_packages_named_run_or_create(self) -> None:
+        """The refusal is npm-subcommand-scoped, not a name blocklist.
+
+        `npx -y run` names a real registry package called `run`; nothing about
+        Consiliency/pmcp#183 should make that unresolvable.
+        """
+        assert detect_package_type("npx", ["-y", "run"]) == ("npm", "run")
+        assert detect_package_type("npx", ["-y", "create"]) == ("npm", "create")
+        # And the operand position is still a package for the other
+        # subcommands -- only `run`/`create` name something else.
+        assert detect_package_type("npm", ["exec", "run"]) == ("npm", "run")
+
     def test_a_leading_flag_does_not_consume_the_subcommand_skip(self) -> None:
         """npm accepts global flags before the subcommand.
 

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -75,13 +75,23 @@ class TestDetectPackageType:
         assert pkg_name == "my-mcp-server"
 
     def test_npm_command(self) -> None:
-        """Test detection with npm command picks first non-flag arg."""
-        # `npm exec` IS special-cased now -- see TestPackageIdentityCollisions.
-        # This case has no subcommand at all, so the first non-flag token is
-        # the package either way.
-        pkg_type, pkg_name = detect_package_type("npm", ["-y", "server-pkg"])
+        """`npm` reads its package from an allowlisted subcommand's operand.
+
+        This test previously asserted `npm -y server-pkg` -> `server-pkg`.
+        That is not a legal npm invocation -- npm requires a subcommand -- and
+        the assertion encoded the parser's old permissiveness: the first
+        non-flag token was taken as a package whatever it was, which is the
+        Consiliency/pmcp#183 hazard (`npm run mcp` -> package `mcp`, then
+        installed and executed via `npx -y`). A bare token now fails closed;
+        the real form is exercised here instead.
+        """
+        pkg_type, pkg_name = detect_package_type("npm", ["exec", "-y", "server-pkg"])
         assert pkg_type == "npm"
         assert pkg_name == "server-pkg"
+
+    def test_npm_without_a_subcommand_is_not_a_package(self) -> None:
+        """A bare `npm <token>` is not legal npm, so no identity is claimed."""
+        assert detect_package_type("npm", ["-y", "server-pkg"]) == ("unknown", None)
 
     def test_uvx_simple_package(self) -> None:
         """Test detection of uvx (PyPI) package."""
@@ -286,11 +296,15 @@ class TestNpmSubcommandSkipFiresOnce:
     def test_npx_does_not_skip_a_package_named_exec(self) -> None:
         assert detect_package_type("npx", ["-y", "exec"]) == ("npm", "exec")
 
-    def test_npm_with_no_subcommand_still_finds_the_package(self) -> None:
-        assert detect_package_type("npm", ["-y", "server-pkg"]) == (
-            "npm",
-            "server-pkg",
-        )
+    def test_npm_without_a_subcommand_yields_no_identity(self) -> None:
+        """Renamed and inverted from ..._still_finds_the_package.
+
+        `npm -y server-pkg` is not a legal npm invocation, and treating its
+        first token as a package is the Consiliency/pmcp#183 hazard in general
+        form. The allowlist now requires a recognised subcommand before
+        anything is read as a package.
+        """
+        assert detect_package_type("npm", ["-y", "server-pkg"]) == ("unknown", None)
 
     def test_npm_run_names_a_script_not_a_package(self) -> None:
         """`npm run <script>` has no recoverable package identity.
@@ -312,6 +326,52 @@ class TestNpmSubcommandSkipFiresOnce:
             "unknown",
             None,
         )
+
+    @pytest.mark.parametrize(
+        "args",
+        [
+            # script runners
+            ["run", "mcp"],
+            ["run-script", "mcp"],
+            ["start"],
+            ["test"],
+            ["stop"],
+            ["restart"],
+            # initializers (npm resolves `init foo`/`create foo` to create-foo)
+            ["init", "foo"],
+            ["create", "foo"],
+            # TYPOS and anything else unrecognised -- the allowlist is what
+            # makes these safe. Under the denylist that shipped first, every
+            # one of these resolved to a package named after the subcommand
+            # and would have been installed and executed.
+            ["rum", "mcp"],
+            ["urn", "mcp"],
+            ["innit", "foo"],
+            ["publish"],
+            ["audit"],
+            # ...and with a global flag in front.
+            ["--silent", "run", "mcp"],
+        ],
+    )
+    def test_a_subcommand_without_a_package_operand_fails_closed(
+        self, args: list[str]
+    ) -> None:
+        """Anything outside the allowlist yields no identity at all.
+
+        Consiliency/pmcp#183. `gateway.update_server` builds `npx -y
+        {name}@latest --help` from whatever comes back, and `npx -y` installs
+        without prompting -- so a subcommand that falls through as a package
+        name gets fetched and run from the public registry.
+
+        This is an ALLOWLIST, not a denylist of script runners. A denylist
+        shipped first and was wrong: with only `run` and `create` denied,
+        `npm start`, `npm test`, `npm run-script mcp`, `npm init foo` and
+        typos like `npm rum mcp` all still resolved to packages named after the
+        subcommand (ah board review, red-team seat). Failing closed costs only
+        the ability to auto-update an unusual launch form; failing open costs
+        arbitrary package execution.
+        """
+        assert detect_package_type("npm", args) == ("unknown", None)
 
     def test_npm_create_operand_is_not_the_package_npm_would_run(self) -> None:
         """`npm create foo` resolves to the package `create-foo`, not `foo`.


### PR DESCRIPTION
Closes **#183**.

## The defect

`gateway.update_server` builds its update probe from the parsed package name — `npx -y {name}@latest --help` — and **`npx -y` installs without prompting**.

A server configured as `npm run mcp` names a **script** in the local `package.json`, not a registry package. The parser returned it as one, so pmcp fetched and executed whatever occupied that name on the public npm registry. Short generic script names — `run`, `start`, `dev`, `mcp` — are exactly the kind someone can register and wait on.

Reaching this needed a server configured with an affected form **and** an operator invoking `update_server` on it; it was not remotely triggerable. But the failure mode is arbitrary package installation and execution, not a mislabelled cache entry.

## The fix is in the parser, not at the execution site

`handlers.py:5040` **already** refuses cleanly on `("unknown", None)`, before any probe is constructed. The defect was that `npm run mcp` never reached that guard, because the parser handed back a plausible-looking name.

So `npm run <script>` and `npm create <initializer>` now report **no recoverable package identity**, and the existing refusal does the rest — the same rule the identity gate follows: *cannot confirm, so do not act on a guess*. Adding a second guard at the probe site would have been a divergent check for the same property, and this repo has spent three phases paying for divergent implementations of one rule.

**`npm create` was wrong in a second way the issue didn't record:** npm resolves `npm create foo` to the package **`create-foo`**, so returning `foo` named a genuinely different package than the one npm would run.

## Scoped to subcommands, not to names

| refuses | unchanged |
|---|---|
| `npm run mcp` | `npx -y run` → `run` |
| `npm run start` | `npx -y create` → `create` |
| `npm create foo` | `npm exec run` → `run` |
| `npm --silent run mcp` | all 8 other real-package forms |

`run` is a real npm package; nothing here should make `npx -y run` unresolvable. The refusal keys on the *subcommand position*, not on the token.

## Verification

`2722 passed, 3 skipped, 0 failed`; ruff clean; mypy clean — with `__pycache__` purged and `PYTHONDONTWRITEBYTECODE=1`, per the tooling note in `.consiliency/evidence/mutation-180.md` (stale bytecode fabricated both a false red and, potentially, a false green during #184).

**The end-to-end test asserts no probe was executed**, not merely that the parse changed — the parse being right only matters if it reaches the refusal. Mutation-proved: removing the refusal fails that test.

```
=== MUTANT: script-name refusal removed (the #183 defect) ===
FAILED tests/test_tools.py::...::test_update_server_never_probes_a_script_name
1 failed in 2.06s
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbREMUsxgJ8TDBLpJ56PWb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790288414&installation_model_id=427051&pr_number=185&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F185&signature=1a2821211192d3e0db9c5a62906954cde936c3063109a3716d0912e9ff4c5c42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->