### PR TITLE
chore: v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.1] - 2026-08-25
+
 ### Security
 - **`gateway.update_server` no longer installs and executes a registry package
   derived from a misparsed command.** The update probe is built from the parsed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "2.4.0"
+version = "2.4.1"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "2.4.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release cut for 2.4.1. Version bump only — no source behaviour changes in this PR.

Carries two merged, unreleased fixes.

## #183 — security (#185)

`gateway.update_server` built its update probe from the parsed package name — `npx -y {name}@latest --help` — and **`npx -y` installs without prompting**. A server configured as `npm run mcp` names a **script** in the local `package.json`, so pmcp fetched and executed whatever occupied `mcp` on the public npm registry.

npm package detection is now an **allowlist** (`exec`, `x`, `install`, `i`, `add`, `dlx`). Every other subcommand — `run`, `start`, `test`, `run-script`, `init`, `create`, and typos like `rum` — yields no recoverable identity, and `update_server` refuses before constructing a probe.

The first cut of this fix was a *denylist* of `run`/`create`, which failed open; all four board seats found that independently and all four recommended the inversion.

## #180 — narrowed (#184)

- **Docker split on the first `:`** — `registry:5000/old-image` and `registry:5000/new-image` both read as the image `registry`.
- **npm subcommands were taken as the package** — `npm exec old-pkg` and `npm exec new-pkg` both read as `exec`.

Both closed, plus two live defects found along the way: a docker digest was reported as a **version pin fragment**, and a pin on an `npm exec` server was reported as **unpinned**.

## Why patch, not minor

No API or schema change. Two user-visible consequences, both documented:

- Affected servers refresh their cached descriptions **once** — their package identity now parses differently than the cache recorded.
- A server launched via a non-package npm subcommand can no longer be auto-updated. That path never worked: it installed an unrelated registry package, touched none of the server's code, and reported success.

## Still open

**#180 is deliberately not closed.** Identity is still collapsed wherever a flag's *value* is taken as the package name — `docker run --env-file X <image>`, `--mount`, `npm exec --package=`, and the `uvx`/`pip`/`cargo` equivalents. Tracked on **#182**.

## Verification

`2737 passed, 3 skipped, 0 failed`; ruff clean; mypy clean. Release-note extraction dry-run with the workflow's own awk: 82 lines, two unique `###` headings, terminates cleanly before the 2.4.0 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbREMUsxgJ8TDBLpJ56PWb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790289826&installation_model_id=427051&pr_number=186&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F186&signature=a745e323b068fd8747b1341baf6260f7f860d22427da3793d44bac12fb210597"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->