### PR TITLE
fix(ci): give every workflow job a timeout (closes #187)

### DIFF
--- a/.consiliency/evidence/bypass-proofs-187.md
+++ b/.consiliency/evidence/bypass-proofs-187.md
@@ -1,0 +1,63 @@
+# Acceptance-test bypass proofs — Consiliency/pmcp#187
+
+The first version of this plan's acceptance test had three bypasses, all found
+by the advisor board's correctness seat and all reproduced empirically before
+being acted on. Each is recorded with the original (exit 0, wrongly passing)
+and hardened (exit 1) result.
+
+The general shape: **a check that only asserts presence proves almost nothing.**
+This is the fifth round in this repo where a check I wrote looked adequate and
+was not, three of those written immediately after documenting that exact
+failure mode.
+
+## A. `.yaml` extension escapes the glob
+
+Original globbed `*.yml` only. GitHub runs both extensions.
+
+    original : missing: none                          EXIT=0   <- WRONG
+    hardened : ['sneaky.yaml:unbounded -> None']      EXIT=1
+
+## B. Presence checked, value not
+
+`timeout-minutes: "not a number"` passed. So did `timeout-minutes: 360` --
+which **re-creates the six-hour default this issue exists to fix** while
+satisfying the test.
+
+    original : missing: none                          EXIT=0   <- WRONG
+    hardened : ['release.yml:build -> 360']           EXIT=1
+
+Hardened form asserts `isinstance(v, int) and not isinstance(v, bool) and
+1 <= v <= 30`, and skips jobs with `uses:` (a reusable-workflow call cannot
+carry `timeout-minutes`, so requiring one there would force invalid YAML).
+
+## C. A job silently deleted still passes
+
+Over-indenting `publish:` makes it parse as a key *inside* `build`'s mapping.
+The YAML is valid, `jobs` becomes `[build, github-release]`, and the presence
+check passes because every *surviving* job has a timeout. The publish job is
+simply gone.
+
+    original : jobs [build, github-release], missing: none   EXIT=0   <- WRONG
+    hardened : release.yml: [build, github-release, publish]
+                         -> [build, github-release]          EXIT=1
+
+**This is the one that mattered.** The plan claimed "the real proof is CI
+itself" -- false for `release.yml`, which triggers only on tag push and never
+appears in PR checks. A mangled release.yml would have surfaced at the next tag
+push, as a broken release. The hardened check compares job-name sets against
+`main` and **fails** rather than printing.
+
+## Also corrected
+
+Live `test (3.10)` p100 is **5.30m** (measured over 5 runs), not the 4-5m the
+plan's table recorded. The plan's own acceptance criterion ("each value >= 4x
+observed") was therefore falsified by its own value of 20 on day one. Raised to
+25.
+
+## Why actionlint is mandatory here, not optional
+
+`release.yml` cannot be exercised pre-merge -- it triggers only on tag push --
+so actionlint is the *only* Actions-schema validation on the release path
+before a tag is cut. The plan's original invocation was also fail-open
+(`command -v actionlint && actionlint ... || echo skipped` swallows a non-zero
+actionlint into the `||` branch), which is the same defect class as B above.

--- a/.consiliency/evidence/bypass-proofs-187.md
+++ b/.consiliency/evidence/bypass-proofs-187.md
@@ -122,3 +122,74 @@ Check #1 skips jobs carrying `uses:` (a reusable-workflow call cannot take
 the exemption is currently untested against real input. It is correct to have --
 without it, a future `uses:` job would force invalid YAML to satisfy the check --
 but it would silently exempt any future job that gains a `uses:` key.
+
+---
+
+## Implementation-board round: check 0, and seven mutants the others miss
+
+Four seats on the code. grok AGREE, gemini AGREE, codex DISAGREE, fable
+PARTIALLY AGREE. Two findings were live; both are now closed.
+
+### The plan shipped the PROVEN-WEAK verification block
+
+Both dissenting seats found the same thing, and it is the sharpest finding of
+the round: this PR's *plan* still carried check #1 as `glob("*.yml")`
+presence-only, check #2 as print-only, and `actionlint` with the extension gap
+— **the exact three bypasses this evidence file proves are exploitable**, sitting
+one file away. The PR would have shipped the weak script as the canonical
+runnable procedure while the proof of its weakness travelled beside it.
+
+Fixed: the plan's Verification block is replaced with the hardened forms, with a
+note forbidding reintroduction of the weak variants, and its stale table row
+(`test` → 20, "4–5m") corrected to 25 / 5.35m p100.
+
+### Check 0 — audit the diff SHAPE — is stronger than 1–3 combined
+
+The correctness seat's contribution, and it changes what this change is guarded
+by. Checks 1–3 cover exactly *{job-name set} × {timeout presence and value}*.
+Every other byte of `release.yml` is unguarded. Seven mutants pass all three:
+
+| mutant | consequence |
+|---|---|
+| `environment: release` dropped | silent; publish runs unprotected |
+| `needs: publish` → `needs: build` | silent; GH release no longer gated on PyPI |
+| tag pattern `"v*"` → `"V*"` | **silent forever** — no run, so no red X ever |
+| `on:` tags filter deleted | fires on every branch push |
+| publish `needs: build` dropped | loud, but next-tag-only |
+| `build` 20 → 3 (below p100) | job killed on next tag push |
+| `maintenance.yml` deleted outright | c3, one level up |
+
+The tag-pattern case is the worst and is precisely #187's motivating failure:
+corrupt the pattern and **nothing runs at all**, so unlike a broken job there is
+never a red X to notice.
+
+Verified here: check 0 (`every changed line matches ^\+\s+timeout-minutes: \d+$,
+nothing removed`) **catches all three** of the silent release.yml mutants that
+checks 1–3 miss. It is now the first check in the plan, and it subsumes 1 and 2
+for a purely-additive change like this one.
+
+### Floor raised 1 → 10
+
+The red-team seat found that accepting any int in 1..30 leaves a live mutant:
+`build` 20 → 1 passes the predicate, preserves the job set, and passes
+actionlint, while killing a 4m10s job after one minute. Verified. The floor now
+matches the plan's own stated sizing rule ("floored at 10 minutes"), and every
+delivered value is ≥10, so the constraint is consistent with the change today.
+
+    build 20 -> 1, floor 10:  ['release.yml:build -> 1']  exit 1
+
+### CI evidence, the criterion that could not be checked pre-push
+
+Now satisfied: PR #188 reports **11/11 green**, and its check-name set is
+**identical** to a `main` PR's (diffed against #186) — so no job was silently
+disabled. Live durations under the new caps: `test` legs 3–4m against 25,
+everything else <1m against 10.
+
+### Known and deliberately not fixed here
+
+None of these checks runs in CI — they were executed by hand against this diff,
+so a future PR touching `release.yml` inherits no protection. A persistent guard
+(an `actionlint` job plus a release.yml drift check against the merge base)
+belongs in its own issue, not appended untested to this one. The `uses:`
+exemption in check 1 also remains inert: no job in the five workflows is a
+reusable-workflow call today.

--- a/.consiliency/evidence/bypass-proofs-187.md
+++ b/.consiliency/evidence/bypass-proofs-187.md
@@ -57,7 +57,68 @@ observed") was therefore falsified by its own value of 20 on day one. Raised to
 ## Why actionlint is mandatory here, not optional
 
 `release.yml` cannot be exercised pre-merge -- it triggers only on tag push --
-so actionlint is the *only* Actions-schema validation on the release path
-before a tag is cut. The plan's original invocation was also fail-open
+so actionlint is the only Actions-*schema* validation on the release path
+before a tag is cut. It is not sufficient on its own: see c3 below, where a
+deleted job passes actionlint cleanly and only the job-set comparison catches
+it. The plan's original invocation was also fail-open
 (`command -v actionlint && actionlint ... || echo skipped` swallows a non-zero
 actionlint into the `||` branch), which is the same defect class as B above.
+
+---
+
+## Corrections and additions from the implementation pass
+
+The implementer re-ran the whole matrix against the committed state and found
+three things this document got wrong or missed. All re-verified independently
+before being recorded.
+
+### C is caught by check #2, NOT by check #1
+
+My instruction to the implementer said all three bypasses must make **check #1**
+exit non-zero. That is wrong for C. Measured:
+
+    c  (publish over-indented into build)   check1=0  check2=1  actionlint=1
+    c2 (terminal job over-indented)         check1=0  check2=1  actionlint=1
+    c3 (terminal job DELETED outright)      check1=0  check2=1  actionlint=0
+
+Check #1 counts jobs that *survive parsing*; a swallowed job is not one, so its
+absence cannot make a presence-check fail. The bypass is genuinely closed --
+just by a different check than I claimed. The body of this document already
+attributes C to the job-set comparison, so only the instruction was wrong.
+
+### c3 is the finding that matters: check #2 is the SOLE guard
+
+Deleting a terminal job outright yields a **perfectly valid workflow**.
+Verified: check #1 exits 0, **actionlint exits 0**, and only the job-set
+comparison against `main` exits 1.
+
+actionlint caught c and c2 only because over-indentation is a *syntax* error
+(`unexpected key "publish" for "job" section`, plus `job "github-release" needs
+job "publish" which does not exist`). Deletion is not a syntax error, so nothing
+schema-level sees it.
+
+So for `release.yml` -- which triggers on tag push only and therefore never
+appears in PR checks -- the job-set comparison is the *only* thing standing
+between a dropped `publish` job and a silently broken release. That is the
+argument for its fail-rather-than-print form, stated more strongly than this
+document originally did.
+
+### The actionlint invocation had the same extension gap as bypass A
+
+`actionlint .github/workflows/*.yml` never schema-checks a `.yaml` workflow.
+Verified with a `sneaky.yaml` carrying a bogus `with:` key:
+
+    actionlint .github/workflows/*.yml   -> exit 0   (never looked)
+    actionlint                           -> exit 3   (discovers both)
+
+Check #1 was widened to both extensions but the actionlint line was not -- the
+same gap, one layer down. **Use bare `actionlint`**, which discovers both
+extensions itself, rather than globbing.
+
+### Known-inert exemption
+
+Check #1 skips jobs carrying `uses:` (a reusable-workflow call cannot take
+`timeout-minutes`). No job in any of the five workflows is such a call today, so
+the exemption is currently untested against real input. It is correct to have --
+without it, a future `uses:` job would force invalid YAML to satisfy the check --
+but it would silently exempt any future job that gains a `uses:` key.

--- a/.consiliency/plans/detailed-ci-job-timeouts-20260826-0400.md
+++ b/.consiliency/plans/detailed-ci-job-timeouts-20260826-0400.md
@@ -49,8 +49,8 @@ it is left untouched so this change adds a rule rather than relitigating one.
 - `build` job — **add** `timeout-minutes: 20` — 4m10s observed; the job that stalled.
 - `publish` job — **add** `timeout-minutes: 10` — 19s observed; PyPI upload.
 - `github-release` job — **add** `timeout-minutes: 10` — 8s observed.
-- `on:` block — **add** `workflow_dispatch` with a required `tag` input — see
-  *Recovery* below.
+- `on:` block — **unchanged.** `workflow_dispatch` was proposed and is
+  **struck** — see *Recovery* below.
 
 ### `.github/workflows/test.yml` (modify)
 
@@ -66,25 +66,40 @@ it is left untouched so this change adds a rule rather than relitigating one.
 
 - `notify-worker` job — **add** `timeout-minutes: 10`.
 
-## Recovery: why `workflow_dispatch` is in scope
+## Recovery: `workflow_dispatch` is STRUCK
 
-`release.yml` currently triggers **only** on `push: tags: v*`. When a release run
-fails, the options are `gh run rerun` (worked this time) or deleting and
-re-pushing the tag — which rewrites a ref that consumers may already have
-fetched. `gh run rerun` is not guaranteed: it is unavailable once a run ages out
-of retention, and re-running a *cancelled* run is not a documented-stable path.
+*Board finding, two seats independently, both verified against the workflow.*
 
-Adding `workflow_dispatch` with an explicit `tag` input gives a first-class
-recovery route that never rewrites a published ref.
+The proposal was to add `workflow_dispatch` with a required `tag` input. **It is
+dropped**, and not only for the security widening I flagged — the specified
+change was also simply **incorrect**:
 
-**The security consideration, stated plainly:** `workflow_dispatch` on a
-publishing workflow means anyone with write access can trigger a PyPI publish
-for an arbitrary ref. That is a real widening. Mitigations already in place —
-the `publish` job is bound to `environment: release`, and PyPI trusted
-publishing scopes to this repo+workflow. If the reviewer judges the widening
-unjustified, **drop this item and keep the timeouts**; the timeouts are the fix
-for #187 and stand alone. This is the one part of the plan I am least sure of
-and most want argued.
+- `actions/checkout@v7` at `release.yml:12` and `:63` pins **no ref**.
+- Both tag derivations read `GITHUB_REF_NAME` (`release.yml:73`, `:96`).
+
+Under `workflow_dispatch`, `GITHUB_REF_NAME` is the ref chosen in the *"Use
+workflow from"* dropdown — **not** a workflow input. So dispatching with
+`tag=v2.4.1` from `main` would check out `main`, build and publish **main's**
+artifacts, then try to create a GitHub Release named `main`. The required input
+would be silently ignored. Writing an input and never wiring it is the same
+class of defect as a hollow test: it looks like it constrains something.
+
+The failure mode is the bad one: **PyPI publish can succeed while the GitHub
+release step fails**, leaving a half-published version. And the mitigations I
+offered do not hold — PyPI trusted publishing scoped to repo+workflow does
+**not** restrict to tag events, and `environment: release` only gates if that
+environment has required reviewers, which this plan never verified.
+
+Recovery already exists and is what actually unblocked v2.4.1: `gh run rerun`
+on the failed tag-push run. And the timeouts themselves are the real recovery
+improvement — they convert a 6-hour silent hang into a ~20-minute red X, which
+is what surfaces the stall in the first place.
+
+A correct dispatch path would check out `refs/tags/${{ inputs.tag }}`, use
+`inputs.tag` everywhere in place of `GITHUB_REF_NAME`, assert `pyproject`
+version == tag, handle an already-published PyPI version on partial recovery,
+and keep environment protection. That is a separate design and out of scope for
+#187.
 
 ## Documentation impact
 
@@ -124,8 +139,16 @@ for f in sorted(pathlib.Path('.github/workflows').glob('*.yml')):
     print(f.name, '->', sorted((d.get('jobs') or {}).keys()))
 "
 
-# 3. actionlint if available (do not install it just for this).
-command -v actionlint >/dev/null && actionlint .github/workflows/*.yml || echo "actionlint absent, skipped"
+# 3. actionlint — Actions-SCHEMA validation, which a generic YAML load cannot
+#    replace. NOTE the shape: `cmd && actionlint || echo skipped` is FAIL-OPEN,
+#    because the `||` branch also swallows a non-zero actionlint. Any finding
+#    would print "skipped" and exit 0. Branch explicitly instead (board finding,
+#    red-team seat — same shape as the hollow assertions in #184/#185).
+if command -v actionlint >/dev/null 2>&1; then
+  actionlint .github/workflows/*.yml   # non-zero here MUST fail the run
+else
+  echo "actionlint absent — schema not validated, say so in the PR"
+fi
 
 # 4. The repo suite must be untouched by a CI-only change.
 uv run pytest tests/ -q
@@ -166,6 +189,12 @@ automation:
 - [ ] `pipeline-bootstrap.yml`'s existing `timeout-minutes: 30` is unchanged —
       proven by `git diff main -- .github/workflows/pipeline-bootstrap.yml`
       being empty.
-- [ ] The `workflow_dispatch` decision is explicit: either implemented with the
-      security widening documented in the PR body, or dropped with the reason
-      recorded. Not silently omitted.
+- [ ] `workflow_dispatch` is **not** added, and the PR body records why —
+      proven by `git diff main -- .github/workflows/release.yml` showing no
+      change to the `on:` block. The board found the specified version was not
+      merely a security widening but incorrect: an unwired `tag` input against
+      `GITHUB_REF_NAME` would publish the dispatched *ref*, not the requested
+      tag.
+- [ ] `actionlint` was run and **passed**, or its absence is stated in the PR —
+      proven by the explicit `if/else` in Verification, not the fail-open
+      `&& … || echo` form. A non-zero actionlint must fail, not print "skipped".

--- a/.consiliency/plans/detailed-ci-job-timeouts-20260826-0400.md
+++ b/.consiliency/plans/detailed-ci-job-timeouts-20260826-0400.md
@@ -1,0 +1,171 @@
+# Detailed plan: give every CI job a timeout, and make a stalled release recoverable
+
+## Task
+
+Close Consiliency/pmcp#187. No job in `release.yml`, `test.yml`, `docker.yml`
+or `maintenance.yml` sets `timeout-minutes`, so a stalled job runs to GitHub's
+6-hour default. On the release path that is not merely slow: `publish` and
+`github-release` each `needs:` the job before them, so **one stall silently
+blocks the entire publish for six hours**, and since the tag push *is* the
+publish, a version can sit tagged-but-unshipped with nothing surfacing it.
+
+Observed while cutting v2.4.1: `build` hung 3h11m on `Run tests with coverage`
+against a healthy commit (the same command locally: 2737 passed, 85.86%
+coverage vs a 60% gate). Cancel + `gh run rerun` cleared it, so it was a
+transient runner stall, not the code.
+
+## Research summary
+
+Measured on the live repo, not estimated — per-job durations from
+`GET /actions/runs/{id}/jobs`, `(completed_at - started_at)`:
+
+| workflow | job | observed | proposed timeout |
+|---|---|---|---|
+| `release.yml` | `build` | 4m10s | **20** |
+| `release.yml` | `publish` | 19s | **10** |
+| `release.yml` | `github-release` | 8s | **10** |
+| `test.yml` | `test` (3.10/3.11/3.12) | 4–5m across 5 runs | **20** |
+| `test.yml` | `install-smoke` | <1m | **10** |
+| `test.yml` | `min-version-smoke` | <1m | **10** |
+| `test.yml` | `lint` | <1m | **10** |
+| `test.yml` | `changelog` | <1m | **10** |
+| `test.yml` | `typecheck` | <1m | **10** |
+| `docker.yml` | `build` | <1m | **20** |
+| `maintenance.yml` | `notify-worker` | 9s | **10** |
+| `pipeline-bootstrap.yml` | `bootstrap` | 10m | already has **30** — leave it |
+
+Sizing rule: roughly 4× the observed p100, floored at 10 minutes. The point is
+to fail fast on a *stall*, not to police normal variance — a job that legitimately
+grows 3× should still pass. `docker.yml` gets 20 rather than 10 despite being
+fast, because image builds are network-bound and legitimately spiky.
+
+`pipeline-bootstrap.yml` already sets 30 and is the only precedent in the repo;
+it is left untouched so this change adds a rule rather than relitigating one.
+
+## Changes
+
+### `.github/workflows/release.yml` (modify)
+
+- `build` job — **add** `timeout-minutes: 20` — 4m10s observed; the job that stalled.
+- `publish` job — **add** `timeout-minutes: 10` — 19s observed; PyPI upload.
+- `github-release` job — **add** `timeout-minutes: 10` — 8s observed.
+- `on:` block — **add** `workflow_dispatch` with a required `tag` input — see
+  *Recovery* below.
+
+### `.github/workflows/test.yml` (modify)
+
+- `test`, `install-smoke`, `min-version-smoke`, `lint`, `changelog`, `typecheck`
+  — **add** `timeout-minutes` per the table above. `test` is a 3-version matrix;
+  `timeout-minutes` at job level applies per matrix leg, which is what we want.
+
+### `.github/workflows/docker.yml` (modify)
+
+- `build` job — **add** `timeout-minutes: 20`.
+
+### `.github/workflows/maintenance.yml` (modify)
+
+- `notify-worker` job — **add** `timeout-minutes: 10`.
+
+## Recovery: why `workflow_dispatch` is in scope
+
+`release.yml` currently triggers **only** on `push: tags: v*`. When a release run
+fails, the options are `gh run rerun` (worked this time) or deleting and
+re-pushing the tag — which rewrites a ref that consumers may already have
+fetched. `gh run rerun` is not guaranteed: it is unavailable once a run ages out
+of retention, and re-running a *cancelled* run is not a documented-stable path.
+
+Adding `workflow_dispatch` with an explicit `tag` input gives a first-class
+recovery route that never rewrites a published ref.
+
+**The security consideration, stated plainly:** `workflow_dispatch` on a
+publishing workflow means anyone with write access can trigger a PyPI publish
+for an arbitrary ref. That is a real widening. Mitigations already in place —
+the `publish` job is bound to `environment: release`, and PyPI trusted
+publishing scopes to this repo+workflow. If the reviewer judges the widening
+unjustified, **drop this item and keep the timeouts**; the timeouts are the fix
+for #187 and stand alone. This is the one part of the plan I am least sure of
+and most want argued.
+
+## Documentation impact
+
+- `CHANGELOG.md` — **none.** CI-only; no user-visible behaviour, no shipped
+  artifact changes. Per repo convention the `changelog` job requires an entry
+  only for `src/` changes, and this touches no `src/`. State the decision
+  explicitly rather than silently skipping.
+- No other cross-cutting doc describes CI job limits.
+
+## Dependencies & order
+
+None between the four files — each edit is independent and additive. Do them in
+one commit so the rule lands uniformly rather than half-applied.
+
+## Verification
+
+```bash
+cd /mnt/workspace/worktrees/pmcp-187-timeouts
+
+# 1. Every job in every workflow now has a timeout (the actual acceptance test).
+python3 - <<'PY'
+import pathlib, yaml, sys
+missing = []
+for f in sorted(pathlib.Path(".github/workflows").glob("*.yml")):
+    for name, job in (yaml.safe_load(f.read_text()).get("jobs") or {}).items():
+        if "timeout-minutes" not in job:
+            missing.append(f"{f.name}:{name}")
+print("jobs missing timeout-minutes:", missing or "none")
+sys.exit(1 if missing else 0)
+PY
+
+# 2. Every workflow still parses as valid YAML with its jobs intact.
+python3 -c "
+import pathlib, yaml
+for f in sorted(pathlib.Path('.github/workflows').glob('*.yml')):
+    d = yaml.safe_load(f.read_text())
+    print(f.name, '->', sorted((d.get('jobs') or {}).keys()))
+"
+
+# 3. actionlint if available (do not install it just for this).
+command -v actionlint >/dev/null && actionlint .github/workflows/*.yml || echo "actionlint absent, skipped"
+
+# 4. The repo suite must be untouched by a CI-only change.
+uv run pytest tests/ -q
+```
+
+**The real proof is CI itself**: open the PR and confirm every check still
+passes *and* that each job now reports a timeout. A YAML edit that parses but
+disables a job would show up as a check that never runs — check the PR's check
+list against `main`'s, count included.
+
+Edge cases: `timeout-minutes` at job level vs step level (job level is correct
+here — it bounds the whole job including setup); matrix jobs (applies per leg);
+`needs:`-chained jobs (each needs its own, a timeout does not inherit).
+
+## Automation
+
+```yaml
+automation:
+  suite_command: "uv run pytest -q"
+```
+
+## Execution Policy
+- execute: effort=low, reason=additive YAML with measured values and no source change
+
+## Acceptance criteria
+
+- [ ] Every job in `release.yml`, `test.yml`, `docker.yml` and `maintenance.yml`
+      declares `timeout-minutes` — proven by the enumeration script in
+      Verification exiting 0, which fails today.
+- [ ] Every workflow still parses and lists the same job names as on `main` —
+      proven by the YAML round-trip in Verification, diffed against
+      `git show main:.github/workflows/<f>` job lists.
+- [ ] No timeout is below the observed p100 for its job — the values in the
+      table are each ≥4× observed, so a normal run cannot be killed by this
+      change.
+- [ ] The PR's CI reports the **same set of checks** as a `main` PR, all
+      passing — proven by `gh pr checks`, count and names compared.
+- [ ] `pipeline-bootstrap.yml`'s existing `timeout-minutes: 30` is unchanged —
+      proven by `git diff main -- .github/workflows/pipeline-bootstrap.yml`
+      being empty.
+- [ ] The `workflow_dispatch` decision is explicit: either implemented with the
+      security widening documented in the PR body, or dropped with the reason
+      recorded. Not silently omitted.

--- a/.consiliency/plans/detailed-ci-job-timeouts-20260826-0400.md
+++ b/.consiliency/plans/detailed-ci-job-timeouts-20260826-0400.md
@@ -24,7 +24,7 @@ Measured on the live repo, not estimated — per-job durations from
 | `release.yml` | `build` | 4m10s | **20** |
 | `release.yml` | `publish` | 19s | **10** |
 | `release.yml` | `github-release` | 8s | **10** |
-| `test.yml` | `test` (3.10/3.11/3.12) | 4–5m across 5 runs | **20** |
+| `test.yml` | `test` (3.10/3.11/3.12) | **5.35m p100** (8 runs) | **25** |
 | `test.yml` | `install-smoke` | <1m | **10** |
 | `test.yml` | `min-version-smoke` | <1m | **10** |
 | `test.yml` | `lint` | <1m | **10** |
@@ -116,52 +116,76 @@ one commit so the rule lands uniformly rather than half-applied.
 
 ## Verification
 
+**These scripts are the HARDENED forms.** An earlier draft of this plan shipped
+presence-only checks that were proven bypassable three ways in the same change
+— see `.consiliency/evidence/bypass-proofs-187.md`. Do not reintroduce the
+`glob("*.yml")`-only, presence-only, or print-only variants.
+
 ```bash
 cd /mnt/workspace/worktrees/pmcp-187-timeouts
 
-# 1. Every job in every workflow now has a timeout (the actual acceptance test).
+# 0. STRONGEST CHECK, and the one to reach for first: audit the diff SHAPE.
+#    "every changed line is an added timeout-minutes, nothing removed"
+#    subsumes both checks below in one assertion, and unlike them it also
+#    catches edits to `on:`, `needs:`, `environment:` and `permissions:`.
+git diff main..HEAD -- .github/ | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
+  | grep -vE '^\+\s+timeout-minutes: [0-9]+$' \
+  && { echo "UNEXPECTED change beyond timeout-minutes"; exit 1; } \
+  || echo "diff shape OK: additive timeout-minutes only"
+
+# 1. Every job has a timeout AND the value is sane.
+#    Presence alone is not enough: `timeout-minutes: 360` re-creates the very
+#    6-hour default this change exists to remove, and a string passes too.
+#    Both extensions: GitHub runs .yml and .yaml.
 python3 - <<'PY'
 import pathlib, yaml, sys
-missing = []
-for f in sorted(pathlib.Path(".github/workflows").glob("*.yml")):
+bad = []
+files = sorted(p for ext in ("*.yml", "*.yaml")
+                 for p in pathlib.Path(".github/workflows").glob(ext))
+for f in files:
     for name, job in (yaml.safe_load(f.read_text()).get("jobs") or {}).items():
-        if "timeout-minutes" not in job:
-            missing.append(f"{f.name}:{name}")
-print("jobs missing timeout-minutes:", missing or "none")
-sys.exit(1 if missing else 0)
+        if "uses" in job:      # reusable-workflow call cannot carry a timeout
+            continue
+        v = job.get("timeout-minutes")
+        if not isinstance(v, int) or isinstance(v, bool) or not 10 <= v <= 30:
+            bad.append(f"{f.name}:{name} -> {v!r}")
+print("jobs with a missing/invalid timeout:", bad or "none")
+sys.exit(1 if bad else 0)
 PY
 
-# 2. Every workflow still parses as valid YAML with its jobs intact.
-python3 -c "
-import pathlib, yaml
-for f in sorted(pathlib.Path('.github/workflows').glob('*.yml')):
-    d = yaml.safe_load(f.read_text())
-    print(f.name, '->', sorted((d.get('jobs') or {}).keys()))
-"
+# 2. Job sets must MATCH main, and this must FAIL, not print.
+#    A job silently deleted or swallowed by over-indentation yields a VALID
+#    workflow that check 1 and actionlint both accept. For release.yml --
+#    tag-push only, never in PR checks -- this is the sole guard.
+python3 - <<'PY'
+import pathlib, subprocess, yaml, sys
+bad = []
+for f in sorted(pathlib.Path(".github/workflows").glob("*.y*ml")):
+    now = sorted((yaml.safe_load(f.read_text()).get("jobs") or {}).keys())
+    base = subprocess.run(["git","show",f"main:{f}"],capture_output=True,text=True).stdout
+    was = sorted((yaml.safe_load(base).get("jobs") or {}).keys()) if base else now
+    if now != was:
+        bad.append(f"{f.name}: {was} -> {now}")
+    print(f"  {f.name}: {now}")
+print("job-set changes:", bad or "none")
+sys.exit(1 if bad else 0)
+PY
 
-# 3. actionlint — Actions-SCHEMA validation, which a generic YAML load cannot
-#    replace. NOTE the shape: `cmd && actionlint || echo skipped` is FAIL-OPEN,
-#    because the `||` branch also swallows a non-zero actionlint. Any finding
-#    would print "skipped" and exit 0. Branch explicitly instead (board finding,
-#    red-team seat — same shape as the hollow assertions in #184/#185).
-if command -v actionlint >/dev/null 2>&1; then
-  actionlint .github/workflows/*.yml   # non-zero here MUST fail the run
-else
-  echo "actionlint absent — schema not validated, say so in the PR"
-fi
+# 3. actionlint is MANDATORY. Bare, with no glob -- `*.yml` would leave a
+#    .yaml workflow schema-unchecked, the same gap as check 1's globs.
+actionlint
 
-# 4. The repo suite must be untouched by a CI-only change.
+# 4. bootstrap untouched; suite untouched by a CI-only change.
+git diff main -- .github/workflows/pipeline-bootstrap.yml
 uv run pytest tests/ -q
 ```
 
-**The real proof is CI itself**: open the PR and confirm every check still
-passes *and* that each job now reports a timeout. A YAML edit that parses but
-disables a job would show up as a check that never runs — check the PR's check
-list against `main`'s, count included.
-
-Edge cases: `timeout-minutes` at job level vs step level (job level is correct
-here — it bounds the whole job including setup); matrix jobs (applies per leg);
-`needs:`-chained jobs (each needs its own, a timeout does not inherit).
+**What these checks do NOT guard.** They cover exactly *{job-name set} × {timeout
+presence and value}*. Every other byte of `release.yml` — the `on:` tag filter,
+`needs:` edges, `environment:`, `permissions:` — is unguarded by 1–3, which is
+why check 0 (diff shape) leads. The `on:`-block class is the worst: corrupt the
+tag pattern and there is **no run at all**, so no red X ever appears — exactly
+#187's motivating failure. Check 0 catches it; nothing else here does.
 
 ## Automation
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   notify-worker:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Notify maintenance worker
         continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
 
@@ -37,6 +38,7 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: release
     permissions:
       id-token: write  # Required for trusted publishing
@@ -56,6 +58,7 @@ jobs:
   github-release:
     needs: publish
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
@@ -55,6 +56,7 @@ jobs:
   # missing version constraint.
   install-smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -91,6 +93,7 @@ jobs:
   # This job installs pinned at exactly the declared floor and proves it works.
   min-version-smoke:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -166,6 +169,7 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 
@@ -195,6 +199,7 @@ jobs:
   # no-op there via the `if:` below.
   changelog:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'pull_request'
     # A job-level permissions: block replaces the repo default for every
     # scope, not just the one named — so contents: read has to be repeated
@@ -270,6 +275,7 @@ jobs:
 
   typecheck:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
 


### PR DESCRIPTION
Closes **#187**. CI-only: 12 additive lines across four workflow files, no `src/` change.

## Why

Cutting v2.4.1, `release.yml`'s `build` job hung **3h11m** on "Run tests with coverage" against a healthy commit — the same command locally gave `2737 passed`, 85.86% coverage vs a 60% gate. Cancel + `gh run rerun` cleared it: a transient runner stall.

No job in `release.yml`, `test.yml`, `docker.yml` or `maintenance.yml` set `timeout-minutes`, so a stall ran to GitHub's 6-hour default. `publish` and `github-release` each `needs:` the job before them, so **one stall silently blocked the whole publish** — and since the tag push *is* the publish, a version can sit tagged-but-unshipped with nothing surfacing it. I only noticed by comparing the run's start time against previous cuts.

## Values — measured, not estimated

From `GET /actions/runs/{id}/jobs`, `completed_at - started_at`, last 5 runs. Roughly 4× observed p100 with a 10-minute floor.

| file | job | observed | timeout |
|---|---|---|---|
| `release.yml` | `build` | 3.6–4.4m | 20 |
| `release.yml` | `publish` | ~20s | 10 |
| `release.yml` | `github-release` | ~8s | 10 |
| `test.yml` | `test` ×3 | **5.30m p100** | **25** |
| `test.yml` | 5 other jobs | <1m | 10 |
| `docker.yml` | `build` | <1m | 20 |
| `maintenance.yml` | `notify-worker` | 9s | 10 |

`pipeline-bootstrap.yml` already had `timeout-minutes: 30` and is untouched.

The goal is failing fast on a *stall*, not policing variance — a job that legitimately grows 3× still passes. The board specifically noted that tightening the floor to 5 would be the real false-kill risk, for `min-version-smoke`.

## What the board changed

### `workflow_dispatch` was proposed and **struck**

An earlier draft added it with a `tag` input, for recovering a stalled release without re-pushing a published tag. Two seats independently found it wasn't just a security widening — it was **incorrect**. `actions/checkout` pins no ref (`release.yml:12`, `:63`) and both tag derivations read `GITHUB_REF_NAME` (`:73`, `:97`), which under dispatch is the *selected ref*, not a workflow input. Dispatching `tag=v2.4.1` from `main` would publish **main's** artifacts under that version number.

Worse: **PyPI can succeed while the GitHub release fails**, leaving a half-published version. Both mitigations I'd offered fail on inspection — verified live, there are **no tag rulesets** (`gh api .../rulesets` → 0) and `environment: release` has `protection_rules: []`, so it gates nothing today.

Recovery already exists and is what unblocked v2.4.1: `gh run rerun`. And the timeouts are themselves the recovery improvement — a 6-hour silent hang becomes a ≤25-minute red X.

### Three acceptance-test bypasses, each reproduced

My original check asserted only that `timeout-minutes` was *present*. Proofs in `.consiliency/evidence/bypass-proofs-187.md`:

| bypass | original | hardened |
|---|---|---|
| `.yaml` file escapes a `*.yml` glob | exit 0 | exit 1 |
| `timeout-minutes: 360` — **re-creates the 6h default** | exit 0 | exit 1 |
| over-indented job silently swallowed | exit 0 | exit 1 |

The third is the dangerous one: over-indenting `publish:` makes it parse as a key inside `build`'s mapping. YAML is valid, `jobs` becomes `[build, github-release]`, and the presence check passes because every *surviving* job has a timeout. My plan claimed "the real proof is CI itself" — **false for `release.yml`**, which triggers only on tag push and never appears in PR checks. It would have surfaced at the next tag push, as a broken release.

The hardened check globs both extensions, validates the value (`int`, not `bool`, 1–30), skips `uses:` jobs (a reusable-workflow call can't carry a timeout), and compares job-name sets against `main`, **failing** rather than printing.

`actionlint` is now mandatory rather than best-effort — `release.yml` can't be exercised pre-merge, so it's the only Actions-schema check on the release path before a tag is cut. My original invocation was also fail-open (`&& actionlint || echo skipped` swallows a non-zero exit).

## Verification

- hardened acceptance check: **exit 0**; all three bypasses **exit 1**
- job sets identical to `main` across all five workflows
- `actionlint 1.7.12`: **exit 0**, no findings
- `pipeline-bootstrap.yml`: `git diff main` empty, still 30
- suite: `2737 passed, 3 skipped, 0 failed`

**Reviewer check the plan couldn't do pre-push:** this PR's check list should match a `main` PR's — same names, same count. `release.yml`'s jobs won't appear (tag-triggered), which is precisely why `actionlint` is load-bearing here.

## CHANGELOG

Intentionally untouched, stated rather than silently skipped: CI-only, no `src/` change, and the `changelog` job requires an entry only for `src/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbREMUsxgJ8TDBLpJ56PWb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790308314&installation_model_id=427051&pr_number=188&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F188&signature=011e4884ac7c0cb6fedd03d59d8845f5b215b3433cec2b0fc02120b038e9955a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->