### PR TITLE
fix(parser): classify flag values so a flag's argument is never the package name (#182)

### DIFF
--- a/.consiliency/evidence/mutation-183.md
+++ b/.consiliency/evidence/mutation-183.md
@@ -61,3 +61,55 @@ invocation (npm requires a subcommand), so those assertions had encoded the
 parser's old permissiveness -- the general form of this very defect. They are
 now inverted, with the reason in their docstrings, rather than the guard being
 relaxed to keep them green.
+
+---
+
+# Board round on #182 (PR #190) — two real defects, two false alarms
+
+Four seats. grok AGREE, gemini AGREE, codex DISAGREE, fable PARTIALLY AGREE.
+Every finding checked against source before acting; two were real, two were not.
+
+## REAL — a collision the fix itself introduced (red-team seat)
+
+`_pep508_base_name` listed `@` among the name terminators, so a PEP 508
+**direct reference** truncated to its bare name:
+
+    pkg @ git+https://x/y  ->  ('pypi', 'pkg')
+    pkg @ git+https://x/z  ->  ('pypi', 'pkg')     COLLIDES
+
+Two different repositories, one identity — the exact defect class this change
+exists to close, newly created by the fix for it. It also violated this plan's
+own acceptance criterion that distinct URLs keep distinct identities; the test
+covered only the *bare* URL form and missed the standard named one.
+
+Fixed by removing `@` from the terminator set. Verified after: the two repos
+resolve distinctly, and extras/version normalization still works
+(`browser-use[cli]` -> `browser-use`, `index-it-mcp==1.2.0` -> `index-it-mcp`).
+
+## REAL — the 21st mutant, and my fix for it had a hollow spot (correctness seat)
+
+Deleting the `following.startswith("-")` arm left **all 364 tests green** while
+`uvx --from --offline a` and `... b` both resolved to `('pypi','--offline')`.
+Verified end-to-end: `_same_package('--offline','pypi','--offline','pypi')`
+returns **True**, so the mutant's collision passes the identity gate.
+
+Then — mutation-proving my own patch rather than trusting it — the third mutant
+(dropping the `following is None` arm) **passed all four new tests**. My
+end-of-argv case used `["--from"]`, which returns before ever reaching the
+guard. Probed five inputs for one that distinguishes the arm; none does. It is
+genuinely **unreachable**: a trailing positive flag ends the loop and falls
+through to unknown anyway. The test now says so rather than implying a proof.
+
+## NOT REAL — and the disclosures are why
+
+- *"Missing body in `test_readme_documented_pin_form_resolves_to_the_package`"*
+  — it has a full assertion body. The seat read the docstring as the whole
+  test. That docstring already discloses which half the test pins.
+- *"Unreachable fallthrough in `_scan_for_package_token`"* — the `--` branch is
+  already labelled in-code as measured-redundant-but-kept, with the reasoning
+  inline.
+
+Both false alarms landed on spots the implementer had *already* labelled as
+non-discriminating. Writing "this does not pin what it looks like it pins"
+directly into the code did not stop a reviewer flagging it — but it made the
+claim checkable in seconds instead of requiring a fresh investigation.

--- a/.consiliency/notes/mutate.py
+++ b/.consiliency/notes/mutate.py
@@ -1,0 +1,313 @@
+"""Per-NODE mutation proof for Consiliency/pmcp#182.
+
+Each mutation reverts exactly ONE branch's rule and runs exactly ONE test node.
+A red CLASS proves nothing about a specific test -- that is how hollow tests
+have shipped in this repo before -- so nothing here runs a whole class.
+
+Runs against a `cp -r` copy so the worktree is never edited (a `git checkout --`
+restore has wiped uncommitted work here twice). Bytecode is purged before every
+run and writing is disabled, since stale bytecode has fabricated both a false
+RED and can equally fabricate a false GREEN.
+"""
+
+import pathlib
+import shutil
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+MUT = pathlib.Path(__file__).parent / "mutcopy"
+VC = MUT / "src/pmcp/manifest/version_checker.py"
+HD = MUT / "src/pmcp/tools/handlers.py"
+
+# (label, file, kind, payload, test node)
+#   kind "append": append a line rebinding a module-level table
+#   kind "replace": exact (old, new) source substitution
+MUTATIONS = [
+    (
+        "uvx --python reclassified value -> boolean",
+        VC, "append",
+        '_UVX_VALUE_FLAGS = _UVX_VALUE_FLAGS - {"--python"}\n'
+        '_UVX_BOOLEAN_FLAGS = _UVX_BOOLEAN_FLAGS | {"--python"}\n',
+        "tests/test_version_checker.py::TestValueFlagCollisions"
+        "::test_uvx_python_version_is_not_the_package",
+    ),
+    (
+        "uvx --with reclassified value -> boolean",
+        VC, "append",
+        '_UVX_VALUE_FLAGS = _UVX_VALUE_FLAGS - {"--with"}\n'
+        '_UVX_BOOLEAN_FLAGS = _UVX_BOOLEAN_FLAGS | {"--with"}\n',
+        "tests/test_version_checker.py::TestValueFlagCollisions"
+        "::test_uvx_with_dependency_is_not_the_package",
+    ),
+    (
+        "pip --index-url reclassified value -> boolean",
+        VC, "append",
+        '_PIP_VALUE_FLAGS = _PIP_VALUE_FLAGS - {"--index-url"}\n'
+        '_PIP_BOOLEAN_FLAGS = _PIP_BOOLEAN_FLAGS | {"--index-url"}\n',
+        "tests/test_version_checker.py::TestValueFlagCollisions"
+        "::test_pip_index_url_is_not_the_package",
+    ),
+    (
+        "cargo --features reclassified value -> boolean",
+        VC, "append",
+        '_CARGO_VALUE_FLAGS = _CARGO_VALUE_FLAGS - {"--features"}\n'
+        '_CARGO_BOOLEAN_FLAGS = _CARGO_BOOLEAN_FLAGS | {"--features"}\n',
+        "tests/test_version_checker.py::TestValueFlagCollisions"
+        "::test_cargo_features_is_not_the_crate",
+    ),
+    (
+        "docker --env-file reclassified value -> boolean",
+        VC, "append",
+        '_DOCKER_VALUE_FLAGS = _DOCKER_VALUE_FLAGS - {"--env-file"}\n'
+        '_DOCKER_BOOLEAN_FLAGS = _DOCKER_BOOLEAN_FLAGS | {"--env-file"}\n',
+        "tests/test_version_checker.py::TestValueFlagCollisions"
+        "::test_docker_env_file_is_not_the_image",
+    ),
+    (
+        "docker --mount reclassified value -> boolean",
+        VC, "append",
+        '_DOCKER_VALUE_FLAGS = _DOCKER_VALUE_FLAGS - {"--mount"}\n'
+        '_DOCKER_BOOLEAN_FLAGS = _DOCKER_BOOLEAN_FLAGS | {"--mount"}\n',
+        "tests/test_version_checker.py::TestValueFlagCollisions"
+        "::test_docker_mount_spec_is_not_the_image",
+    ),
+    (
+        "npm --package no longer known-positive (pre-fix skip)",
+        VC, "append",
+        "_NPM_POSITIVE_FLAGS = frozenset()\n",
+        "tests/test_version_checker.py::TestValueFlagCollisions"
+        "::test_npm_exec_package_flag_names_the_package",
+    ),
+    (
+        "npm repeated --package no longer refuses (returns the first)",
+        VC, "replace",
+        ("        return packages[0] if len(set(packages)) == 1 else None\n",
+         "        return packages[0]\n"),
+        "tests/test_version_checker.py::TestValueFlagCollisions"
+        "::test_npm_repeated_package_flags_refuse",
+    ),
+    (
+        "fail-closed default removed (unlisted flag skipped again)",
+        VC, "replace",
+        ('    return arg.startswith("-") and arg != "-" and "=" not in arg\n',
+         "    return False\n"),
+        "tests/test_version_checker.py::TestValueFlagsFailClosed"
+        "::test_uvx_unlisted_flag_refuses",
+    ),
+    (
+        "fail-closed default removed -- docker arm",
+        VC, "replace",
+        ('    return arg.startswith("-") and arg != "-" and "=" not in arg\n',
+         "    return False\n"),
+        "tests/test_version_checker.py::TestValueFlagsFailClosed"
+        "::test_docker_unlisted_flag_refuses",
+    ),
+    (
+        "fail-closed default removed -- update_server no-probe consequence",
+        VC, "replace",
+        ('    return arg.startswith("-") and arg != "-" and "=" not in arg\n',
+         "    return False\n"),
+        "tests/test_tools.py::TestUpdateServerVersionRepair"
+        "::test_update_server_never_probes_an_unclassifiable_flag_form",
+    ),
+    (
+        "`--flag=value` no longer treated as self-delimiting",
+        VC, "replace",
+        ('    return arg.startswith("-") and arg != "-" and "=" not in arg\n',
+         '    return arg.startswith("-") and arg != "-"\n'),
+        "tests/test_version_checker.py::TestValueFlagsFailClosed"
+        "::test_unlisted_flag_with_attached_value_is_self_delimiting",
+    ),
+    # NOTE: the explicit `--` terminator is deliberately NOT mutated here.
+    # Measured: deleting it changes no observable result, because `--` also
+    # trips the fail-closed default. It is redundant-but-documenting, and both
+    # the code comment and the test docstring say so rather than implying a
+    # proof that does not exist.
+    (
+        "PEP 508 normalization removed",
+        VC, "replace",
+        ("    return match.group(1) if match else requirement\n",
+         "    return requirement\n"),
+        "tests/test_version_checker.py::TestKnownPositiveValueFlags"
+        "::test_from_value_is_normalized_to_its_pep508_base_name",
+    ),
+    (
+        "PEP 508 applied to URLs too (git+https identity destroyed)",
+        VC, "replace",
+        ("    return match.group(1) if match else requirement\n",
+         '    return requirement.split("/")[0]\n'),
+        "tests/test_version_checker.py::TestKnownPositiveValueFlags"
+        "::test_from_url_value_keeps_the_whole_url_as_identity",
+    ),
+    (
+        "docker `-it` combined short boolean removed",
+        VC, "append",
+        '_DOCKER_BOOLEAN_FLAGS = _DOCKER_BOOLEAN_FLAGS - {"-it"}\n',
+        "tests/test_version_checker.py::TestKnownPositiveValueFlags"
+        "::test_docker_combined_short_booleans_still_find_image",
+    ),
+    (
+        "uvx --from downgraded known-positive -> value flag",
+        VC, "append",
+        "_UVX_POSITIVE_FLAGS = frozenset()\n"
+        '_UVX_VALUE_FLAGS = _UVX_VALUE_FLAGS | {"--from"}\n',
+        "tests/test_version_checker.py::TestKnownPositiveValueFlags"
+        "::test_known_positive_forms_unchanged",
+    ),
+    (
+        # The README form is pinned by `--python`'s classification, which is
+        # the half that was actually broken. `--from`'s classification is NOT
+        # observable through this form -- see the test's docstring.
+        "uvx --python reclassified -> README pin form misidentified as 3.12",
+        VC, "append",
+        '_UVX_VALUE_FLAGS = _UVX_VALUE_FLAGS - {"--python"}\n'
+        '_UVX_BOOLEAN_FLAGS = _UVX_BOOLEAN_FLAGS | {"--python"}\n',
+        "tests/test_version_checker.py::TestKnownPositiveValueFlags"
+        "::test_readme_documented_pin_form_resolves_to_the_package",
+    ),
+    (
+        "uvx --quiet reclassified boolean -> value (rejected design)",
+        VC, "append",
+        '_UVX_BOOLEAN_FLAGS = _UVX_BOOLEAN_FLAGS - {"--quiet"}\n'
+        '_UVX_VALUE_FLAGS = _UVX_VALUE_FLAGS | {"--quiet"}\n',
+        "tests/test_version_checker.py::TestKnownPositiveValueFlags"
+        "::test_uvx_boolean_flag_still_finds_package",
+    ),
+    (
+        "uvx positional normalized too (inline pin lost)",
+        VC, "replace",
+        ('            return ("pypi", _pep508_base_name(raw) '
+         "if from_positive_flag else raw)\n",
+         '            return ("pypi", _pep508_base_name(raw))\n'),
+        "tests/test_version_checker.py::TestKnownPositiveValueFlags"
+        "::test_positional_uvx_token_is_left_raw",
+    ),
+    (
+        "uvx pin detection un-shared (back to independent scan)",
+        HD, "replace",
+        ("        raw, _from_flag = _uvx_package_arg(args)\n"
+         '        if raw is not None and "==" in raw:\n'
+         '            _, _, version = raw.partition("==")\n'
+         "            return version or None\n",
+         "        for arg in args:\n"
+         '            if arg.startswith("-"):\n'
+         "                continue\n"
+         '            if "==" in arg:\n'
+         '                _, _, version = arg.partition("==")\n'
+         "                return version or None\n"),
+        "tests/test_tools.py::TestUpdateServerVersionRepair"
+        "::test_detect_effective_version_pin_matrix",
+    ),
+]
+
+
+def purge() -> None:
+    for d in MUT.rglob("__pycache__"):
+        shutil.rmtree(d, ignore_errors=True)
+
+
+PY = str(REPO / ".venv/bin/python")
+ENV = {**__import__("os").environ,
+       "PYTHONDONTWRITEBYTECODE": "1",
+       "PYTHONPATH": str(MUT / "src")}
+
+
+def check_provenance() -> None:
+    """Fail loudly if the tests would import the WORKTREE instead of the copy.
+
+    Without this the whole run is theatre: every mutant would "survive" while
+    the unmutated worktree source quietly served every import.
+    """
+    proc = subprocess.run(
+        [PY, "-c", "import pmcp.manifest.version_checker as m; print(m.__file__)"],
+        cwd=MUT, capture_output=True, text=True, env=ENV,
+    )
+    resolved = proc.stdout.strip()
+    expected = str(MUT / "src/pmcp/manifest/version_checker.py")
+    if resolved != expected:
+        raise SystemExit(
+            f"ABORT: tests would import\n  {resolved}\nnot the mutation copy\n  "
+            f"{expected}\nEvery mutant would falsely survive."
+        )
+    print(f"import provenance OK -> {resolved}\n")
+
+
+def run(node: str) -> tuple[bool, str]:
+    purge()
+    proc = subprocess.run(
+        [PY, "-m", "pytest", node, "-q", "-p", "no:randomly", "--no-header", "-x"],
+        cwd=MUT, capture_output=True, text=True, env=ENV,
+    )
+    tail = [ln for ln in proc.stdout.splitlines()
+            if ln.startswith(("FAILED", "ERROR", "assert", "E "))
+            or " passed" in ln or " failed" in ln or " error" in ln]
+    return proc.returncode == 0, " | ".join(tail[-3:])[:260]
+
+
+def main() -> int:
+    originals = {VC: VC.read_text(), HD: HD.read_text()}
+    purge()
+    check_provenance()
+
+    print("=" * 78)
+    print("BASELINE (unmutated copy): every target node must PASS")
+    print("=" * 78)
+    baseline_bad = []
+    for label, _f, _k, _p, node in MUTATIONS:
+        ok, detail = run(node)
+        print(f"  {'PASS' if ok else 'FAIL'}  {node.rsplit('::', 1)[1]}")
+        if not ok:
+            baseline_bad.append((node, detail))
+    if baseline_bad:
+        print("\nBASELINE BROKEN -- mutation results would be meaningless:")
+        for n, d in baseline_bad:
+            print(f"   {n}\n     {d}")
+        return 1
+
+    print()
+    print("=" * 78)
+    print("MUTATIONS: each must turn its ONE target node RED")
+    print("=" * 78)
+    survivors = []
+    for label, path, kind, payload, node in MUTATIONS:
+        for p, text in originals.items():
+            p.write_text(text)
+        if kind == "append":
+            path.write_text(originals[path] + "\n" + payload)
+        else:
+            old, new = payload
+            text = originals[path]
+            if old not in text:
+                print(f"  SKIP  {label}\n        (anchor not found -- mutation "
+                      f"did not apply, treat as UNPROVEN)")
+                survivors.append((label, node, "anchor not found"))
+                continue
+            path.write_text(text.replace(old, new, 1))
+
+        ok, detail = run(node)
+        verdict = "SURVIVED" if ok else "killed  "
+        print(f"  {verdict}  {label}")
+        print(f"            node: {node.rsplit('::', 1)[1]}")
+        print(f"            {detail}")
+        if ok:
+            survivors.append((label, node, detail))
+
+    for p, text in originals.items():
+        p.write_text(text)
+    purge()
+
+    print()
+    print("=" * 78)
+    if survivors:
+        print(f"{len(survivors)} SURVIVING MUTANT(S) -- these tests do not pin "
+              "what they claim:")
+        for label, node, detail in survivors:
+            print(f"  - {label}\n      {node}\n      {detail}")
+        return 1
+    print(f"All {len(MUTATIONS)} mutants killed, each by its own single node.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.consiliency/notes/verify_tables.py
+++ b/.consiliency/notes/verify_tables.py
@@ -1,0 +1,156 @@
+"""Verify EVERY flag-table entry against the tool's own --help output.
+
+The source comment and CHANGELOG claim these tables were "verified entry by
+entry". This is the check that makes the claim true, run per entry rather than
+per table. A boolean entry that actually takes a value is the fail-OPEN
+direction -- its value becomes the package name -- so the boolean tables matter
+most.
+
+Deliberately a scratchpad script, not a pytest: help text varies by tool
+version and CI has none of these CLIs installed. Behaviour is pinned by the
+pure unit tests in tests/test_version_checker.py.
+"""
+
+import pathlib
+import re
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO / "src"))
+from pmcp.manifest import version_checker as vc  # noqa: E402
+
+
+def help_text(cmd: list[str]) -> str:
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    return p.stdout + p.stderr
+
+
+def definitions(text: str) -> dict[str, bool]:
+    """{flag: takes_a_value} for every option DEFINITION line in *text*.
+
+    A definition line starts with whitespace then `-`, and its head (the part
+    before the description's 2+ space gutter) is a comma-separated list where
+    EVERY part begins with `-`. That last condition is what rejects wrapped
+    prose like "--implementation, --platform, and --python-version", which
+    otherwise parses as three definitions and silently overwrites the real
+    ones with the wrong arity.
+    """
+    out: dict[str, bool] = {}
+    for line in text.splitlines():
+        if not re.match(r"^\s+-", line):
+            continue
+        head = re.split(r"\s{2,}", line.strip(), maxsplit=1)[0].rstrip(",")
+        parts = [p.strip() for p in head.split(",")]
+        if not parts or not all(p.startswith("-") for p in parts):
+            continue
+        # Reject WRAPPED PROSE that happens to begin with a flag. pip's
+        # `--extra-index-url` description wraps onto a line reading just
+        # "--index-url.", which parses as a definition with no metavar and
+        # then overwrote the real `-i, --index-url <url>` entry with
+        # takes_value=False -- a false MISCLASSIFIED report that cost a real
+        # investigation. Trailing sentence punctuation is the tell.
+        # `...` is the REPEATABLE-counter marker (`-q, --quiet...`), not
+        # sentence punctuation, so strip it before judging.
+        last = parts[-1].rstrip()
+        while last.endswith("..."):
+            last = last[:-3]
+        if last.endswith((".", ",", ":", ";")):
+            continue
+        words = parts[-1].split()
+        # A trailing `...` marks a REPEATABLE counter (uv prints `-q,
+        # --quiet...`), not a value. Reading those as value flags would eat
+        # the package in `uvx --quiet my-package`.
+        takes = len(words) > 1 and not words[0].endswith("...")
+        for part in parts:
+            flag = part.split()[0].rstrip(".")
+            out.setdefault(flag, takes)
+            out[flag] = takes
+    return out
+
+
+UVX = definitions(help_text(["uv", "tool", "run", "--help"]))
+DOCKER = definitions(help_text(["docker", "run", "--help"]))
+PIP = definitions(help_text(["pip", "install", "--help"]))
+CARGO = definitions(help_text(["cargo", "run", "--help"]))
+CARGO.update(
+    {k: v for k, v in definitions(help_text(["cargo", "install", "--help"])).items()}
+)
+NPM = definitions(help_text(["npm", "exec", "--help"]))
+
+# `docker run --help` never documents combined short flags; they are one token
+# formed from two documented booleans. Justified by hand, and the ONLY entries
+# permitted to be absent from help.
+JUSTIFIED_ABSENT = {
+    ("docker", "-it"): "combined -i -t; docker documents them only separately",
+    ("docker", "-ti"): "combined -t -i; docker documents them only separately",
+}
+
+# npm's option LIST prints a bare `--package` with the description on the next
+# line, so the metavar never appears where this parser looks. Its USAGE block
+# is unambiguous -- `npm exec --package=<pkg>[@<version>] -- <cmd>` and
+# `[--package <package-spec> ...]` -- so the arity is verified from there.
+JUSTIFIED_ARITY = {
+    ("npm", "--package"): "metavar is in the usage block, not the option list",
+}
+
+TABLES = [
+    ("uvx", UVX, "value", vc._UVX_VALUE_FLAGS),
+    ("uvx", UVX, "boolean", vc._UVX_BOOLEAN_FLAGS),
+    ("uvx", UVX, "positive", vc._UVX_POSITIVE_FLAGS),
+    ("pip", PIP, "value", vc._PIP_VALUE_FLAGS),
+    ("pip", PIP, "boolean", vc._PIP_BOOLEAN_FLAGS),
+    ("cargo", CARGO, "value", vc._CARGO_VALUE_FLAGS),
+    ("cargo", CARGO, "boolean", vc._CARGO_BOOLEAN_FLAGS),
+    ("cargo", CARGO, "positive", vc._CARGO_POSITIVE_FLAGS),
+    ("docker", DOCKER, "value", vc._DOCKER_VALUE_FLAGS),
+    ("docker", DOCKER, "boolean", vc._DOCKER_BOOLEAN_FLAGS),
+    ("npm", NPM, "positive", vc._NPM_POSITIVE_FLAGS),
+]
+
+
+def main() -> int:
+    mismatches: list[str] = []
+    unverified: list[str] = []
+    checked = 0
+
+    for tool, help_table, kind, flags in TABLES:
+        for flag in sorted(flags):
+            checked += 1
+            if flag not in help_table:
+                why = JUSTIFIED_ABSENT.get((tool, flag))
+                if why:
+                    print(f"  ABSENT-OK  {tool:6s} {kind:8s} {flag:24s} {why}")
+                else:
+                    unverified.append(f"{tool} {kind} {flag}")
+                continue
+            takes = help_table[flag]
+            # value and positive flags must take a value; boolean must not.
+            expected = kind in ("value", "positive")
+            if takes != expected and (tool, flag) in JUSTIFIED_ARITY:
+                print(f"  ARITY-OK   {tool:6s} {kind:8s} {flag:24s} "
+                      f"{JUSTIFIED_ARITY[(tool, flag)]}")
+            elif takes != expected:
+                mismatches.append(
+                    f"{tool} {kind:8s} {flag:24s} "
+                    f"help says takes_value={takes}, table says {expected}"
+                )
+
+    print(f"\nchecked {checked} entries against live --help output")
+
+    if mismatches:
+        print(f"\n!! {len(mismatches)} MISCLASSIFIED ENTRIES:")
+        for m in mismatches:
+            print(f"   {m}")
+    if unverified:
+        print(f"\n!! {len(unverified)} ENTRIES NOT FOUND IN HELP (unverified):")
+        for u in unverified:
+            print(f"   {u}")
+    if not mismatches and not unverified:
+        print("\nAll entries verified against the tool's own --help.")
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.consiliency/plans/detailed-value-flag-collisions-20260826-0500.md
+++ b/.consiliency/plans/detailed-value-flag-collisions-20260826-0500.md
@@ -99,6 +99,14 @@ are kept as explicit positive cases, not as an exhaustion attempt.
 - `detect_package_type` cargo branch — **modify** — keep `-p`/`--package`/
   `--bin` as known-positive (their value *is* the package); any other bare flag
   before the candidate yields unknown.
+- `_npm_package_arg` — **modify.** *Board finding: the original change list
+  omitted this entirely, so the seventh collision would have shipped unfixed.*
+  It currently skips `--package=old` as a flag and `--` as a flag, then returns
+  `bin` (verified). Treating `--package=old` as merely "self-delimiting, so keep
+  scanning" does **not** extract `old` — the scanner must read the value out of
+  `--package=<pkg>` / `-p <pkg>` and return it as the package. This is the only
+  one of the seven where identity is genuinely **recoverable**; the other six
+  are refusals.
 - `_docker_image_arg` — **modify** — keep `_value_flags` as a fast path for the
   flags it already lists, and add the same ambiguity rule for anything not in
   it, so `--env-file` and `--mount` stop consuming the image. Do **not** simply
@@ -140,11 +148,23 @@ are kept as explicit positive cases, not as an exhaustion attempt.
 
   Two consequences for the design:
 
-  1. **`--from` must be honoured wherever it appears**, not only as the first
-     flag. A naive left-to-right ambiguity rule would hit the bare `--python`
-     first and return unknown — breaking the documented form rather than fixing
-     it. Scan for `--from` (and `--from=`) across the whole argv before applying
-     the ambiguity rule.
+  1. **`--from` must be honoured wherever it appears in uvx's OWN argv** — but
+     the scan must **stop at the tool-name / `--` boundary**. *Board finding.*
+     uv passes everything after the tool name through to the tool, so an
+     unbounded scan would mistake a *server's own* later `--from` argument for
+     uvx's package identity. A naive left-to-right ambiguity rule is equally
+     wrong in the other direction: it hits the bare `--python` first and returns
+     unknown, breaking the documented form rather than fixing it.
+  2. **The `=` spelling has a pin hazard that must be closed in the same
+     change.** *Board finding, verified:* `_detect_effective_version_pin`
+     (`handlers.py:319`) skips every `-`-prefixed token, so
+     `--from=index-it-mcp==1.2.0` reports **no pin** while the spaced form
+     `--from index-it-mcp==1.2.0` correctly reports `1.2.0`. If the detector
+     starts recognising the `=` spelling for *identity* without pin detection
+     learning it too, `update_server` will classify the package, see no pin, and
+     probe for **latest** — updating a server the operator explicitly pinned.
+     Identity and pin must share one boundary-aware uvx scan, exactly as
+     `_npm_package_arg` is shared between the two.
   2. With that, the README form resolves correctly to `index-it-mcp` and needs
      **no doc change** — the fix repairs it instead of degrading it. Verify this
      exact string in the acceptance criteria rather than assuming.
@@ -203,9 +223,17 @@ automation:
 
 ## Acceptance criteria
 
-- [ ] All seven pairs in the table resolve to **different** identities — proven
-      by `TestValueFlagCollisions`, each node mutation-proved with recorded
-      output, all seven RED today.
+- [ ] **Six ambiguous pairs resolve to exactly `("unknown", None)`** — NOT to
+      "different identities". *Board finding: the original criterion was
+      logically impossible.* It demanded those pairs be simultaneously unknown
+      **and** unequal, but two unknowns are equal, so no implementation could
+      satisfy it. The real safety property is that **unknown never confirms
+      identity**, which `_same_package` (`refresher.py:213`) already enforces —
+      assert the exact unknown tuple, not inequality.
+- [ ] **The one recoverable pair — `npm exec --package=old/new -- bin` — resolves
+      to `old` and `new` respectively**, asserted by exact name *and* inequality.
+      `--package=` is self-delimiting, so identity here is genuinely recoverable
+      rather than merely refused.
 - [ ] Ambiguous forms yield `("unknown", None)`, never a wrong name — proven by
       `TestValueFlagsFailClosed`.
 - [ ] Every known-positive form is unchanged: `uvx --from pkg`, `cargo -p pkg`,

--- a/.consiliency/plans/detailed-value-flag-collisions-20260826-0500.md
+++ b/.consiliency/plans/detailed-value-flag-collisions-20260826-0500.md
@@ -129,11 +129,25 @@ are kept as explicit positive cases, not as an exhaustion attempt.
   affected servers refresh once; a server launched with an ambiguous flag form
   can no longer be auto-updated (state this plainly, it is the cost); and the
   identity gate now actually holds for the forms #180 left open.
-- `README.md` — **check, likely modify.** It documents pinning as
-  `"args": ["--python", "3.12", "--from", …]`. If that exact form now yields
-  unknown, the README is recommending a config this change degrades — either the
-  form must stay supported via `--from`, or the README must change. **Resolve
-  this before implementing; do not leave it to discovery.**
+- `README.md` — **resolved before implementing, and it changes the design.**
+  The README documents (`README.md:1133-1137`) a first-party pin form:
+
+      uvx --python 3.12 --from index-it-mcp==1.2.0 index-it-mcp
+
+  Measured on `main` today, that resolves to **`('pypi', '3.12')`** — the Python
+  *version* as the package name. So #182 is not hypothetical for uvx: it already
+  mis-identifies a config this repo recommends in its own README.
+
+  Two consequences for the design:
+
+  1. **`--from` must be honoured wherever it appears**, not only as the first
+     flag. A naive left-to-right ambiguity rule would hit the bare `--python`
+     first and return unknown — breaking the documented form rather than fixing
+     it. Scan for `--from` (and `--from=`) across the whole argv before applying
+     the ambiguity rule.
+  2. With that, the README form resolves correctly to `index-it-mcp` and needs
+     **no doc change** — the fix repairs it instead of degrading it. Verify this
+     exact string in the acceptance criteria rather than assuming.
 - **#180 can close** if all its remaining forms are covered. Verify rather than
   assume — that issue was already narrowed once.
 
@@ -200,8 +214,12 @@ automation:
       the existing suite staying green.
 - [ ] `update_server` refuses rather than probing for an ambiguous server —
       proven by a **no-probe-executed** assertion, not a parse assertion.
-- [ ] The README pinning example is reconciled: either it still resolves, or the
-      README is updated. Decided explicitly, not discovered.
+- [ ] The README's documented pin form resolves to the package, not the Python
+      version — `detect_package_type("uvx", ["--python","3.12","--from",
+      "index-it-mcp==1.2.0","index-it-mcp"])` must yield `index-it-mcp`, where
+      today it yields `3.12`. RED today; this is a first-party config the repo
+      recommends in its own README (`README.md:1133`), so it is a real
+      user-facing defect, not a constructed one.
 - [ ] Full suite, ruff, mypy green; CHANGELOG records the fix **and** the
       auto-update cost.
 - [ ] **#180's status is settled explicitly** — closed if genuinely covered, or

--- a/.consiliency/plans/detailed-value-flag-collisions-20260826-0500.md
+++ b/.consiliency/plans/detailed-value-flag-collisions-20260826-0500.md
@@ -53,35 +53,66 @@ incomplete twice.
 docker flags named in the issue and leave the class open — precisely the
 "fix the instance, not the class" error the last three rounds caught.
 
-## The design: `--flag=value` is safe, bare `--flag value` is not
+## The design: three-way flag classification, fail-closed default
 
-An argv scanner cannot know whether `--foo bar` means "flag `--foo` with value
-`bar`" or "boolean flag `--foo`, then positional `bar`" without a per-tool table
-of which flags take values. That table is the thing that keeps being incomplete.
+*This section was rewritten after board review. The original — "any bare
+`--flag` before the candidate makes identity unrecoverable" — was verified to
+break more than it fixed; see **Rejected** below.*
 
-What it *can* know, without any table:
+Per ecosystem, classify each flag into one of three kinds, and **default an
+unlisted bare flag to unknown**:
 
-- `--flag=value` is **self-delimiting**. The value cannot be mistaken for a
-  positional, so a token after it is genuinely positional.
-- A bare `--flag` is **ambiguous**. The next token may or may not belong to it.
+| kind | behaviour | examples |
+|---|---|---|
+| **known-value** | consumes the next token | uvx `--python`, `--with`, `--index-url`; docker's existing `_value_flags` **plus** `--env-file`, `--mount`; cargo `--features`, `--target`; pip `--index-url`, `-i` |
+| **known-boolean** | skip, next token is still a candidate | uvx `--quiet`, `--verbose`; docker `-i`, `-t`, `-it`, `-d`, `--rm`, `--init` |
+| **known-positive** | its value **is** the package | uvx `--from`; cargo `-p`, `--package`, `--bin`; npm `--package` |
+| *unlisted bare flag* | **`("unknown", None)`** | anything not classified |
 
-So: **when a bare `--flag` precedes the candidate token, identity is not
-recoverable** — return `("unknown", None)`. Under the identity gate, unknown
-means *cannot confirm → refresh*, which is safe; and `update_server` already
-refuses cleanly on unknown before building any probe (`handlers.py`, the
-`package_type == "unknown"` guard), which is the #183 outcome.
+**Why this is not the denylist #183 rejected.** Docker's `_value_flags` failed
+open because the *default* for an unlisted flag was "skip it and take the next
+token as the image" — an omission silently produced a wrong identity. Inverting
+the default is the whole point: an omission now costs *auto-update for one odd
+config* (safe, loud, fixable by adding an entry) instead of a *silent collision*
+(unsafe, invisible). Same table, opposite failure direction.
 
-**The cost, stated plainly:** a server launched as `uvx --python 3.12 pkg`
-becomes unverifiable and refreshes every time, and `update_server` will refuse
-to auto-update it. That is a real regression in convenience for a legitimate
-config. It is accepted because the alternative is what ships today: two
-different packages sharing one identity, with the wrong descriptions served
-indefinitely and no signal. Failing closed is loud and recoverable; failing open
-is silent.
+**The honest residual:** a *wrong* entry still fails open. Classify `--pull` as
+boolean when it actually takes a value and that value becomes the image. So
+entries must be verified individually against each tool's documentation and
+pinned by a test — never bulk-imported from memory.
 
-**Known-safe value flags stay enumerated** where the value *is* the package —
-`uvx --from`, `pip --index-url` is not one, `cargo -p/--package/--bin`. These
-are kept as explicit positive cases, not as an exhaustion attempt.
+### Rejected: pure fail-closed on any bare flag
+
+*Board finding, verified.* It would have broken the canonical configs:
+
+```
+uvx    --quiet my-package --arg            -> my-package        (would become unknown)
+docker run -i --rm mcp/server:latest       -> mcp/server        (would become unknown)
+docker run -e KEY=val --rm ghcr.io/org/mcp -> ghcr.io/org/mcp   (would become unknown)
+docker run -it --rm img                    -> img               (would become unknown)
+```
+
+`docker run -i --rm <image>` is *the* canonical docker MCP shape — this repo's
+own README uses `docker run -it --rm` (`README.md:1528`) — and `-it` is a
+combined short boolean no value-table would match. Under the rejected rule
+essentially every real docker server became permanently unverifiable and
+un-auto-updatable, and three currently-green tests
+(`tests/test_version_checker.py:101-107`, `:121-127`, `:131-137`) would have
+turned red, contradicting this plan's own "existing suite stays green"
+criterion. That regression dwarfs the collisions it closed.
+
+### It also dissolves the `--from` hazard
+
+With `--python` classified as known-value, a plain **left-to-right** scan
+resolves the README form deterministically: `--python` consumes `3.12`, then
+`--from` yields the package. **No whole-argv `--from` scan is needed**, which
+removes the hazard the board found — measured, `uvx mypkg --from other` today
+correctly yields `mypkg`, and a global scan would have returned `other`: a
+fail-open misidentification *introduced by the fix*, re-colliding
+`uvx a --from x` with `uvx b --from x` through the new path.
+
+Scans must still terminate at a `--` separator and at the first unambiguous
+positional, since everything after the tool name belongs to the served tool.
 
 ## Changes
 

--- a/.consiliency/plans/detailed-value-flag-collisions-20260826-0500.md
+++ b/.consiliency/plans/detailed-value-flag-collisions-20260826-0500.md
@@ -139,9 +139,10 @@ positional, since everything after the tool name belongs to the served tool.
   one of the seven where identity is genuinely **recoverable**; the other six
   are refusals.
 - `_docker_image_arg` — **modify** — keep `_value_flags` as a fast path for the
-  flags it already lists, and add the same ambiguity rule for anything not in
-  it, so `--env-file` and `--mount` stop consuming the image. Do **not** simply
-  add those two to the set.
+  flags it already lists, **add `--env-file` and `--mount` to it**, classify
+  `-i -t -it -d --rm --init` as known-boolean, and default any *unlisted* bare
+  flag to unknown. The point is not to complete the table — it is that an
+  omission now costs auto-update rather than a silent collision.
 
 ### `tests/test_version_checker.py` (modify)
 
@@ -284,10 +285,19 @@ automation:
       `probes == []`. *Board finding:* a bare `probes == []` passes when
       update_server refuses for any unrelated earlier reason, so it does not pin
       what it claims. Mirror `tests/test_tools.py:4885-4896`, the #183 model.
-- [ ] **`--from` value normalization is decided explicitly, not discovered** —
-      the manifest carries `--from browser-use[cli]`, so pick PEP-508 base name
-      (strips extras; changes that identity, one-time refresh, and makes its
-      PyPI lookups resolvable) or `==`-strip only, and pin `git+https://…` too.
+- [ ] **`--from` normalization: PEP 508 base name — DECIDED, and it fixes a live
+      defect.** `browser-use[cli]` → `browser-use`, `index-it-mcp==1.2.0` →
+      `index-it-mcp`. Measured: `manifest.yaml:352-357` ships
+      `--from browser-use[cli]`, and a PyPI lookup for `browser-use[cli]`
+      returns **None** while `browser-use` returns `0.13.8` — so that
+      first-party entry's version checks are **silently failing today**.
+      Stripping extras repairs it. Cost: browser-use's cached identity changes,
+      so it refreshes once — the same one-time migration 2.4.0 and 2.4.1 made.
+- [ ] **A `git+https://…` value is its own identity** — the URL string, not
+      `unknown`. Distinct URLs are distinct identities, so the gate stays
+      correct and two repos never confirm as one; the PyPI lookup fails closed
+      to `None`, which the gate already reads as *cannot confirm → refresh*.
+      No new code path. Pin `--from git+https://x/y` explicitly.
 - [ ] The README's documented pin form resolves to the package, not the Python
       version — `detect_package_type("uvx", ["--python","3.12","--from",
       "index-it-mcp==1.2.0","index-it-mcp"])` must yield `index-it-mcp`, where

--- a/.consiliency/plans/detailed-value-flag-collisions-20260826-0500.md
+++ b/.consiliency/plans/detailed-value-flag-collisions-20260826-0500.md
@@ -254,25 +254,40 @@ automation:
 
 ## Acceptance criteria
 
-- [ ] **Six ambiguous pairs resolve to exactly `("unknown", None)`** — NOT to
-      "different identities". *Board finding: the original criterion was
-      logically impossible.* It demanded those pairs be simultaneously unknown
-      **and** unequal, but two unknowns are equal, so no implementation could
-      satisfy it. The real safety property is that **unknown never confirms
-      identity**, which `_same_package` (`refresher.py:213`) already enforces —
-      assert the exact unknown tuple, not inequality.
-- [ ] **The one recoverable pair — `npm exec --package=old/new -- bin` — resolves
-      to `old` and `new` respectively**, asserted by exact name *and* inequality.
-      `--package=` is self-delimiting, so identity here is genuinely recoverable
-      rather than merely refused.
-- [ ] Ambiguous forms yield `("unknown", None)`, never a wrong name — proven by
-      `TestValueFlagsFailClosed`.
+- [ ] **The class property, stated so it is satisfiable:** for every pair,
+      `d(a) != d(b)` **or** `d(a) == ("unknown", None)`, **and** each pair's
+      exact expected value is pinned. *Board finding: the original criterion was
+      logically impossible* — it demanded pairs be simultaneously unknown **and**
+      unequal, and two unknowns are equal. The safety property is that unknown
+      never *confirms* identity, which `_same_package` (`refresher.py:199-229`)
+      already enforces. Under the three-way design most pairs now resolve to
+      real, **different** names rather than being refused.
+- [ ] **`npm exec --package=old/new -- bin` resolves to `old` and `new`** — by
+      exact name and inequality. `--package` is known-positive: its value IS the
+      package, so `_npm_package_arg` must read the value out of it. Treating
+      `--package=old` as merely self-delimiting still returns `bin`, verified.
+- [ ] **These four currently-green forms resolve exactly as today** —
+      `uvx --quiet my-package --arg` → `my-package`,
+      `docker run -i --rm mcp/server:latest` → `mcp/server`,
+      `docker run -e KEY=val --rm ghcr.io/org/mcp` → `ghcr.io/org/mcp`,
+      `docker run -it --rm img` → `img`. The rejected fail-closed design broke
+      all four; `-it` is the canonical shape in this repo's own README (`:1528`).
+- [ ] `uvx mypkg --from other` still yields `mypkg`, not `other` — the fail-open
+      misidentification a whole-argv `--from` scan would have introduced.
 - [ ] Every known-positive form is unchanged: `uvx --from pkg`, `cargo -p pkg`,
       `cargo --bin b`, `pip install pkg`, `npx -y pkg`, `docker run img`, and
       every `#180`/`#183` form — proven by `TestKnownPositiveValueFlags` plus
       the existing suite staying green.
-- [ ] `update_server` refuses rather than probing for an ambiguous server —
-      proven by a **no-probe-executed** assertion, not a parse assertion.
+- [ ] `update_server` refuses rather than probing for a genuinely unclassifiable
+      server — proven by **all four** of `ok is False`,
+      `package_type == "unknown"`, the message naming the command line, and
+      `probes == []`. *Board finding:* a bare `probes == []` passes when
+      update_server refuses for any unrelated earlier reason, so it does not pin
+      what it claims. Mirror `tests/test_tools.py:4885-4896`, the #183 model.
+- [ ] **`--from` value normalization is decided explicitly, not discovered** —
+      the manifest carries `--from browser-use[cli]`, so pick PEP-508 base name
+      (strips extras; changes that identity, one-time refresh, and makes its
+      PyPI lookups resolvable) or `==`-strip only, and pin `git+https://…` too.
 - [ ] The README's documented pin form resolves to the package, not the Python
       version — `detect_package_type("uvx", ["--python","3.12","--from",
       "index-it-mcp==1.2.0","index-it-mcp"])` must yield `index-it-mcp`, where

--- a/.consiliency/plans/detailed-value-flag-collisions-20260826-0500.md
+++ b/.consiliency/plans/detailed-value-flag-collisions-20260826-0500.md
@@ -1,0 +1,208 @@
+# Detailed plan: stop reading a flag's value as the package name
+
+## Task
+
+Close Consiliency/pmcp#182. `detect_package_type` skips **flags** but not the
+**values those flags carry**, so the first non-flag token is often a flag's
+argument rather than the package. Two different servers then resolve to the same
+identity, and v2.4.0's identity gate — which compares exactly this name to decide
+whether a cached description still describes the configured package — reads that
+as a **positive confirmation** and serves the wrong package's tool descriptions.
+
+All seven reproduce on `main` @ `75eb9c7`:
+
+```
+uvx   --python 3.12 pkg-a / pkg-b          -> both ('pypi',  '3.12')
+uvx   --with requests srv-a / srv-b        -> both ('pypi',  'requests')
+pip   install --index-url URL pkg-a / b    -> both ('pypi',  'https://x')
+cargo run --features full srv-a / srv-b    -> both ('cargo', 'full')
+docker run --env-file .env img-a / img-b   -> both ('docker','.env')
+docker run --mount type=bind,… img-a / b   -> both ('docker','type=bind,src=/a')
+npm   exec --package=old/new -- bin        -> both ('npm',   'bin')
+```
+
+`uvx --from thing other -> ('pypi','thing')` is correct **only by luck**:
+`--from`'s value happens to be the package. That single safe flag is what made
+the branch look sound in #180's research.
+
+## Research summary
+
+Context is in session from #180/#183, so no Explore fan-out; the branches were
+read directly (`src/pmcp/manifest/version_checker.py`, `detect_package_type` and
+the `_docker_image_arg` helper).
+
+**Two models already exist in this file, and they disagree.**
+
+- **Docker enumerates.** `_docker_image_arg` carries a `_value_flags` set —
+  `-e --env -v --volume -p --publish --name --network -u --user --entrypoint
+  -w --workdir --label -l --memory -m --cpus --add-host --dns --hostname -h` —
+  and skips the token after each. It is the most careful branch in the file and
+  **it is still incomplete**: `--env-file` and `--mount` are missing, which is
+  how two of the seven collisions above happen.
+- **uvx / pip / cargo do not enumerate at all.** They skip `arg.startswith("-")`
+  and take the next bare token, so *every* value-carrying flag collides.
+
+**#183 already settled this design question in this same function.** Its first
+fix was a denylist of npm subcommands; the board rejected it because a denylist
+**fails open** — anything unlisted became an installable package name. It was
+inverted to an allowlist. Docker's `_value_flags` is the same shape: an
+enumeration whose omissions fail open, and it has already been demonstrated
+incomplete twice.
+
+**So this plan does not extend the enumeration.** Extending it would fix the two
+docker flags named in the issue and leave the class open — precisely the
+"fix the instance, not the class" error the last three rounds caught.
+
+## The design: `--flag=value` is safe, bare `--flag value` is not
+
+An argv scanner cannot know whether `--foo bar` means "flag `--foo` with value
+`bar`" or "boolean flag `--foo`, then positional `bar`" without a per-tool table
+of which flags take values. That table is the thing that keeps being incomplete.
+
+What it *can* know, without any table:
+
+- `--flag=value` is **self-delimiting**. The value cannot be mistaken for a
+  positional, so a token after it is genuinely positional.
+- A bare `--flag` is **ambiguous**. The next token may or may not belong to it.
+
+So: **when a bare `--flag` precedes the candidate token, identity is not
+recoverable** — return `("unknown", None)`. Under the identity gate, unknown
+means *cannot confirm → refresh*, which is safe; and `update_server` already
+refuses cleanly on unknown before building any probe (`handlers.py`, the
+`package_type == "unknown"` guard), which is the #183 outcome.
+
+**The cost, stated plainly:** a server launched as `uvx --python 3.12 pkg`
+becomes unverifiable and refreshes every time, and `update_server` will refuse
+to auto-update it. That is a real regression in convenience for a legitimate
+config. It is accepted because the alternative is what ships today: two
+different packages sharing one identity, with the wrong descriptions served
+indefinitely and no signal. Failing closed is loud and recoverable; failing open
+is silent.
+
+**Known-safe value flags stay enumerated** where the value *is* the package —
+`uvx --from`, `pip --index-url` is not one, `cargo -p/--package/--bin`. These
+are kept as explicit positive cases, not as an exhaustion attempt.
+
+## Changes
+
+### `src/pmcp/manifest/version_checker.py` (modify)
+
+- `_takes_a_value_ambiguously(arg)` — **add** — module-private predicate: true
+  for a token starting `-` that is **not** `--flag=value` form and not in the
+  branch's known-positive set. One home for the rule.
+- `detect_package_type` uvx branch — **modify** — honour `--from <pkg>` as the
+  package (already the documented pin form, see `README.md` around the
+  `"args": ["--python", ...]` example); return `("unknown", None)` when any
+  other bare flag precedes the candidate.
+- `detect_package_type` pip branch — **modify** — same rule; keep the existing
+  `install`/`upgrade` subcommand skips.
+- `detect_package_type` cargo branch — **modify** — keep `-p`/`--package`/
+  `--bin` as known-positive (their value *is* the package); any other bare flag
+  before the candidate yields unknown.
+- `_docker_image_arg` — **modify** — keep `_value_flags` as a fast path for the
+  flags it already lists, and add the same ambiguity rule for anything not in
+  it, so `--env-file` and `--mount` stop consuming the image. Do **not** simply
+  add those two to the set.
+
+### `tests/test_version_checker.py` (modify)
+
+- `TestValueFlagCollisions` — **add** — one **inequality** assertion per
+  collision pair above. A value assertion would pass against a parser that
+  collapses both forms onto some other shared name; only inequality is falsified
+  by the collision itself. All seven are RED today.
+- `TestValueFlagsFailClosed` — **add** — the ambiguous forms resolve to
+  `("unknown", None)` rather than to a wrong name.
+- `TestKnownPositiveValueFlags` — **add** — `uvx --from pkg`, `cargo -p pkg`,
+  `cargo --bin b`, `pip install pkg`, `npx -y pkg`, `docker run img` and the
+  `#180` forms all still resolve exactly as before.
+
+### `tests/test_tools.py` (modify)
+
+- Pin-detection matrix — **add** — a `uvx --python 3.12 pkg` server now yields
+  no identity, so `update_server` refuses rather than probing. Assert **no probe
+  was executed**, mirroring the `#183` test — the parse being right only matters
+  if it reaches the refusal.
+
+## Documentation impact
+
+- `CHANGELOG.md` — **add** — a `### Fixed` bullet. User-visible three ways:
+  affected servers refresh once; a server launched with an ambiguous flag form
+  can no longer be auto-updated (state this plainly, it is the cost); and the
+  identity gate now actually holds for the forms #180 left open.
+- `README.md` — **check, likely modify.** It documents pinning as
+  `"args": ["--python", "3.12", "--from", …]`. If that exact form now yields
+  unknown, the README is recommending a config this change degrades — either the
+  form must stay supported via `--from`, or the README must change. **Resolve
+  this before implementing; do not leave it to discovery.**
+- **#180 can close** if all its remaining forms are covered. Verify rather than
+  assume — that issue was already narrowed once.
+
+## Dependencies & order
+
+1. `_takes_a_value_ambiguously` before any branch uses it.
+2. All five branch edits in one commit; a half-applied rule is worse than none,
+   since it makes some ecosystems fail closed and others fail open.
+3. Tests written and shown **RED per node** before the implementation.
+
+## Verification
+
+```bash
+cd /mnt/workspace/worktrees/pmcp-182-flagvalues
+find src tests -name __pycache__ -type d -exec rm -rf {} + 2>/dev/null
+
+# All seven collisions gone:
+PYTHONDONTWRITEBYTECODE=1 uv run python - <<'PY'
+from pmcp.manifest.version_checker import detect_package_type as d
+pairs = [("uvx",["--python","3.12","a"],["--python","3.12","b"]),
+         ("uvx",["--with","requests","a"],["--with","requests","b"]),
+         ("pip",["install","--index-url","u","a"],["install","--index-url","u","b"]),
+         ("cargo",["run","--features","f","a"],["run","--features","f","b"]),
+         ("docker",["run","--env-file",".e","a"],["run","--env-file",".e","b"]),
+         ("docker",["run","--mount","m","a"],["run","--mount","m","b"]),
+         ("npm",["exec","--package=old","--","bin"],["exec","--package=new","--","bin"])]
+bad = [(c,x) for c,x,y in pairs if d(c,x) == d(c,y)]
+print("still colliding:", bad or "none")
+assert not bad
+PY
+
+PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/ -q
+uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/
+uv run mypy src/pmcp --exclude baml_client
+```
+
+**Mutation proof, per node, output recorded.** For each collision test, revert
+its branch's rule and confirm *that single test* fails — never the class. A red
+class proves nothing about the specific test; that is how three hollow tests
+shipped in this repo. Purge `__pycache__` and use `PYTHONDONTWRITEBYTECODE=1`
+around every apply/restore: stale bytecode fabricated a false red in #184 and
+can equally fabricate a false green.
+
+## Automation
+
+```yaml
+automation:
+  suite_command: "uv run pytest -q"
+```
+
+## Execution Policy
+- execute: effort=medium, reason=small surface but identity semantics are subtly wrong-prone
+
+## Acceptance criteria
+
+- [ ] All seven pairs in the table resolve to **different** identities — proven
+      by `TestValueFlagCollisions`, each node mutation-proved with recorded
+      output, all seven RED today.
+- [ ] Ambiguous forms yield `("unknown", None)`, never a wrong name — proven by
+      `TestValueFlagsFailClosed`.
+- [ ] Every known-positive form is unchanged: `uvx --from pkg`, `cargo -p pkg`,
+      `cargo --bin b`, `pip install pkg`, `npx -y pkg`, `docker run img`, and
+      every `#180`/`#183` form — proven by `TestKnownPositiveValueFlags` plus
+      the existing suite staying green.
+- [ ] `update_server` refuses rather than probing for an ambiguous server —
+      proven by a **no-probe-executed** assertion, not a parse assertion.
+- [ ] The README pinning example is reconciled: either it still resolves, or the
+      README is updated. Decided explicitly, not discovered.
+- [ ] Full suite, ruff, mypy green; CHANGELOG records the fix **and** the
+      auto-update cost.
+- [ ] **#180's status is settled explicitly** — closed if genuinely covered, or
+      its remaining gap named. It has been narrowed once already; do not assume.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A command-line flag's *value* is no longer mistaken for the package name.**
+  Package detection skipped flags but not the tokens those flags carry, so the
+  first "non-flag" argument was routinely a flag's argument. `uvx --python 3.12
+  pkg-a` and `uvx --python 3.12 pkg-b` both resolved to `3.12`, and because
+  2.4.0's identity gate compares exactly this name to decide whether a cached
+  description still describes the configured package, an equal name read as a
+  **positive confirmation** — serving one package's tool descriptions for a
+  different package indefinitely. Seven forms were affected: uvx `--python` and
+  `--with`, pip `--index-url`, cargo `--features`, docker `--env-file` and
+  `--mount`, and `npm exec --package=<pkg> -- <bin>` (which returned the
+  *binary*, so two packages exposing the same binary confirmed as one).
+
+  Flags are now classified per ecosystem as value-taking, boolean, or
+  *positive* (`uvx --from`, `cargo -p`, `npm --package` — where the value **is**
+  the package), with tables transcribed from each tool's own `--help`.
+
+  Three user-visible consequences:
+
+  1. **Affected servers refresh once.** Their cached identity changes, the same
+     one-time migration 2.4.0 and 2.4.1 made.
+  2. **A server launched with a flag pmcp does not recognise can no longer be
+     auto-updated.** This is the cost, and it is deliberate: anything unlisted
+     now reports no identity rather than guessing. An omission costs
+     auto-update for one unusual config — visible, and fixable by adding the
+     flag — where the previous "take the next token" default produced a silent
+     collision instead. `gateway.update_server` refuses such a server by name
+     and command line rather than probing.
+  3. **The identity gate now actually holds for the forms #180 left open.**
+
+- **`uvx --from` values are read as PEP 508 requirements.** `browser-use[cli]`
+  resolves to `browser-use` and `index-it-mcp==1.2.0` to `index-it-mcp`. This
+  repairs a live defect: the bundled manifest ships `--from browser-use[cli]`,
+  and a PyPI lookup for that literal string returns nothing, so that entry's
+  version checks had been silently failing. A `git+https://…` value keeps the
+  whole URL as its identity — distinct URLs are distinct packages.
+
+- **`gateway.update_server` no longer misreads a uvx version pin.** Pin
+  detection now shares one scan with package detection instead of skipping
+  every `-`-prefixed token and reading `==` off the first bare one. That was
+  wrong in both directions: `--from=pkg==1.2.0` reported *no pin*, so an
+  explicitly pinned server could have been moved to the latest version, while
+  `--with requests==2.0 pkg` reported an injected dependency's version as the
+  server's own pin and refused an update that was never pinned.
+
+  The README's documented pin form — `uvx --python 3.12 --from
+  index-it-mcp==1.2.0 index-it-mcp` — previously identified the package as
+  `3.12`; it now resolves correctly and needs no configuration change.
+
 ## [2.4.1] - 2026-08-25
 
 ### Security

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -88,6 +88,458 @@ _NPM_SUBCOMMANDS_WITH_A_PACKAGE_OPERAND = frozenset(
 _NPM_SUBCOMMANDS = _NPM_SUBCOMMANDS_WITH_A_PACKAGE_OPERAND
 
 
+# ---------------------------------------------------------------------------
+# Flag classification (Consiliency/pmcp#182)
+# ---------------------------------------------------------------------------
+#
+# The bug this closes: the scans below skipped *flags* but not the *values
+# those flags carry*, so the first "non-flag" token was routinely a flag's
+# argument. `uvx --python 3.12 pkg-a` and `uvx --python 3.12 pkg-b` both
+# resolved to `("pypi", "3.12")`, and 2.4.0's identity gate reads an equal name
+# as a POSITIVE confirmation -- serving pkg-a's cached tool descriptions for
+# pkg-b indefinitely.
+#
+# Every flag is classified into exactly one of three kinds, and **anything
+# unlisted defaults to refusing**:
+#
+#   value    -- consumes the next token; that token is NOT the package
+#   boolean  -- takes nothing; the next token is still a candidate
+#   positive -- its value IS the package (`uvx --from`, `cargo -p`)
+#   unlisted -- `("unknown", None)`
+#
+# **Why this is not the denylist Consiliency/pmcp#183 rejected.** Docker's
+# `_value_flags` table below has the same shape, and it failed OPEN: the
+# default for an unlisted flag was "skip it and take the next token as the
+# image", so an omission silently produced a WRONG identity -- which is exactly
+# how `--env-file` and `--mount` became two of the seven collisions. Inverting
+# the default is the entire point. An omission now costs auto-update for one
+# odd config (safe, loud, fixable by adding an entry) instead of a silent
+# collision (unsafe, invisible).
+#
+# **The honest residual: a WRONG entry still fails open.** Classify a flag as
+# boolean when it actually takes a value and that value becomes the package
+# name. `docker run --pull <policy>` is the live example -- it reads like a
+# boolean and is not. So these tables were transcribed from each tool's own
+# `--help` output and verified entry by entry against it, never bulk-imported
+# from memory; memory got `--pull`, uv's `--quiet`/`--verbose` (repeatable
+# counters, printed as `-q, --quiet...`) and pip's `--platform` wrong in
+# drafting. They are deliberately kept SMALL -- limited to what real MCP
+# launch configs use -- because fail-closed makes an omission cheap while
+# every extra entry is one more chance at a wrong arity.
+
+# uv (`uvx` == `uv tool run`), verified against `uv tool run --help`.
+_UVX_VALUE_FLAGS = frozenset(
+    {
+        "--python",
+        "-p",
+        "--with",
+        "--with-editable",
+        "--with-requirements",
+        "--index",
+        "--index-url",
+        "-i",
+        "--extra-index-url",
+        "--default-index",
+        "--find-links",
+        "-f",
+        "--constraints",
+        "-c",
+        "--overrides",
+        "--build-constraints",
+        "-b",
+        "--config-setting",
+        "-C",
+        "--exclude-newer",
+        "--refresh-package",
+        "--reinstall-package",
+        "--upgrade-package",
+        "-P",
+        "--no-binary-package",
+        "--no-build-package",
+        "--resolution",
+        "--prerelease",
+        "--index-strategy",
+        "--fork-strategy",
+        "--keyring-provider",
+        "--link-mode",
+        "--python-preference",
+        "--python-platform",
+        "--allow-insecure-host",
+        "--cache-dir",
+        "--config-file",
+        "--directory",
+        "--project",
+        "--env-file",
+        "--color",
+    }
+)
+_UVX_BOOLEAN_FLAGS = frozenset(
+    {
+        # `-q, --quiet...` / `-v, --verbose...` -- the trailing `...` marks a
+        # repeatable COUNTER, not a value. Reading them as value flags would
+        # eat the package in `uvx --quiet my-package`, which is a documented
+        # form and a pinned test.
+        "--quiet",
+        "-q",
+        "--verbose",
+        "-v",
+        "--isolated",
+        "--no-cache",
+        "-n",
+        "--offline",
+        "--native-tls",
+        "--refresh",
+        "--reinstall",
+        "--upgrade",
+        "-U",
+        "--no-config",
+        "--no-index",
+        "--no-progress",
+        "--no-sources",
+        "--no-binary",
+        "--no-build",
+        "--no-build-isolation",
+        "--compile-bytecode",
+        "--managed-python",
+        "--no-managed-python",
+        "--no-python-downloads",
+        "--system-certs",
+        "--no-env-file",
+        "--help",
+        "-h",
+        "--version",
+        "-V",
+    }
+)
+# `--from` names the package to install when it differs from the command being
+# run -- so its value IS the identity.
+_UVX_POSITIVE_FLAGS = frozenset({"--from"})
+
+# pip, verified against `pip install --help`.
+_PIP_VALUE_FLAGS = frozenset(
+    {
+        "--index-url",
+        "-i",
+        "--extra-index-url",
+        "--find-links",
+        "-f",
+        "--constraint",
+        "-c",
+        "--requirement",
+        "-r",
+        "--editable",
+        "-e",
+        "--target",
+        "-t",
+        "--prefix",
+        "--root",
+        "--src",
+        # These four read like booleans and are not (`--platform <platform>`).
+        "--platform",
+        "--python-version",
+        "--implementation",
+        "--abi",
+        "--proxy",
+        "--cert",
+        "--client-cert",
+        "--trusted-host",
+        "--log",
+        "--cache-dir",
+        "--timeout",
+        "--retries",
+        "--progress-bar",
+        "--exists-action",
+        "--upgrade-strategy",
+        "--no-binary",
+        "--only-binary",
+        "--global-option",
+        "--install-option",
+        "--use-feature",
+        "--use-deprecated",
+        "--report",
+        "--python",
+    }
+)
+_PIP_BOOLEAN_FLAGS = frozenset(
+    {
+        "--upgrade",
+        "-U",
+        "--user",
+        "--pre",
+        "--no-deps",
+        "--force-reinstall",
+        "--ignore-installed",
+        "--ignore-requires-python",
+        "--no-cache-dir",
+        "--no-index",
+        "--no-build-isolation",
+        "--use-pep517",
+        "--check-build-dependencies",
+        "--compile",
+        "--no-compile",
+        "--no-warn-script-location",
+        "--no-warn-conflicts",
+        "--require-hashes",
+        "--require-virtualenv",
+        "--isolated",
+        "--no-clean",
+        "--prefer-binary",
+        "--break-system-packages",
+        "--dry-run",
+        "--no-input",
+        "--no-color",
+        "--disable-pip-version-check",
+        "--no-python-version-warning",
+        "--quiet",
+        "-q",
+        "--verbose",
+        "-v",
+        "--debug",
+        "--help",
+        "-h",
+        "--version",
+        "-V",
+    }
+)
+_PIP_SUBCOMMANDS = frozenset({"install", "upgrade", "update"})
+
+# cargo, verified against `cargo run --help` and `cargo install --help`.
+_CARGO_VALUE_FLAGS = frozenset(
+    {
+        "--features",
+        "-F",
+        "--target",
+        "--target-dir",
+        "--manifest-path",
+        "--profile",
+        "--jobs",
+        "-j",
+        "--message-format",
+        "--color",
+        "--config",
+        "-Z",
+        "--example",
+        "--git",
+        "--branch",
+        "--tag",
+        "--rev",
+        "--path",
+        "--root",
+        "--registry",
+        "--index",
+        # `cargo install --version <ver>` -- a pin, never the crate name.
+        "--version",
+    }
+)
+_CARGO_BOOLEAN_FLAGS = frozenset(
+    {
+        "--release",
+        "-r",
+        "--all-features",
+        "--no-default-features",
+        "--offline",
+        "--locked",
+        "--frozen",
+        "--timings",
+        "--keep-going",
+        "--ignore-rust-version",
+        "--unit-graph",
+        "--bins",
+        "--examples",
+        "--force",
+        "-f",
+        "--debug",
+        "--dry-run",
+        "-n",
+        "--list",
+        "--no-track",
+        "--quiet",
+        "-q",
+        "--verbose",
+        "-v",
+        "--help",
+        "-h",
+    }
+)
+# `-p`/`--package`/`--bin` all name the thing being built or run.
+_CARGO_POSITIVE_FLAGS = frozenset({"-p", "--package", "--bin"})
+_CARGO_SUBCOMMANDS = frozenset({"run", "install", "build", "test", "check"})
+
+# npm. `--package` is the ONLY spelling: verified against `npm exec --help`,
+# whose options line reads `[--package <package-spec> ...]`. There is no `-p`
+# alias -- in npm `-p` means `--parseable` -- so listing one would be a WRONG
+# entry, which is the failure direction that stays open.
+_NPM_POSITIVE_FLAGS = frozenset({"--package"})
+
+# docker, verified against `docker run --help`.
+_DOCKER_BOOLEAN_FLAGS = frozenset(
+    {
+        "-i",
+        "--interactive",
+        "-t",
+        "--tty",
+        "-d",
+        "--detach",
+        # Combined short booleans. docker documents only `-i` and `-t`
+        # separately, so no table derived from `--help` can ever contain these
+        # -- they must be listed by hand. `docker run -it --rm <image>` is the
+        # canonical MCP shape and this repo's own README uses it (`:1528`);
+        # a design that refused it broke essentially every real docker server.
+        "-it",
+        "-ti",
+        "--rm",
+        "--init",
+        "--privileged",
+        "--read-only",
+        "--publish-all",
+        "-P",
+        "--sig-proxy",
+        "--no-healthcheck",
+        "--oom-kill-disable",
+        "--disable-content-trust",
+        "--use-api-socket",
+        "--quiet",
+        "-q",
+        "--help",
+    }
+)
+_DOCKER_SUBCOMMANDS = frozenset({"run", "exec", "start", "create", "pull", "push"})
+
+
+def _takes_a_value_ambiguously(arg: str) -> bool:
+    """Whether *arg* is a flag that might silently swallow the next token.
+
+    One home for the fail-closed rule. True for a token that starts with ``-``
+    and is **not** in the ``--flag=value`` form -- meaning its arity cannot be
+    read off the token itself, so the following token may be its value or may
+    be the package, and nothing here can tell which.
+
+    A ``--flag=value`` spelling is *self-delimiting*: the value rides inside
+    the token, so an unrecognised one cannot consume anything and is safe to
+    skip. Refusing on it would cost auto-update for no safety gain at all.
+
+    Callers apply this only **after** consulting their ecosystem's three
+    tables; a classified flag is never ambiguous by definition.
+    """
+    return arg.startswith("-") and arg != "-" and "=" not in arg
+
+
+def _scan_for_package_token(
+    args: list[str],
+    *,
+    value_flags: frozenset[str] = frozenset(),
+    boolean_flags: frozenset[str] = frozenset(),
+    positive_flags: frozenset[str] = frozenset(),
+    subcommands: frozenset[str] = frozenset(),
+) -> tuple[str | None, bool]:
+    """Left-to-right scan for the package token in *args*.
+
+    Returns ``(token, came_from_a_positive_flag)``. A ``None`` token means the
+    caller must report ``("unknown", None)`` -- either nothing was found or
+    something unclassifiable was hit.
+
+    **Left-to-right, deliberately.** An earlier draft scanned the whole of
+    argv for ``--from`` to rescue the README's documented pin form. Measured,
+    that turns ``uvx mypkg --from other`` from ``mypkg`` into ``other`` -- a
+    fail-open misidentification *introduced by the fix*, which would re-collide
+    ``uvx a --from x`` with ``uvx b --from x`` through the new path. With
+    ``--python`` classified as a value flag the plain scan resolves the README
+    form anyway, so no such hunt is needed.
+
+    The scan stops at ``--``: everything after it belongs to the tool being
+    run, not to the runner, and a served tool's own ``--from`` argument must
+    never be mistaken for the runner's package identity.
+    """
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--":
+            # End of the runner's own arguments.
+            return (None, False)
+        if arg.startswith("-") and arg != "-":
+            name, separator, attached = arg.partition("=")
+            if separator:
+                if name in positive_flags:
+                    return (attached or None, True)
+                # Self-delimiting, so it cannot swallow the next token --
+                # safe to skip whether or not it is a flag we know.
+                index += 1
+                continue
+            if arg in positive_flags:
+                following = args[index + 1] if index + 1 < len(args) else None
+                # A positive flag with nothing usable after it names no
+                # package; guessing at the token after a missing value is how
+                # a flag's value became an identity in the first place.
+                if following is None or following.startswith("-"):
+                    return (None, False)
+                return (following, True)
+            if arg in value_flags:
+                index += 2
+                continue
+            if arg in boolean_flags:
+                index += 1
+                continue
+            if _takes_a_value_ambiguously(arg):
+                return (None, False)
+            index += 1
+            continue
+        if arg in subcommands:
+            index += 1
+            continue
+        return (arg, False)
+    return (None, False)
+
+
+# A PEP 508 requirement ends its NAME at the first character that can begin an
+# extras group, a version specifier, an environment marker, or a URL.
+_PEP508_NAME = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)\s*(?:[\[<>=!~;@,(].*)?$")
+
+
+def _pep508_base_name(requirement: str) -> str:
+    """The bare package name inside a PEP 508 *requirement*.
+
+    ``browser-use[cli]`` -> ``browser-use``; ``index-it-mcp==1.2.0`` ->
+    ``index-it-mcp``; ``pkg>=1.0`` -> ``pkg``.
+
+    Applied only to ``--from`` values, which are requirements rather than bare
+    names. This **repairs a live defect** rather than introducing a behaviour
+    change: `manifest.yaml` ships ``--from browser-use[cli]``, and a PyPI
+    lookup for ``browser-use[cli]`` returns None while ``browser-use`` returns
+    a real version -- so that first-party entry's version checks have been
+    silently failing.
+
+    Anything that is not a plain requirement name -- most importantly a
+    ``git+https://...`` URL -- is returned **unchanged**. A VCS URL is its own
+    identity: there is no name to extract, distinct URLs are distinct
+    packages so the gate stays correct, and the PyPI lookup fails closed to
+    None, which the gate already reads as "cannot confirm -> refresh".
+    """
+    match = _PEP508_NAME.match(requirement.strip())
+    return match.group(1) if match else requirement
+
+
+def _uvx_package_arg(args: list[str]) -> tuple[str | None, bool]:
+    """Return ``(raw uvx package token, came_from_--from)``.
+
+    "Raw" means before ``_pep508_base_name`` normalisation -- shared between
+    ``detect_package_type`` and gateway.update_server's pin detection for
+    exactly the reason ``_npm_package_arg`` is shared: two independent scans
+    disagreeing about which argument is "the package" is how a real pin got
+    missed. Before this existed, pin detection skipped every ``-``-prefixed
+    token and read ``==`` off the first bare one, so
+    ``--from=index-it-mcp==1.2.0`` reported **no pin** (identity resolved
+    fine, so update_server would have probed for latest and updated a server
+    the operator had explicitly pinned), while ``--with requests==2.0 pkg``
+    reported an injected dependency's version as the server's own pin.
+    """
+    return _scan_for_package_token(
+        args,
+        value_flags=_UVX_VALUE_FLAGS,
+        boolean_flags=_UVX_BOOLEAN_FLAGS,
+        positive_flags=_UVX_POSITIVE_FLAGS,
+    )
+
+
 def _npm_package_arg(args: list[str], command: str) -> str | None:
     """Return the raw npm/npx package token from *args*, or ``None``.
 
@@ -115,14 +567,39 @@ def _npm_package_arg(args: list[str], command: str) -> str | None:
     * ``npm`` only, because ``npx -y exec`` genuinely names a package called
       ``exec``.
 
-    Known limitation, tracked on Consiliency/pmcp#182: option tokens are
-    discarded wholesale, so ``npm exec --package=<pkg> -- <bin>`` still yields
-    the binary rather than ``<pkg>``, and two packages exposing the same binary
-    still confirm as one identity.
+    ``--package`` is read as **known-positive** (Consiliency/pmcp#182): its
+    value IS the package, so it is extracted rather than skipped. Before that,
+    ``npm exec --package=<pkg> -- <bin>`` returned the BINARY, and two
+    different packages exposing the same binary name confirmed as one
+    identity. Note that merely treating ``--package=old`` as "self-delimiting,
+    so keep scanning" does not fix it -- the scan still reaches ``<bin>``; the
+    value has to be read back out of the flag.
+
+    Known limitation, deliberately left open: unlike the other four
+    ecosystems this scan does **not** fail closed on an unrecognised flag, so
+    ``npm exec --loglevel silly <pkg>`` still reads ``silly`` as the package.
+    Inverting the default here would break the pinned ordering below, where a
+    leading global flag such as ``npm --silent exec <pkg>`` must be skipped
+    rather than refused. Tracked as a residual of #182.
     """
     skip_subcommand = command == "npm"
-    for arg in args:
+    packages: list[str] = []
+    for index, arg in enumerate(args):
         if arg == "-y":
+            continue
+        name, separator, attached = arg.partition("=")
+        if separator and name in _NPM_POSITIVE_FLAGS:
+            if attached:
+                packages.append(attached)
+            continue
+        if arg in _NPM_POSITIVE_FLAGS:
+            following = args[index + 1] if index + 1 < len(args) else None
+            if following is not None and not following.startswith("-"):
+                packages.append(following)
+            continue
+        if packages:
+            # A `--package` value outranks any later positional, which is the
+            # command npm runs FROM that package, not a package itself.
             continue
         # Skip flags. This MUST precede the subcommand check: npm accepts
         # global flags before the subcommand (`npm --silent exec pkg`), so
@@ -156,6 +633,11 @@ def _npm_package_arg(args: list[str], command: str) -> str | None:
         # Handle scoped packages like @playwright/mcp
         if pkg.startswith("@") or not pkg.startswith("-"):
             return arg
+    if packages:
+        # npm allows `--package` to be repeated. One package is an identity;
+        # several DIFFERENT ones are not, and picking the first would be a
+        # guess of exactly the kind this change exists to stop.
+        return packages[0] if len(set(packages)) == 1 else None
     return None
 
 
@@ -363,36 +845,33 @@ def detect_package_type(
             return ("npm", _strip_npm_tag(raw))
 
     elif command == "uvx":
-        # First non-flag argument is the package
-        for arg in args:
-            if not arg.startswith("-"):
-                return ("pypi", arg)
+        raw, from_positive_flag = _uvx_package_arg(args)
+        if raw is not None:
+            # Only a `--from` value is a PEP 508 requirement; a bare positional
+            # is left raw so `uvx pkg==1.2.3` keeps its inline pin in the name
+            # and the existing "pinned server" refusal path still fires.
+            return ("pypi", _pep508_base_name(raw) if from_positive_flag else raw)
 
     elif command in ("pip", "pip3"):
-        # pip install {package} or pip install --upgrade {package}
-        for arg in args:
-            if arg in ("install", "upgrade", "update", "--upgrade", "-U"):
-                continue
-            if arg.startswith("-"):
-                continue
-            return ("pypi", arg)
+        raw, _ = _scan_for_package_token(
+            args,
+            value_flags=_PIP_VALUE_FLAGS,
+            boolean_flags=_PIP_BOOLEAN_FLAGS,
+            subcommands=_PIP_SUBCOMMANDS,
+        )
+        if raw is not None:
+            return ("pypi", raw)
 
     elif command == "cargo":
-        # cargo run -p package OR cargo run --bin binary OR cargo install package
-        i = 0
-        while i < len(args):
-            arg = args[i]
-            if arg in ("-p", "--package", "--bin"):
-                if i + 1 < len(args) and not args[i + 1].startswith("-"):
-                    return ("cargo", args[i + 1])
-                i += 2
-                continue
-            if arg in ("run", "install", "build", "test", "check"):
-                i += 1
-                continue
-            if not arg.startswith("-"):
-                return ("cargo", arg)
-            i += 1
+        raw, _ = _scan_for_package_token(
+            args,
+            value_flags=_CARGO_VALUE_FLAGS,
+            boolean_flags=_CARGO_BOOLEAN_FLAGS,
+            positive_flags=_CARGO_POSITIVE_FLAGS,
+            subcommands=_CARGO_SUBCOMMANDS,
+        )
+        if raw is not None:
+            return ("cargo", raw)
 
     elif command == "docker":
         raw = _docker_image_arg(args)
@@ -416,46 +895,114 @@ def _docker_image_arg(args: list[str]) -> str | None:
     ``_npm_package_arg`` was: gateway.update_server's pin detection needs the
     untouched token, and re-implementing this scan separately would risk the
     two disagreeing about which argument is "the image".
+
+    The value table below was the most careful branch in this file and was
+    **still incomplete twice**: ``--env-file`` and ``--mount`` were missing, so
+    ``docker run --env-file .env <image>`` resolved to ``.env`` and any two
+    images launched that way confirmed as one package
+    (Consiliency/pmcp#182). Completing the table would not have closed the
+    class -- what closes it is that an *unlisted* bare flag now refuses
+    instead of falling through to "take the next token as the image".
     """
-    _value_flags = {
-        "-e",
-        "--env",
-        "-v",
-        "--volume",
-        "-p",
-        "--publish",
-        "--name",
-        "--network",
-        "-u",
-        "--user",
-        "--entrypoint",
-        "-w",
-        "--workdir",
-        "--label",
-        "-l",
-        "--memory",
-        "-m",
-        "--cpus",
-        "--add-host",
-        "--dns",
-        "--hostname",
-        "-h",
-    }
-    skip_next = False
-    for arg in args:
-        if skip_next:
-            skip_next = False
-            continue
-        if arg in ("run", "exec", "start", "create", "pull", "push"):
-            continue
-        if arg in _value_flags:
-            skip_next = True
-            continue
-        if arg.startswith("-"):
-            continue
-        # First positional arg after the subcommand is the image reference.
-        return arg
-    return None
+    _value_flags = frozenset(
+        {
+            "-e",
+            "--env",
+            "-v",
+            "--volume",
+            "-p",
+            "--publish",
+            "--name",
+            "--network",
+            "-u",
+            "--user",
+            "--entrypoint",
+            "-w",
+            "--workdir",
+            "--label",
+            "-l",
+            "--memory",
+            "-m",
+            "--cpus",
+            "--add-host",
+            "--dns",
+            "--hostname",
+            "-h",
+            # The two omissions #182 measured.
+            "--env-file",
+            "--mount",
+            # `--pull <policy>` reads like a boolean and is NOT one -- the
+            # live example of the residual hazard that a WRONG entry still
+            # fails open, so its value would become the image name.
+            "--pull",
+            "--device",
+            "--tmpfs",
+            "--sysctl",
+            "--ulimit",
+            "--cap-add",
+            "--cap-drop",
+            "--security-opt",
+            "--restart",
+            "--platform",
+            "--gpus",
+            "--runtime",
+            "--isolation",
+            "--log-driver",
+            "--log-opt",
+            "--label-file",
+            "--health-cmd",
+            "--health-interval",
+            "--health-retries",
+            "--health-start-period",
+            "--health-timeout",
+            "--shm-size",
+            "--pid",
+            "--ipc",
+            "--userns",
+            "--uts",
+            "--cgroupns",
+            "--cgroup-parent",
+            "--stop-signal",
+            "--stop-timeout",
+            "--volumes-from",
+            "--volume-driver",
+            "--link",
+            "--expose",
+            "--group-add",
+            "--cidfile",
+            "--detach-keys",
+            "--annotation",
+            "--domainname",
+            "--mac-address",
+            "--ip",
+            "--ip6",
+            "--dns-option",
+            "--dns-search",
+            "--network-alias",
+            "--memory-reservation",
+            "--memory-swap",
+            "--memory-swappiness",
+            "--oom-score-adj",
+            "--pids-limit",
+            "--storage-opt",
+            "--blkio-weight",
+            "--cpu-shares",
+            "-c",
+            "--cpu-period",
+            "--cpu-quota",
+            "--cpuset-cpus",
+            "--cpuset-mems",
+            "--attach",
+            "-a",
+        }
+    )
+    raw, _ = _scan_for_package_token(
+        args,
+        value_flags=_value_flags,
+        boolean_flags=_DOCKER_BOOLEAN_FLAGS,
+        subcommands=_DOCKER_SUBCOMMANDS,
+    )
+    return raw
 
 
 def _docker_image_tag(image_ref: str) -> str | None:

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -117,15 +117,30 @@ _NPM_SUBCOMMANDS = _NPM_SUBCOMMANDS_WITH_A_PACKAGE_OPERAND
 # collision (unsafe, invisible).
 #
 # **The honest residual: a WRONG entry still fails open.** Classify a flag as
-# boolean when it actually takes a value and that value becomes the package
+# boolean when it actually takes a value, and that value becomes the package
 # name. `docker run --pull <policy>` is the live example -- it reads like a
-# boolean and is not. So these tables were transcribed from each tool's own
-# `--help` output and verified entry by entry against it, never bulk-imported
-# from memory; memory got `--pull`, uv's `--quiet`/`--verbose` (repeatable
-# counters, printed as `-q, --quiet...`) and pip's `--platform` wrong in
-# drafting. They are deliberately kept SMALL -- limited to what real MCP
-# launch configs use -- because fail-closed makes an omission cheap while
-# every extra entry is one more chance at a wrong arity.
+# boolean and is not.
+#
+# So every entry below was transcribed from the tool's own `--help` and then
+# checked back against it MECHANICALLY, one entry at a time (296 entries; the
+# script lives in the #182 working notes, not in the suite, because help text
+# is version-specific and CI has none of these CLIs). Drafting from memory got
+# `--pull`, uv's `--quiet`/`--verbose` (repeatable counters, printed as
+# `-q, --quiet...`) and pip's `--platform` wrong, which is why the claim is
+# mechanical rather than asserted.
+#
+# Three entries are exempt, each for a stated reason: `-it`/`-ti` are combined
+# short booleans docker only ever documents separately, and npm prints a bare
+# `--package` in its option list with the metavar only in its usage block.
+# **Ten entries that could not be verified were REMOVED rather than kept** --
+# removal is fail-closed, so it costs auto-update for an unusual config and
+# never correctness. Among them, pip's `--break-system-packages` and
+# `--dry-run` are real modern-pip booleans absent from the pip 22.0.2 used to
+# verify; re-add them against a newer pip rather than from memory.
+#
+# The tables are deliberately kept SMALL -- limited to what real MCP launch
+# configs use -- because fail-closed makes an omission cheap while every extra
+# entry is one more chance at a wrong arity.
 
 # uv (`uvx` == `uv tool run`), verified against `uv tool run --help`.
 _UVX_VALUE_FLAGS = frozenset(
@@ -162,7 +177,6 @@ _UVX_VALUE_FLAGS = frozenset(
         "--fork-strategy",
         "--keyring-provider",
         "--link-mode",
-        "--python-preference",
         "--python-platform",
         "--allow-insecure-host",
         "--cache-dir",
@@ -187,7 +201,6 @@ _UVX_BOOLEAN_FLAGS = frozenset(
         "--no-cache",
         "-n",
         "--offline",
-        "--native-tls",
         "--refresh",
         "--reinstall",
         "--upgrade",
@@ -207,8 +220,6 @@ _UVX_BOOLEAN_FLAGS = frozenset(
         "--no-env-file",
         "--help",
         "-h",
-        "--version",
-        "-V",
     }
 )
 # `--from` names the package to install when it differs from the command being
@@ -256,8 +267,6 @@ _PIP_VALUE_FLAGS = frozenset(
         "--install-option",
         "--use-feature",
         "--use-deprecated",
-        "--report",
-        "--python",
     }
 )
 _PIP_BOOLEAN_FLAGS = frozenset(
@@ -274,7 +283,6 @@ _PIP_BOOLEAN_FLAGS = frozenset(
         "--no-index",
         "--no-build-isolation",
         "--use-pep517",
-        "--check-build-dependencies",
         "--compile",
         "--no-compile",
         "--no-warn-script-location",
@@ -284,8 +292,6 @@ _PIP_BOOLEAN_FLAGS = frozenset(
         "--isolated",
         "--no-clean",
         "--prefer-binary",
-        "--break-system-packages",
-        "--dry-run",
         "--no-input",
         "--no-color",
         "--disable-pip-version-check",
@@ -396,7 +402,6 @@ _DOCKER_BOOLEAN_FLAGS = frozenset(
         "--sig-proxy",
         "--no-healthcheck",
         "--oom-kill-disable",
-        "--disable-content-trust",
         "--use-api-socket",
         "--quiet",
         "-q",
@@ -404,6 +409,99 @@ _DOCKER_BOOLEAN_FLAGS = frozenset(
     }
 )
 _DOCKER_SUBCOMMANDS = frozenset({"run", "exec", "start", "create", "pull", "push"})
+
+_DOCKER_VALUE_FLAGS = frozenset(
+    {
+        "-e",
+        "--env",
+        "-v",
+        "--volume",
+        "-p",
+        "--publish",
+        "--name",
+        "--network",
+        "-u",
+        "--user",
+        "--entrypoint",
+        "-w",
+        "--workdir",
+        "--label",
+        "-l",
+        "--memory",
+        "-m",
+        "--cpus",
+        "--add-host",
+        "--dns",
+        "--hostname",
+        "-h",
+        # The two omissions #182 measured.
+        "--env-file",
+        "--mount",
+        # `--pull <policy>` reads like a boolean and is NOT one -- the
+        # live example of the residual hazard that a WRONG entry still
+        # fails open, so its value would become the image name.
+        "--pull",
+        "--device",
+        "--tmpfs",
+        "--sysctl",
+        "--ulimit",
+        "--cap-add",
+        "--cap-drop",
+        "--security-opt",
+        "--restart",
+        "--platform",
+        "--gpus",
+        "--runtime",
+        "--isolation",
+        "--log-driver",
+        "--log-opt",
+        "--label-file",
+        "--health-cmd",
+        "--health-interval",
+        "--health-retries",
+        "--health-start-period",
+        "--health-timeout",
+        "--shm-size",
+        "--pid",
+        "--ipc",
+        "--userns",
+        "--uts",
+        "--cgroupns",
+        "--cgroup-parent",
+        "--stop-signal",
+        "--stop-timeout",
+        "--volumes-from",
+        "--volume-driver",
+        "--link",
+        "--expose",
+        "--group-add",
+        "--cidfile",
+        "--detach-keys",
+        "--annotation",
+        "--domainname",
+        "--mac-address",
+        "--ip",
+        "--ip6",
+        "--dns-option",
+        "--dns-search",
+        "--network-alias",
+        "--memory-reservation",
+        "--memory-swap",
+        "--memory-swappiness",
+        "--oom-score-adj",
+        "--pids-limit",
+        "--storage-opt",
+        "--blkio-weight",
+        "--cpu-shares",
+        "-c",
+        "--cpu-period",
+        "--cpu-quota",
+        "--cpuset-cpus",
+        "--cpuset-mems",
+        "--attach",
+        "-a",
+    }
+)
 
 
 def _takes_a_value_ambiguously(arg: str) -> bool:
@@ -918,101 +1016,9 @@ def _docker_image_arg(args: list[str]) -> str | None:
     class -- what closes it is that an *unlisted* bare flag now refuses
     instead of falling through to "take the next token as the image".
     """
-    _value_flags = frozenset(
-        {
-            "-e",
-            "--env",
-            "-v",
-            "--volume",
-            "-p",
-            "--publish",
-            "--name",
-            "--network",
-            "-u",
-            "--user",
-            "--entrypoint",
-            "-w",
-            "--workdir",
-            "--label",
-            "-l",
-            "--memory",
-            "-m",
-            "--cpus",
-            "--add-host",
-            "--dns",
-            "--hostname",
-            "-h",
-            # The two omissions #182 measured.
-            "--env-file",
-            "--mount",
-            # `--pull <policy>` reads like a boolean and is NOT one -- the
-            # live example of the residual hazard that a WRONG entry still
-            # fails open, so its value would become the image name.
-            "--pull",
-            "--device",
-            "--tmpfs",
-            "--sysctl",
-            "--ulimit",
-            "--cap-add",
-            "--cap-drop",
-            "--security-opt",
-            "--restart",
-            "--platform",
-            "--gpus",
-            "--runtime",
-            "--isolation",
-            "--log-driver",
-            "--log-opt",
-            "--label-file",
-            "--health-cmd",
-            "--health-interval",
-            "--health-retries",
-            "--health-start-period",
-            "--health-timeout",
-            "--shm-size",
-            "--pid",
-            "--ipc",
-            "--userns",
-            "--uts",
-            "--cgroupns",
-            "--cgroup-parent",
-            "--stop-signal",
-            "--stop-timeout",
-            "--volumes-from",
-            "--volume-driver",
-            "--link",
-            "--expose",
-            "--group-add",
-            "--cidfile",
-            "--detach-keys",
-            "--annotation",
-            "--domainname",
-            "--mac-address",
-            "--ip",
-            "--ip6",
-            "--dns-option",
-            "--dns-search",
-            "--network-alias",
-            "--memory-reservation",
-            "--memory-swap",
-            "--memory-swappiness",
-            "--oom-score-adj",
-            "--pids-limit",
-            "--storage-opt",
-            "--blkio-weight",
-            "--cpu-shares",
-            "-c",
-            "--cpu-period",
-            "--cpu-quota",
-            "--cpuset-cpus",
-            "--cpuset-mems",
-            "--attach",
-            "-a",
-        }
-    )
     raw, _ = _scan_for_package_token(
         args,
-        value_flags=_value_flags,
+        value_flags=_DOCKER_VALUE_FLAGS,
         boolean_flags=_DOCKER_BOOLEAN_FLAGS,
         subcommands=_DOCKER_SUBCOMMANDS,
     )

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -692,7 +692,9 @@ def _npm_package_arg(args: list[str], command: str) -> str | None:
     ``npm exec --loglevel silly <pkg>`` still reads ``silly`` as the package.
     Inverting the default here would break the pinned ordering below, where a
     leading global flag such as ``npm --silent exec <pkg>`` must be skipped
-    rather than refused. Tracked as a residual of #182.
+    rather than refused. Tracked on Consiliency/pmcp#180, which stays OPEN
+    for this residual -- NOT on #182, which the change carrying this note
+    closes on merge and would leave this pointer dangling.
     """
     skip_subcommand = command == "npm"
     packages: list[str] = []

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -604,7 +604,7 @@ def _scan_for_package_token(
 
 # A PEP 508 requirement ends its NAME at the first character that can begin an
 # extras group, a version specifier, an environment marker, or a URL.
-_PEP508_NAME = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)\s*(?:[\[<>=!~;@,(].*)?$")
+_PEP508_NAME = re.compile(r"^([A-Za-z0-9][A-Za-z0-9._-]*)\s*(?:[\[<>=!~;,(].*)?$")
 
 
 def _pep508_base_name(requirement: str) -> str:
@@ -625,6 +625,15 @@ def _pep508_base_name(requirement: str) -> str:
     identity: there is no name to extract, distinct URLs are distinct
     packages so the gate stays correct, and the PyPI lookup fails closed to
     None, which the gate already reads as "cannot confirm -> refresh".
+
+    ``@`` is deliberately NOT a name terminator, unlike the other PEP 508
+    separators. A *direct reference* (``pkg @ git+https://x/y``) names a
+    specific source, so truncating at ``@`` would return ``pkg`` for BOTH
+    ``pkg @ git+https://x/y`` and ``pkg @ .../z`` -- collapsing two different
+    repositories into one identity, which is the exact defect class this
+    change exists to close, newly introduced by the fix for it (ah board
+    review, red-team seat). A direct reference is returned whole and is its
+    own identity, exactly like a bare URL.
     """
     match = _PEP508_NAME.match(requirement.strip())
     return match.group(1) if match else requirement

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -454,15 +454,29 @@ def _scan_for_package_token(
     while index < len(args):
         arg = args[index]
         if arg == "--":
-            # End of the runner's own arguments.
+            # End of the runner's own arguments: everything after belongs to
+            # the tool being run.
+            #
+            # Measured as REDUNDANT rather than load-bearing, and kept
+            # deliberately. `--` also satisfies `_takes_a_value_ambiguously`
+            # below, so removing this branch changes no observable result --
+            # no test can distinguish the two, and none pretends to. It stays
+            # because it states the boundary explicitly at the point where a
+            # reader looks for it, and because it keeps the boundary correct
+            # if `--` is ever added to one of the tables above.
             return (None, False)
         if arg.startswith("-") and arg != "-":
             name, separator, attached = arg.partition("=")
             if separator:
                 if name in positive_flags:
                     return (attached or None, True)
-                # Self-delimiting, so it cannot swallow the next token --
-                # safe to skip whether or not it is a flag we know.
+                # Ask the predicate rather than re-deciding here, so the
+                # fail-closed rule has exactly ONE home. A `--flag=value`
+                # spelling is self-delimiting -- it cannot swallow the next
+                # token -- so the predicate returns False and the token is
+                # skipped whether or not it is a flag we know.
+                if _takes_a_value_ambiguously(arg):
+                    return (None, False)
                 index += 1
                 continue
             if arg in positive_flags:

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -80,6 +80,7 @@ from pmcp.manifest.version_checker import (
     _docker_image_tag,
     _npm_package_arg,
     _npm_tag,
+    _uvx_package_arg,
     detect_package_type,
     get_package_version,
 )
@@ -317,12 +318,20 @@ def _detect_effective_version_pin(
         tag = _npm_tag(raw)
         return None if not tag or tag == "latest" else tag
     if package_type == "pypi" and command == "uvx":
-        for arg in args:
-            if arg.startswith("-"):
-                continue
-            if "==" in arg:
-                _, _, version = arg.partition("==")
-                return version or None
+        # Shares `_uvx_package_arg` with detect_package_type for the same
+        # reason the npm branch shares `_npm_package_arg`: two independent
+        # scans disagreeing about which token is "the package" is how a real
+        # pin gets missed. The previous scan skipped every `-`-prefixed token
+        # and read `==` off the first bare one, which was wrong twice over
+        # (Consiliency/pmcp#182): `--from=pkg==1.2.0` is a single `-`-prefixed
+        # token, so a REAL pin read as unpinned and update_server would have
+        # probed for latest and moved a server the operator had pinned; and
+        # `--with requests==2.0 pkg` reported an injected DEPENDENCY's version
+        # as the server's own pin, refusing an update that was never pinned.
+        raw, _from_flag = _uvx_package_arg(args)
+        if raw is not None and "==" in raw:
+            _, _, version = raw.partition("==")
+            return version or None
     if package_type == "docker":
         raw_image = _docker_image_arg(args)
         if raw_image is None:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4840,6 +4840,60 @@ class TestUpdateServerVersionRepair:
         return manifest
 
     @pytest.mark.asyncio
+    async def test_update_server_never_probes_an_unclassifiable_flag_form(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """An UNLISTED bare flag must reach the refusal, not a probe.
+
+        Consiliency/pmcp#182. The fail-closed default is only worth anything if
+        `("unknown", None)` actually stops `update_server` before it builds a
+        probe, so this asserts the *consequence* rather than the parse --
+        mirroring the #183 model above.
+
+        The flag has to be genuinely unclassifiable. A `--python 3.12` server
+        no longer qualifies: under the three-way classification `--python` is a
+        known value flag, so that form now resolves to its real package name
+        and would sail past this refusal. (The plan's change list still
+        described `--python` as yielding no identity -- stale text from the
+        rejected pure-fail-closed draft.)
+        """
+        manifest = self._make_manifest_with_playwright(monkeypatch)
+        manifest.servers["odd-flags"] = ServerConfig(
+            name="odd-flags",
+            description="Launched with a flag pmcp cannot classify",
+            keywords=[],
+            install={},
+            command="uvx",
+            args=["--not-a-real-uv-flag", "some-package"],
+            requires_api_key=False,
+        )
+        gt = GatewayTools(
+            client_manager=MockClientManager(),  # type: ignore
+            policy_manager=PolicyManager(),
+        )
+
+        probes: list[list[str]] = []
+
+        async def _record_probe(cmd, env=None):
+            probes.append(cmd)
+            return (True, "ok")
+
+        monkeypatch.setattr(gt, "_run_update_probe_command", _record_probe)
+
+        result = await gt.update_server({"server_name": "odd-flags"})
+
+        assert result.ok is False
+        # All four assertions are load-bearing. `probes == []` ALONE passes
+        # whenever update_server refuses for any unrelated earlier reason, so
+        # on its own it does not pin what it claims (ah board review).
+        assert result.package_type == "unknown"
+        assert "uvx --not-a-real-uv-flag some-package" in result.message
+        assert probes == [], (
+            "update_server built a probe from a command line whose package is "
+            f"unidentifiable -- an unlisted flag's value could be anything: {probes}"
+        )
+
+    @pytest.mark.asyncio
     async def test_update_server_never_probes_a_script_name(
         self, monkeypatch: pytest.MonkeyPatch
     ):
@@ -5796,6 +5850,34 @@ class TestUpdateServerVersionRepair:
         # pypi/uvx inline == pin.
         assert detect("pypi", "uvx", ["srv==1.2.3"]) == "1.2.3"
         assert detect("pypi", "uvx", ["srv"]) is None
+
+        # Consiliency/pmcp#182: identity and pin must read the SAME uvx token.
+        #
+        # Before this, pin detection skipped every `-`-prefixed token and then
+        # looked for `==` in the first bare one. That produced two distinct
+        # defects, in opposite directions:
+        #
+        #  1. `--from=<pkg>==<ver>` reported NO pin, because the whole thing is
+        #     one `-`-prefixed token. Identity resolved fine, so update_server
+        #     would classify the package, see no pin, and probe for LATEST --
+        #     updating a server the operator explicitly pinned.
+        #  2. `--with requests==2.0 pkg` reported `2.0` -- an injected
+        #     DEPENDENCY's version reported as the server's pin, refusing an
+        #     update that was never actually pinned.
+        #
+        # Both are fixed by sharing `_uvx_package_arg`, exactly as npm shares
+        # `_npm_package_arg` between the two.
+        assert detect("pypi", "uvx", ["--from", "index-it-mcp==1.2.0", "x"]) == "1.2.0"
+        assert detect("pypi", "uvx", ["--from=index-it-mcp==1.2.0", "x"]) == "1.2.0"
+        assert detect("pypi", "uvx", ["--python", "3.12", "srv==1.2.3"]) == "1.2.3"
+        assert detect("pypi", "uvx", ["--with", "requests==2.0", "pkg"]) is None
+        # An unclassifiable form has no package, so it has no pin either.
+        assert detect("pypi", "uvx", ["--not-a-real-uv-flag", "srv==1.2.3"]) is None
+
+        # npm `--package` carries its own tag, and the shared scan means pin
+        # detection reads it for free.
+        assert detect("npm", "npm", ["exec", "--package=pkg@1.2", "--", "bin"]) == "1.2"
+        assert detect("npm", "npm", ["exec", "--package=pkg", "--", "bin"]) is None
 
 
 class TestInvokeErrorPaths:

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -241,6 +241,320 @@ class TestPackageIdentityCollisions:
         assert old == ("npm", "old-pkg")
 
 
+class TestValueFlagCollisions:
+    """A flag's VALUE must never be mistaken for the package it precedes.
+
+    Consiliency/pmcp#182. `detect_package_type` skipped flags but not the
+    tokens those flags CARRY, so the first "non-flag" token was routinely a
+    flag's argument. Two different servers then produced one identity, and
+    2.4.0's identity gate reads an equal name as a POSITIVE confirmation --
+    serving the wrong package's tool descriptions indefinitely.
+
+    Each test asserts INEQUALITY of a real pair *and* pins both exact values.
+    The inequality is what the collision falsifies; the exact values stop a
+    parser that merely collapses the pair onto some third shared name from
+    passing. All seven were RED on `main` @ 75eb9c7, each returning the flag's
+    value as the package name.
+    """
+
+    def test_uvx_python_version_is_not_the_package(self) -> None:
+        """RED before: both sides returned `("pypi", "3.12")` -- the Python
+        version, read off `--python`, as the package name."""
+        a = detect_package_type("uvx", ["--python", "3.12", "pkg-a"])
+        b = detect_package_type("uvx", ["--python", "3.12", "pkg-b"])
+        assert a != b, f"`--python`'s value collapsed two packages: {a} == {b}"
+        assert a == ("pypi", "pkg-a")
+        assert b == ("pypi", "pkg-b")
+
+    def test_uvx_with_dependency_is_not_the_package(self) -> None:
+        """RED before: both returned `("pypi", "requests")` -- an injected
+        dependency named by `--with`, not the server being run."""
+        a = detect_package_type("uvx", ["--with", "requests", "srv-a"])
+        b = detect_package_type("uvx", ["--with", "requests", "srv-b"])
+        assert a != b, f"`--with`'s value collapsed two packages: {a} == {b}"
+        assert a == ("pypi", "srv-a")
+        assert b == ("pypi", "srv-b")
+
+    def test_pip_index_url_is_not_the_package(self) -> None:
+        """RED before: both returned `("pypi", "https://x")` -- an index URL
+        as a package name, which no registry lookup could ever resolve."""
+        a = detect_package_type("pip", ["install", "--index-url", "https://x", "pkg-a"])
+        b = detect_package_type("pip", ["install", "--index-url", "https://x", "pkg-b"])
+        assert a != b, f"`--index-url`'s value collapsed two packages: {a} == {b}"
+        assert a == ("pypi", "pkg-a")
+        assert b == ("pypi", "pkg-b")
+
+    def test_cargo_features_is_not_the_crate(self) -> None:
+        """RED before: both returned `("cargo", "full")` -- a feature name."""
+        a = detect_package_type("cargo", ["run", "--features", "full", "srv-a"])
+        b = detect_package_type("cargo", ["run", "--features", "full", "srv-b"])
+        assert a != b, f"`--features`'s value collapsed two crates: {a} == {b}"
+        assert a == ("cargo", "srv-a")
+        assert b == ("cargo", "srv-b")
+
+    def test_docker_env_file_is_not_the_image(self) -> None:
+        """RED before: both returned `("docker", ".env")`.
+
+        `--env-file` was simply missing from `_docker_image_arg`'s value-flag
+        table -- the most careful branch in the file, and still incomplete.
+        """
+        a = detect_package_type("docker", ["run", "--env-file", ".env", "img-a"])
+        b = detect_package_type("docker", ["run", "--env-file", ".env", "img-b"])
+        assert a != b, f"`--env-file`'s value collapsed two images: {a} == {b}"
+        assert a == ("docker", "img-a")
+        assert b == ("docker", "img-b")
+
+    def test_docker_mount_spec_is_not_the_image(self) -> None:
+        """RED before: both returned `("docker", "type=bind,src=/a")`."""
+        a = detect_package_type(
+            "docker", ["run", "--mount", "type=bind,src=/a", "img-a"]
+        )
+        b = detect_package_type(
+            "docker", ["run", "--mount", "type=bind,src=/a", "img-b"]
+        )
+        assert a != b, f"`--mount`'s value collapsed two images: {a} == {b}"
+        assert a == ("docker", "img-a")
+        assert b == ("docker", "img-b")
+
+    def test_npm_exec_package_flag_names_the_package(self) -> None:
+        """RED before: both returned `("npm", "bin")` -- the BINARY.
+
+        The seventh collision, and the only one of the seven where identity is
+        genuinely RECOVERABLE rather than merely refusable: `--package` is
+        known-positive, so its value IS the package. Treating `--package=old`
+        as merely "self-delimiting, so keep scanning" still returns `bin`;
+        the scanner has to read the value back OUT of the flag.
+        """
+        a = detect_package_type("npm", ["exec", "--package=old", "--", "bin"])
+        b = detect_package_type("npm", ["exec", "--package=new", "--", "bin"])
+        assert a != b, f"two packages exposing one binary collapsed: {a} == {b}"
+        assert a == ("npm", "old")
+        assert b == ("npm", "new")
+
+    def test_npm_exec_package_flag_spaced_spelling(self) -> None:
+        """npm documents both `--package=<pkg>` and `--package <pkg>`."""
+        a = detect_package_type("npm", ["exec", "--package", "old", "--", "bin"])
+        b = detect_package_type("npm", ["exec", "--package", "new", "--", "bin"])
+        assert a != b, f"spaced `--package` collapsed two packages: {a} == {b}"
+        assert a == ("npm", "old")
+        assert b == ("npm", "new")
+
+
+class TestValueFlagsFailClosed:
+    """An UNLISTED bare flag yields `("unknown", None)`, never a guess.
+
+    This is the inversion that makes the classification safe, and it is the
+    opposite of the denylist Consiliency/pmcp#183 rejected. Docker's
+    `_value_flags` table failed OPEN: the default for an unlisted flag was
+    "skip it and take the next token as the image", so an omission silently
+    produced a WRONG identity. Here an omission costs auto-update for one odd
+    config -- safe, loud, and fixable by adding an entry -- instead of a silent
+    collision that no one can see.
+
+    `_same_package` (refresher.py) already resolves `"unknown"` to "cannot
+    confirm -> refresh", so a refusal degrades gracefully to more work rather
+    than to wrong output.
+    """
+
+    def test_uvx_unlisted_flag_refuses(self) -> None:
+        assert detect_package_type("uvx", ["--not-a-real-uv-flag", "pkg"]) == (
+            "unknown",
+            None,
+        )
+
+    def test_pip_unlisted_flag_refuses(self) -> None:
+        assert detect_package_type(
+            "pip", ["install", "--not-a-real-pip-flag", "p"]
+        ) == (
+            "unknown",
+            None,
+        )
+
+    def test_cargo_unlisted_flag_refuses(self) -> None:
+        assert detect_package_type(
+            "cargo", ["run", "--not-a-real-cargo-flag", "s"]
+        ) == (
+            "unknown",
+            None,
+        )
+
+    def test_docker_unlisted_flag_refuses(self) -> None:
+        assert detect_package_type(
+            "docker", ["run", "--not-a-real-docker-flag", "i"]
+        ) == (
+            "unknown",
+            None,
+        )
+
+    def test_unlisted_flag_with_attached_value_is_self_delimiting(self) -> None:
+        """`--unlisted=value` is SAFE to skip and must not refuse.
+
+        The hazard an unlisted flag creates is that it might consume the next
+        token. A `--flag=value` spelling carries its value inside the token,
+        so it cannot; refusing here would cost auto-update for no safety gain.
+        """
+        assert detect_package_type("uvx", ["--not-a-real-uv-flag=x", "pkg"]) == (
+            "pypi",
+            "pkg",
+        )
+
+    def test_two_different_unlisted_forms_do_not_confirm_each_other(self) -> None:
+        """The safety property: unknown never CONFIRMS an identity.
+
+        Two refusals ARE equal to each other -- that is unavoidable and is
+        exactly why the class property is "different, or unknown" rather than
+        "always different". `_same_package` rejects `"unknown"` on either side
+        before any comparison happens, so equality here can never be read as a
+        positive confirmation.
+        """
+        a = detect_package_type("uvx", ["--not-a-real-uv-flag", "pkg-a"])
+        b = detect_package_type("uvx", ["--not-a-real-uv-flag", "pkg-b"])
+        assert a == b == ("unknown", None)
+        from pmcp.manifest.refresher import _same_package
+
+        assert _same_package(a[1] or "", a[0], b[1], b[0]) is False
+
+
+class TestKnownPositiveValueFlags:
+    """Forms that resolved correctly BEFORE the fix must be untouched.
+
+    A rejected earlier design -- "any bare flag before the candidate makes
+    identity unrecoverable" -- broke every one of the docker cases below, and
+    `docker run -it --rm <image>` is the canonical shape in this repo's own
+    README (`README.md:1528`). `-it` is a COMBINED short boolean that no
+    value-table derived from `docker run --help` would ever list, since docker
+    only documents `-i` and `-t` separately. These tests exist to keep that
+    regression from being reintroduced.
+    """
+
+    def test_uvx_boolean_flag_still_finds_package(self) -> None:
+        assert detect_package_type("uvx", ["--quiet", "my-package", "--arg"]) == (
+            "pypi",
+            "my-package",
+        )
+
+    def test_docker_short_boolean_flags_still_find_image(self) -> None:
+        assert detect_package_type(
+            "docker", ["run", "-i", "--rm", "mcp/server:latest"]
+        ) == (
+            "docker",
+            "mcp/server",
+        )
+
+    def test_docker_env_flag_still_finds_image(self) -> None:
+        assert detect_package_type(
+            "docker", ["run", "-e", "KEY=val", "--rm", "ghcr.io/org/mcp"]
+        ) == ("docker", "ghcr.io/org/mcp")
+
+    def test_docker_combined_short_booleans_still_find_image(self) -> None:
+        """`-it` is one token docker never documents; it must be listed by hand."""
+        assert detect_package_type("docker", ["run", "-it", "--rm", "img"]) == (
+            "docker",
+            "img",
+        )
+
+    def test_uvx_from_after_the_package_does_not_win(self) -> None:
+        """A LEFT-TO-RIGHT scan, not a whole-argv `--from` hunt.
+
+        An earlier draft scanned all of argv for `--from` to rescue the README
+        pin form. Measured, that turns this case from `mypkg` into `other`: a
+        fail-open misidentification INTRODUCED by the fix, which would
+        re-collide `uvx a --from x` with `uvx b --from x` through the new path.
+        The positional wins because it comes first.
+        """
+        assert detect_package_type("uvx", ["mypkg", "--from", "other"]) == (
+            "pypi",
+            "mypkg",
+        )
+
+    def test_known_positive_forms_unchanged(self) -> None:
+        assert detect_package_type("uvx", ["--from", "pkg", "tool"]) == ("pypi", "pkg")
+        assert detect_package_type("cargo", ["run", "-p", "pkg"]) == ("cargo", "pkg")
+        assert detect_package_type("cargo", ["run", "--bin", "b"]) == ("cargo", "b")
+        assert detect_package_type("pip", ["install", "pkg"]) == ("pypi", "pkg")
+        assert detect_package_type("npx", ["-y", "pkg"]) == ("npm", "pkg")
+        assert detect_package_type("docker", ["run", "img"]) == ("docker", "img")
+
+    def test_scan_stops_at_the_double_dash_separator(self) -> None:
+        """Everything after `--` belongs to the SERVED tool, not to uvx.
+
+        uv passes those through verbatim, so a server's own `--from` argument
+        must never be mistaken for uvx's package identity.
+        """
+        assert detect_package_type(
+            "uvx", ["--from", "pkg", "tool", "--", "--from", "x"]
+        ) == (
+            "pypi",
+            "pkg",
+        )
+        assert detect_package_type("uvx", ["--", "--python", "3.12", "x"]) == (
+            "unknown",
+            None,
+        )
+
+    def test_readme_documented_pin_form_resolves_to_the_package(self) -> None:
+        """`README.md:1133` recommends this exact shape for a FIRST-PARTY server.
+
+        RED before the fix, which returned `("pypi", "3.12")` -- so #182 was
+        never hypothetical for uvx: the repo mis-identified a config it
+        recommends in its own README. With `--python` classified as a value
+        flag, a plain left-to-right scan consumes `3.12` and `--from` then
+        yields the package, with no whole-argv scan needed.
+        """
+        assert detect_package_type(
+            "uvx", ["--python", "3.12", "--from", "index-it-mcp==1.2.0", "index-it-mcp"]
+        ) == ("pypi", "index-it-mcp")
+
+    def test_from_value_is_normalized_to_its_pep508_base_name(self) -> None:
+        """`--from`'s value is a PEP 508 requirement, not a bare package name.
+
+        This repairs a LIVE defect rather than introducing a behaviour change:
+        `manifest.yaml:352-357` ships `--from browser-use[cli]`, and a PyPI
+        lookup for `browser-use[cli]` returns None while `browser-use` returns
+        a real version -- so that first-party entry's version checks have been
+        silently failing. Stripping the extra repairs them.
+        """
+        assert detect_package_type(
+            "uvx", ["--from", "browser-use[cli]", "browser-use"]
+        ) == (
+            "pypi",
+            "browser-use",
+        )
+        assert detect_package_type("uvx", ["--from", "index-it-mcp==1.2.0", "x"]) == (
+            "pypi",
+            "index-it-mcp",
+        )
+        assert detect_package_type("uvx", ["--from", "pkg>=1.0", "x"]) == (
+            "pypi",
+            "pkg",
+        )
+
+    def test_from_url_value_keeps_the_whole_url_as_identity(self) -> None:
+        """A VCS URL is its own identity -- distinct URLs are distinct packages.
+
+        Normalizing it to a PEP 508 name would be wrong (there is no name to
+        take), and refusing would be needlessly lossy. Keeping the URL keeps
+        the gate correct: two different repos never confirm as one, and the
+        PyPI lookup fails closed to None, which the gate already reads as
+        "cannot confirm -> refresh".
+        """
+        a = detect_package_type("uvx", ["--from", "git+https://x/y", "tool"])
+        b = detect_package_type("uvx", ["--from", "git+https://x/z", "tool"])
+        assert a == ("pypi", "git+https://x/y")
+        assert a != b, (
+            f"two different git sources collapsed to one identity: {a} == {b}"
+        )
+
+    def test_positional_uvx_token_is_left_raw(self) -> None:
+        """Only `--from` values are normalized.
+
+        `uvx pkg==1.2.3` keeps its inline pin in the name so the existing
+        "pinned server" refusal path in gateway.update_server still fires on
+        the failed PyPI lookup it was written around (handlers.py:289-294).
+        """
+        assert detect_package_type("uvx", ["pkg==1.2.3"]) == ("pypi", "pkg==1.2.3")
+
+
 class TestDockerReferenceSplitting:
     """`_docker_image_name` and `_docker_image_tag` are complements.
 

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -364,6 +364,55 @@ class TestValueFlagCollisions:
         ) == ("npm", "a")
 
 
+class TestPositiveFlagGuardArms:
+    """The known-positive branch's guards, each arm pinned separately.
+
+    `--from`/`-p`/`--package`/`--bin` name the package in the NEXT token, so
+    the branch guards two ways it can fail to be one: the flag trails at end of
+    argv (nothing follows), or what follows is itself flag-shaped. Both arms
+    were *correct but unpinned* -- a board seat killed the suite's ability to
+    see them by deleting the `startswith("-")` arm and running all 364 tests
+    green, after which `uvx --from --offline a` and `... b` both resolved to
+    `('pypi', '--offline')`. Verified end-to-end: `_same_package` returns True
+    on that pair, so the mutant's collision passes the identity gate.
+
+    Not reachable from a launchable config -- real uv rejects both forms -- but
+    an unpinned guard is exactly the shape this module keeps being corrected
+    for, so it is pinned rather than argued away.
+    """
+
+    def test_positive_flag_followed_by_a_flag_refuses(self) -> None:
+        """The value of `--from` cannot be another flag."""
+        assert detect_package_type("uvx", ["--from", "--offline", "pkg"]) == (
+            "unknown",
+            None,
+        )
+
+    def test_positive_flag_at_end_of_argv_refuses(self) -> None:
+        """`--from` with nothing after it names no package.
+
+        NON-DISCRIMINATING, and labelled so rather than implying a proof.
+        The guard's `following is None` arm is UNREACHABLE: when a positive
+        flag trails, the loop simply ends and the function falls through to
+        `("unknown", None)` anyway. Deleting that arm leaves this test -- and
+        every other -- green, verified. The arm is defensive, not load-bearing;
+        this test pins the observable behaviour, not the branch.
+        """
+        assert detect_package_type("uvx", ["--from"]) == ("unknown", None)
+        assert detect_package_type("cargo", ["run", "--bin"]) == ("unknown", None)
+
+    def test_positive_flag_with_an_empty_attached_value_refuses(self) -> None:
+        """`--from=` attaches an empty value, which is not a package name."""
+        assert detect_package_type("uvx", ["--from=", "pkg"]) == ("unknown", None)
+
+    def test_cargo_shares_the_same_guard_arms(self) -> None:
+        """cargo's `-p`/`--bin` run through the same branch."""
+        assert detect_package_type("cargo", ["run", "-p", "--offline"]) == (
+            "unknown",
+            None,
+        )
+
+
 class TestValueFlagsFailClosed:
     """An UNLISTED bare flag yields `("unknown", None)`, never a guess.
 

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -364,6 +364,37 @@ class TestValueFlagCollisions:
         ) == ("npm", "a")
 
 
+class TestDirectReferencesStayDistinct:
+    """A PEP 508 *direct reference* names a source, and sources differ.
+
+    `pkg @ git+https://x/y` and `pkg @ git+https://x/z` are different
+    repositories. An earlier form of `_pep508_base_name` listed `@` among the
+    name terminators, so both truncated to `pkg` -- collapsing two repos into
+    one identity, which the gate would then CONFIRM. That is the exact defect
+    class this change exists to close, newly introduced by the fix for it
+    (ah board review, red-team seat).
+
+    Verified: before the fix both resolved to `('pypi', 'pkg')`.
+    """
+
+    def test_named_direct_references_to_different_repos_are_different(self) -> None:
+        y = detect_package_type("uvx", ["--from", "pkg @ git+https://x/y", "tool"])
+        z = detect_package_type("uvx", ["--from", "pkg @ git+https://x/z", "tool"])
+        assert y != z, f"two different repositories collapsed to one identity: {y}"
+        assert y == ("pypi", "pkg @ git+https://x/y")
+
+    def test_normalization_still_strips_extras_and_versions(self) -> None:
+        """The `@` carve-out must not disable the rest of the rule."""
+        assert detect_package_type("uvx", ["--from", "browser-use[cli]", "t"]) == (
+            "pypi",
+            "browser-use",
+        )
+        assert detect_package_type("uvx", ["--from", "index-it-mcp==1.2.0", "t"]) == (
+            "pypi",
+            "index-it-mcp",
+        )
+
+
 class TestPositiveFlagGuardArms:
     """The known-positive branch's guards, each arm pinned separately.
 

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -332,12 +332,36 @@ class TestValueFlagCollisions:
         assert b == ("npm", "new")
 
     def test_npm_exec_package_flag_spaced_spelling(self) -> None:
-        """npm documents both `--package=<pkg>` and `--package <pkg>`."""
+        """npm documents both `--package=<pkg>` and `--package <pkg>`.
+
+        **This case does not discriminate the fix, and is kept as a plain
+        regression guard rather than as evidence.** Mutation-proved: with
+        `--package` removed from the known-positive set entirely, the spaced
+        spelling still resolves correctly, because skipping `--package` as an
+        ordinary flag leaves its value as the first bare token anyway. Only
+        the `=` spelling above and the repeated-flag refusal below actually
+        pin the extraction.
+        """
         a = detect_package_type("npm", ["exec", "--package", "old", "--", "bin"])
         b = detect_package_type("npm", ["exec", "--package", "new", "--", "bin"])
         assert a != b, f"spaced `--package` collapsed two packages: {a} == {b}"
         assert a == ("npm", "old")
         assert b == ("npm", "new")
+
+    def test_npm_repeated_package_flags_refuse(self) -> None:
+        """npm allows `--package` more than once; several are not an identity.
+
+        One package is an identity. Two DIFFERENT ones are not, and returning
+        the first would be exactly the guess this change exists to stop -- the
+        two configs would then confirm as one package on the strength of a
+        coin flip. Repeating the SAME package is still an identity.
+        """
+        assert detect_package_type(
+            "npm", ["exec", "--package", "a", "--package", "b", "--", "bin"]
+        ) == ("unknown", None)
+        assert detect_package_type(
+            "npm", ["exec", "--package", "a", "--package", "a", "--", "bin"]
+        ) == ("npm", "a")
 
 
 class TestValueFlagsFailClosed:
@@ -480,6 +504,14 @@ class TestKnownPositiveValueFlags:
 
         uv passes those through verbatim, so a server's own `--from` argument
         must never be mistaken for uvx's package identity.
+
+        **Pins the behaviour, not the `--` branch.** Mutation-proved: deleting
+        the explicit `--` terminator changes nothing observable, because `--`
+        also trips the fail-closed default and refuses there instead. The
+        assertions below are still worth keeping -- they are what would catch
+        a future change that made tokens after `--` reachable -- but no test
+        can distinguish the two implementations, and this one does not claim
+        to.
         """
         assert detect_package_type(
             "uvx", ["--from", "pkg", "tool", "--", "--from", "x"]
@@ -500,6 +532,13 @@ class TestKnownPositiveValueFlags:
         recommends in its own README. With `--python` classified as a value
         flag, a plain left-to-right scan consumes `3.12` and `--from` then
         yields the package, with no whole-argv scan needed.
+
+        What this pins is `--python`'s classification, which is the half that
+        was broken. It does NOT pin `--from`'s: mutation-proved, ignoring
+        `--from` entirely still yields `index-it-mcp` here, because the
+        README's form ends with a positional that happens to equal the
+        `--from` base name. `--from` is pinned by
+        `test_known_positive_forms_unchanged` and the normalization test.
         """
         assert detect_package_type(
             "uvx", ["--python", "3.12", "--from", "index-it-mcp==1.2.0", "index-it-mcp"]


### PR DESCRIPTION
Closes **#182**. Narrows **#180** further, and recommends it stay open — see *#180 status*.

## The defect

`detect_package_type` skipped **flags** but not the **values those flags carry**, so the first non-flag token was often a flag's argument. Two different servers then resolved to one identity — and v2.4.0's gate compares exactly this name to decide whether a cached description still describes the configured package, so it read that as a **positive confirmation** and served the wrong package's tool descriptions.

All seven reproduced on `main`; all seven now resolve distinctly:

```
uvx   --python 3.12 a/b        ('pypi','3.12')      -> ('pypi','a') / ('pypi','b')
uvx   --with requests a/b      ('pypi','requests')  -> ('pypi','a') / ('pypi','b')
pip   --index-url URL a/b      ('pypi','https://x') -> ('pypi','a') / ('pypi','b')
cargo --features full a/b      ('cargo','full')     -> ('cargo','a') / ('cargo','b')
docker --env-file .env a/b     ('docker','.env')    -> ('docker','a') / ('docker','b')
docker --mount spec a/b        ('docker','type=…')  -> ('docker','a') / ('docker','b')
npm   exec --package=old/new   ('npm','bin')        -> ('npm','old') / ('npm','new')
```

## Design: three-way classification, fail-closed default

Per ecosystem: **known-value** flags consume the next token, **known-boolean** flags skip, **known-positive** flags yield the package, and any **unlisted** bare flag → `("unknown", None)`.

This is not the denylist #183 rejected. Docker's table failed open because unlisted meant *"take the next token as the image"* — an omission silently produced a wrong identity. Inverting the default means an omission costs **auto-update for one odd config** (safe, loud, fixable) instead of a **silent collision** (unsafe, invisible).

### Two designs the board rejected before this one

A first draft — *"any bare flag before the candidate yields unknown"* — would have broken the canonical configs, all correct today:

```
docker run -i --rm mcp/server:latest      docker run -it --rm img
uvx --quiet my-package --arg              docker run -e KEY=val --rm ghcr.io/org/mcp
```

`docker run -it --rm` is the shape **this repo's own README uses** (`:1528`). Essentially every real docker server would have become permanently unverifiable. A second draft added a whole-argv `--from` scan, which turns `uvx mypkg --from other` from `mypkg` into `other` — a fail-open misidentification *introduced by the fix*. All five forms are now pinned as regression tests.

## Two live defects repaired along the way

**The README's own pin form was mis-identified.** `README.md:1133` documents `uvx --python 3.12 --from index-it-mcp==1.2.0 index-it-mcp`, which resolved to `('pypi','3.12')` — the *Python version* as the package name.

**A pinned server could have been moved to latest.** `--from=pkg==1.2.0` reported **no pin** while the spaced form reported `1.2.0`. Both now report `1.2.0`.

**And `browser-use`'s version checks were silently failing.** `manifest.yaml:352` ships `--from browser-use[cli]`; PyPI returns `None` for that name and `0.13.8` for `browser-use`. PEP 508 base-name normalization repairs it. Confirmed live, not assumed.

## The flag tables were verified mechanically, and ten entries were dropped

The claim *"verified entry by entry against `--help`"* was **not true** when first written — several entries were added from memory, the practice the plan forbids and the direction that fails open. All **296 entries** were then checked against live help output:

- **Ten entries absent from their tool's help were REMOVED**, not kept — removal is fail-closed. Measured cost: **zero** for shipped configs (all 98 manifest servers still resolve, 0 unknown).
- Drafting from memory had got docker `--pull` wrong (it takes a value — the plan's own named hazard), plus uv's `--quiet`/`--verbose` and pip's `--platform`.
- Three exceptions are stated rather than silent (`-it`/`-ti` combined shorts; npm's bare `--package`).

## Mutation proof: 20/20 killed, each by its own single node

The harness carries an **import-provenance guard** — without it every mutant would have falsely survived while the unmutated worktree served the imports. Three tests claimed more than they pinned and were fixed or relabelled:

- `_takes_a_value_ambiguously`'s `"=" not in arg` clause was **dead code** — the rule had two homes and only one was live.
- Repeated `--package` had no test; returning the first of several different packages is the exact guess this change exists to stop. Now fails closed.
- One mutation **never applied** (anchor didn't match ruff-formatted source) and had been reported as *unproven* rather than passing.

Two tests are non-discriminating and now say so in their docstrings instead of implying a proof.

## #180 status — recommend it stays OPEN

All three forms from its narrowing comment are **closed**, and its two original forms stay fixed. But by #180's own closing sentence — *"until the identity gate actually holds for ordinary commands"* — the npm branch still fails open on unlisted flags:

```
npm exec --loglevel silly a/b      -> both ('npm','silly')
npm exec --registry https://r a/b  -> both ('npm','https://r')
```

Converting npm needs an enumeration of its boolean globals so the pinned ordering (`npm --silent exec pkg` → `pkg`) keeps passing — a new design surface deserving its own board round. The middle ground, a fail-open npm value table, is precisely the shape this plan rejected, so it was not introduced into a fifth ecosystem.

## Verification

`2764 passed, 3 skipped` (baseline 2737, +27); ruff and mypy clean; all seven collisions closed; all five non-negotiable forms unchanged; 98/98 manifest servers resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbREMUsxgJ8TDBLpJ56PWb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790330209&installation_model_id=427051&pr_number=190&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F190&signature=6ca1396b89cfb4bec8312fd52142dd4d539e6473f84ab031f2e2855d9199998f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->