### PR TITLE
chore: v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-08-26
+
 ### Fixed
 - **A command-line flag's *value* is no longer mistaken for the package name.**
   Package detection skipped flags but not the tokens those flags carry, so the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "2.4.1"
+version = "2.5.0"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "2.4.1"
+__version__ = "2.5.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "2.4.1"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release cut for 2.5.0. Version bump only — no source behaviour changes in this PR.

Ships **#182** (#190), merged to main and unreleased.

## What's in it

`detect_package_type` skipped **flags** but not the **values those flags carry**, so the first non-flag token was often a flag's argument. Two different servers then resolved to one identity — and 2.4.0's gate compares exactly this name to decide whether a cached description still describes the configured package, so it read that as a **positive confirmation** and served the wrong package's tool descriptions.

Seven forms, all now resolving distinctly:

```
uvx   --python 3.12 a/b        ('pypi','3.12')      -> ('pypi','a') / ('pypi','b')
uvx   --with requests a/b      ('pypi','requests')  -> ('pypi','a') / ('pypi','b')
pip   --index-url URL a/b      ('pypi','https://x') -> ('pypi','a') / ('pypi','b')
cargo --features full a/b      ('cargo','full')     -> ('cargo','a') / ('cargo','b')
docker --env-file .env a/b     ('docker','.env')    -> ('docker','a') / ('docker','b')
docker --mount spec a/b        ('docker','type=…')  -> ('docker','a') / ('docker','b')
npm   exec --package=old/new   ('npm','bin')        -> ('npm','old') / ('npm','new')
```

## Three live defects repaired that no issue had recorded

- **The README's own documented pin form was mis-identified.** `uvx --python 3.12 --from index-it-mcp==1.2.0 index-it-mcp` resolved to `('pypi','3.12')` — the *Python version* as the package name.
- **A pinned server could have been moved to latest.** `--from=pkg==1.2.0` reported **no pin** while the spaced form reported `1.2.0`.
- **`browser-use`'s version checks were silently failing.** The manifest ships `--from browser-use[cli]`; PyPI returns `None` for that name and `0.13.8` for `browser-use`.

## Why minor, not patch

Two user-visible consequences, both documented:

- Affected servers' **package identity changes**, so their cached descriptions refresh once.
- A server launched with a flag the parser cannot classify **can no longer be auto-updated** — it fails closed rather than guessing. That is the deliberate trade: failing closed is loud and recoverable, failing open is silent.

## Still open

**#180** is re-narrowed, not closed. npm still fails open on unlisted flags (`npm exec --loglevel silly <pkg>`), which needs npm's boolean globals enumerated mechanically and deserves its own review round rather than being rushed to close an issue.

**#187**'s CI job timeouts are also on main but are **deliberately absent from the CHANGELOG** — CI-only, no user-visible behaviour, and the repo's convention requires an entry only for `src/` changes.

## Verification

`2770 passed, 3 skipped, 0 failed`; ruff and mypy clean. Release-note extraction dry-run with the workflow's own awk: 50 lines, one `###` heading, terminates cleanly before the 2.4.1 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbREMUsxgJ8TDBLpJ56PWb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790333556&installation_model_id=427051&pr_number=191&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F191&signature=5a793f27f575a30ecfb001a2b295681687d000fcb4a31bb3c1cf000d90f142d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->