### PR TITLE
fix(parser): fail closed on unrecognised npm flags (closes #180)

### DIFF
--- a/.consiliency/notes/derive_npm_flags.py
+++ b/.consiliency/notes/derive_npm_flags.py
@@ -1,0 +1,356 @@
+"""Derive npm's flag-arity tables from npm's OWN config schema, and verify them.
+
+`_npm_package_arg` must know, for every npm flag, whether the token after it is
+that flag's value or the package name. Getting one entry wrong in the
+"consumes nothing" direction is fail-OPEN: the flag's value becomes the package
+identity, and two different servers collapse into one (Consiliency/pmcp#180).
+npm has 181 flags and 40 shorthands, which is far past what anyone can recall
+correctly -- #182 removed ten memory-drafted entries across four ecosystems for
+exactly that reason. So the table is generated, never hand-listed.
+
+THE SOURCE IS `@npmcli/config/lib/definitions/index.js`, NOT `npm config list`.
+-----------------------------------------------------------------------------
+`npm config list --json` is disqualified as a source, and this is not a style
+preference. It emits the *active merged configuration*, not the definition set:
+
+  * it omits private entries (`_auth`, `password`),
+  * it adds host-specific ones (`npm-version`, a user-scoped registry),
+  * `NPM_CONFIG_COLOR=always` flips `color` from a boolean to a string,
+  * it omits all 40 shorthands wholesale, so `--silent` looks like an unknown
+    flag rather than an alias of `--loglevel silent`.
+
+The same generator would therefore classify differently on different hosts. The
+definitions module, by contrast, declares each flag's `type` -- the real arity
+declaration, independent of environment and of any default value.
+
+WHAT `type` MEANS, AND THE TWO MEMBERS THAT ARE NOT VALUE TYPES
+--------------------------------------------------------------
+`type` is a SET, e.g. `color` is `['always', Boolean]`. Two members are
+multiplicity/absence markers rather than value types and are dropped before
+classifying:
+
+  `null`   "unset". Dropping it is load-bearing: `yes`, `optional`,
+           `production`, `workspaces` and `expect-results` are all
+           `null|Boolean`, so without the drop they read as conditional and
+           `--yes`/`-y` -- a real MCP launch form -- would be refused.
+  `Array`  "may repeat". Measured inert on npm 11.19.0 (no definition changes
+           class either way, and none is `Boolean|Array`); the generator
+           reports it if that ever stops being true.
+
+Classification, after the drop:
+
+  Boolean alone         -> boolean-arity: consumes nothing ... except a literal
+                           `true`/`false`, which npm's parser DOES take as the
+                           flag's value. Verified below for all 76.
+  no Boolean member     -> value: consumes the next token. This is where
+                           `proxy` (`null|false|{url}`) belongs -- it has no
+                           Boolean member and always consumes, including
+                           `--proxy a` where it swallows the package.
+  Boolean AND non-Bool  -> CONDITIONAL: arity depends on the next token's
+                           content, so no single class is right. Left UNLISTED,
+                           which makes the scanner refuse. Fail closed.
+
+SHORTHANDS EXPAND; ARITY COMES FROM THE EXPANSION'S LENGTH
+----------------------------------------------------------
+  length >= 2  a value is baked in (`silent` -> ['--loglevel','silent'])
+               => boolean-arity, consumes nothing.
+  length == 1  a pure rename (`reg` -> ['--registry'], `y` -> ['--yes'])
+               => the target's arity.
+
+This subsumes the hand-coded `-y` special case `_npm_package_arg` used to
+carry, and makes `npm --silent exec pkg` -> `pkg` hold by construction.
+
+Deliberately NOT a pytest: npm's schema is version-specific and CI has no npm.
+Behaviour is pinned by the pure unit tests in tests/test_version_checker.py;
+this script is what keeps those pins honest against a real npm.
+
+Usage:
+    python3 .consiliency/notes/derive_npm_flags.py            # emit the tables
+    python3 .consiliency/notes/derive_npm_flags.py --verify   # check committed
+"""
+
+import json
+import pathlib
+import subprocess
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parents[2]
+
+# Multiplicity/absence markers, not value types. See the module docstring --
+# dropping `null` is what keeps `--yes` usable.
+_NOT_A_VALUE_TYPE = frozenset({"null", "Array"})
+
+BOOLEAN, VALUE, CONDITIONAL, UNINTERPRETABLE = (
+    "boolean",
+    "value",
+    "conditional",
+    "uninterpretable",
+)
+
+# `--package` is handled as a KNOWN-POSITIVE by the scanner (its value IS the
+# package), so it is deliberately absent from both emitted tables; the scanner
+# consults its positive table first.
+_POSITIVE = frozenset({"package"})
+
+# Read npm's definitions module and dump it as JSON, labelling each `type`
+# member. Also probes npm's real parser (`nopt`) for every flag, so the
+# declared classification can be checked against observed behaviour rather
+# than trusted -- the type strings alone are what falsified an earlier design.
+_NODE = r"""
+const path = require('path');
+const root = process.argv[1];
+const defsPath = path.join(
+  root, 'node_modules', '@npmcli', 'config', 'lib', 'definitions', 'index.js');
+const m = require(defsPath);
+const nopt = require(path.join(root, 'node_modules', 'nopt'));
+
+const label = (x) => {
+  if (x === null) return 'null';
+  if (x === false) return 'false';
+  if (x === true) return 'true';
+  if (typeof x === 'string' || typeof x === 'number') return '<literal>';
+  if (typeof x === 'function') return x.name || '<anon-fn>';
+  if (typeof x === 'object') return x && x.Url ? 'url' : 'path';
+  return '<unknown:' + typeof x + '>';
+};
+
+const types = {};
+for (const [k, v] of Object.entries(m.definitions)) types[k] = v.type;
+const remain = (argv) => nopt(types, m.shorthands, argv, 0).argv.remain;
+// Does `--flag PROBE` swallow PROBE? Probe with an arbitrary token, with the
+// two boolean literals, and -- when the type declares one -- with a real enum
+// member, since that is exactly where a conditional flag reveals itself.
+const consumes = (flag, probe) => !remain(['--' + flag, probe, 'TAIL']).includes(probe);
+
+const definitions = {};
+for (const [k, v] of Object.entries(m.definitions)) {
+  const t = Array.isArray(v.type) ? v.type : [v.type];
+  const lit = t.find((x) => typeof x === 'string' || typeof x === 'number');
+  const probes = ['zzarbitrary', 'true', 'false'];
+  if (lit !== undefined) probes.push(String(lit));
+  definitions[k] = {
+    type: t.map(label),
+    short: v.short === undefined ? [] : [].concat(v.short),
+    probes: Object.fromEntries(probes.map((p) => [p, consumes(k, p)])),
+  };
+}
+console.log(JSON.stringify({
+  npm_version: require(path.join(root, 'package.json')).version,
+  definitions,
+  shorthands: m.shorthands,
+}));
+"""
+
+
+def npm_root() -> str:
+    """The global npm install directory, i.e. where `@npmcli/config` lives."""
+    out = subprocess.run(
+        ["npm", "root", "-g"], capture_output=True, text=True, check=True
+    )
+    return str(pathlib.Path(out.stdout.strip()) / "npm")
+
+
+def read_schema() -> dict:
+    out = subprocess.run(
+        ["node", "-e", _NODE, npm_root()],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(out.stdout)
+
+
+def classify(type_labels: list[str]) -> str:
+    """npm's declared `type` -> one of BOOLEAN / VALUE / CONDITIONAL."""
+    members = [t for t in type_labels if t not in _NOT_A_VALUE_TYPE]
+    has_boolean = "Boolean" in members
+    others = [t for t in members if t != "Boolean"]
+    if has_boolean and not others:
+        return BOOLEAN
+    if not has_boolean and others:
+        return VALUE
+    if has_boolean and others:
+        return CONDITIONAL
+    return UNINTERPRETABLE
+
+
+def expected_arity(cls: str, probe_results: dict[str, bool]) -> bool | None:
+    """What the declared class PLUS the true/false rule predicts, per probe.
+
+    Returns None for CONDITIONAL (no prediction is made -- it goes unlisted).
+    """
+    if cls == BOOLEAN:
+        return None  # handled per-probe by the caller
+    if cls == VALUE:
+        return True
+    return None
+
+
+def build(schema: dict) -> tuple[dict[str, str], list[str], list[str], list[str]]:
+    """Return (flag -> class, conditional names, union-with-Boolean, unreadable)."""
+    defs = schema["definitions"]
+    classes: dict[str, str] = {}
+    conditional: list[str] = []
+    union_with_boolean: list[str] = []
+    unreadable: list[str] = []
+
+    name_class: dict[str, str] = {}
+    for name, info in defs.items():
+        cls = classify(info["type"])
+        name_class[name] = cls
+        if cls == UNINTERPRETABLE:
+            unreadable.append(f"{name}: type={info['type']}")
+            continue
+        if cls == CONDITIONAL:
+            # Print the PROBES too, not just the type string. `browser` is
+            # declared `null|Boolean|String` and so classifies conditional,
+            # but nopt shows it consuming every probe -- i.e. it behaves as a
+            # value flag, and listing it as one would cost nothing in safety.
+            # It is left unlisted anyway, because refusing is never the unsafe
+            # direction and no MCP launch form uses `--browser`. A reader
+            # re-deciding that needs the evidence in front of them.
+            probes = " ".join(f"{p}={c}" for p, c in info["probes"].items())
+            conditional.append(
+                f"{name}: type={'|'.join(info['type'])}  nopt-consumes[{probes}]"
+            )
+        if cls == VALUE and "Boolean" in info["type"]:
+            # Cannot happen under the current rule, but if npm ever declares a
+            # value type that also carries Boolean, that is the class that
+            # falsified the first design and it must not pass silently.
+            union_with_boolean.append(f"{name}: type={'|'.join(info['type'])}")
+        if name in _POSITIVE:
+            continue
+        if cls in (BOOLEAN, VALUE):
+            classes[f"--{name}"] = cls
+            for short in info["short"]:
+                classes[f"-{short}"] = cls
+                classes[f"--{short}"] = cls
+        if cls == BOOLEAN:
+            # `--no-X` negates a boolean and, like the boolean itself,
+            # consumes only a literal true/false. Verified against nopt.
+            classes[f"--no-{name}"] = cls
+
+    for key, expansion in schema["shorthands"].items():
+        if len(expansion) >= 2:
+            cls = BOOLEAN  # a value is baked into the expansion
+        else:
+            target = expansion[0].lstrip("-")
+            if target.startswith("no-"):
+                # `--no-global`, `--no-yes`: boolean-arity iff the base is a
+                # boolean. Otherwise unlisted -- `--no-color` refuses, safely.
+                cls = BOOLEAN if name_class.get(target[3:]) == BOOLEAN else CONDITIONAL
+            else:
+                cls = name_class.get(target, CONDITIONAL)
+        if cls in (BOOLEAN, VALUE):
+            classes[f"-{key}"] = cls
+            classes[f"--{key}"] = cls
+
+    return classes, conditional, union_with_boolean, unreadable
+
+
+def check_against_nopt(schema: dict) -> list[str]:
+    """Declared class + the true/false rule must reproduce npm's own parser.
+
+    This is the check that makes "verified against npm's parser" true rather
+    than asserted. A BOOLEAN flag is predicted to consume a probe iff the probe
+    is exactly `true`/`false`; a VALUE flag is predicted to consume every
+    probe; a CONDITIONAL flag makes no prediction because it is unlisted.
+    """
+    bad: list[str] = []
+    for name, info in schema["definitions"].items():
+        cls = classify(info["type"])
+        for probe, observed in info["probes"].items():
+            if cls == BOOLEAN:
+                predicted = probe in ("true", "false")
+            elif cls == VALUE:
+                predicted = True
+            else:
+                continue
+            if predicted != observed:
+                bad.append(
+                    f"--{name} {probe}: declared={cls} predicts "
+                    f"consumes={predicted}, nopt says {observed} "
+                    f"(type={'|'.join(info['type'])})"
+                )
+    return bad
+
+
+def emit(classes: dict[str, str]) -> str:
+    def block(cls: str) -> str:
+        entries = sorted(f for f, c in classes.items() if c == cls)
+        body = "\n".join(f'        "{e}",' for e in entries)
+        return "{\n" + body + "\n    }"
+
+    return (
+        f"_NPM_VALUE_FLAGS = frozenset(\n    {block(VALUE)}\n)\n\n\n"
+        f"_NPM_BOOLEAN_FLAGS = frozenset(\n    {block(BOOLEAN)}\n)\n"
+    )
+
+
+def main() -> int:
+    schema = read_schema()
+    classes, conditional, union, unreadable = build(schema)
+
+    print(f"npm {schema['npm_version']}: "
+          f"{len(schema['definitions'])} definitions, "
+          f"{len(schema['shorthands'])} shorthands", file=sys.stderr)
+
+    # REQUIRED REPORTING. An unlisted flag refuses, which is safe -- but the
+    # set must be reviewed rather than accidental.
+    print(f"\nCONDITIONAL ARITY -> left unlisted, scanner refuses ({len(conditional)}):",
+          file=sys.stderr)
+    for entry in conditional:
+        print(f"  {entry}", file=sys.stderr)
+    print(f"\nVALUE flags carrying a Boolean member ({len(union)}):", file=sys.stderr)
+    for entry in union:
+        print(f"  {entry}", file=sys.stderr)
+    print(f"\nUNINTERPRETABLE type ({len(unreadable)}):", file=sys.stderr)
+    for entry in unreadable:
+        print(f"  {entry}", file=sys.stderr)
+
+    mismatches = check_against_nopt(schema)
+    print(f"\nnopt cross-check: {len(mismatches)} mismatch(es) over "
+          f"{len(schema['definitions'])} definitions", file=sys.stderr)
+    for entry in mismatches:
+        print(f"  {entry}", file=sys.stderr)
+
+    if "--verify" not in sys.argv:
+        print(emit(classes))
+        return 0
+
+    sys.path.insert(0, str(REPO / "src"))
+    from pmcp.manifest import version_checker as vc
+
+    print(f"\nverifying tables in {vc.__file__}", file=sys.stderr)
+    failures = list(mismatches)
+    for label, live, committed in (
+        ("value", {f for f, c in classes.items() if c == VALUE}, vc._NPM_VALUE_FLAGS),
+        ("boolean", {f for f, c in classes.items() if c == BOOLEAN},
+         vc._NPM_BOOLEAN_FLAGS),
+    ):
+        for flag in sorted(live - committed):
+            failures.append(f"{label}: {flag} in live npm, MISSING from table")
+        for flag in sorted(committed - live):
+            failures.append(f"{label}: {flag} in table, absent from live npm")
+
+    # A flag classified one way here and the other way in the table is the
+    # fail-OPEN direction if the table says boolean; report both directions.
+    overlap = vc._NPM_VALUE_FLAGS & vc._NPM_BOOLEAN_FLAGS
+    for flag in sorted(overlap):
+        failures.append(f"{flag} is in BOTH committed tables")
+
+    if failures:
+        print(f"\nFAIL: {len(failures)} discrepanc(ies)", file=sys.stderr)
+        for entry in failures:
+            print(f"  {entry}", file=sys.stderr)
+        return 1
+    print(
+        f"\nOK: {len(vc._NPM_VALUE_FLAGS)} value + "
+        f"{len(vc._NPM_BOOLEAN_FLAGS)} boolean entries match live npm",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.consiliency/notes/derive_npm_flags.py
+++ b/.consiliency/notes/derive_npm_flags.py
@@ -53,7 +53,11 @@ Classification, after the drop:
 SHORTHANDS EXPAND; ARITY COMES FROM THE EXPANSION'S LENGTH
 ----------------------------------------------------------
   length >= 2  a value is baked in (`silent` -> ['--loglevel','silent'])
-               => boolean-arity, consumes nothing.
+               => SKIP: consumes nothing, ever. NOT the same as boolean --
+               a real boolean consumes a literal `true`/`false` and one of
+               these does not, so collapsing the two is fail-OPEN:
+                 --silent true TAIL -> remain ["true","TAIL"]
+                 --global true TAIL -> remain ["TAIL"]
   length == 1  a pure rename (`reg` -> ['--registry'], `y` -> ['--yes'])
                => the target's arity.
 
@@ -80,11 +84,12 @@ REPO = pathlib.Path(__file__).resolve().parents[2]
 # dropping `null` is what keeps `--yes` usable.
 _NOT_A_VALUE_TYPE = frozenset({"null", "Array"})
 
-BOOLEAN, VALUE, CONDITIONAL, UNINTERPRETABLE = (
+BOOLEAN, VALUE, CONDITIONAL, UNINTERPRETABLE, SKIP = (
     "boolean",
     "value",
     "conditional",
     "uninterpretable",
+    "skip",
 )
 
 # `--package` is handled as a KNOWN-POSITIVE by the scanner (its value IS the
@@ -194,6 +199,24 @@ def build(schema: dict) -> tuple[dict[str, str], list[str], list[str], list[str]
     union_with_boolean: list[str] = []
     unreadable: list[str] = []
 
+    def record(flag: str, cls: str) -> None:
+        """Write one entry, refusing to silently reclassify an existing one.
+
+        Definitions, `short` aliases and shorthands are written in that order,
+        so a plain `classes[flag] = cls` would let a later source overwrite an
+        earlier one. That is the fail-OPEN drift direction -- it yields a
+        WRONG entry rather than a missing one -- and it would pass `--verify`
+        silently because the generator and the table would agree with each
+        other while both disagreeing with npm. Empty on 11.19.0; this exists
+        so a future npm cannot make it non-empty quietly.
+        """
+        previous = classes.get(flag)
+        if previous is not None and previous != cls:
+            raise SystemExit(
+                f"conflicting classification for {flag}: {previous} vs {cls}"
+            )
+        classes[flag] = cls
+
     name_class: dict[str, str] = {}
     for name, info in defs.items():
         cls = classify(info["type"])
@@ -221,18 +244,27 @@ def build(schema: dict) -> tuple[dict[str, str], list[str], list[str], list[str]
         if name in _POSITIVE:
             continue
         if cls in (BOOLEAN, VALUE):
-            classes[f"--{name}"] = cls
+            record(f"--{name}", cls)
             for short in info["short"]:
-                classes[f"-{short}"] = cls
-                classes[f"--{short}"] = cls
+                record(f"-{short}", cls)
+                record(f"--{short}", cls)
         if cls == BOOLEAN:
             # `--no-X` negates a boolean and, like the boolean itself,
             # consumes only a literal true/false. Verified against nopt.
-            classes[f"--no-{name}"] = cls
+            record(f"--no-{name}", cls)
 
     for key, expansion in schema["shorthands"].items():
         if len(expansion) >= 2:
-            cls = BOOLEAN  # a value is baked into the expansion
+            # A value is baked into the expansion, so by the time npm parses
+            # argv there is no flag left awaiting one. Crucially this is NOT
+            # the same as BOOLEAN: a real boolean consumes a literal
+            # `true`/`false`, and a baked-value shorthand does not. Verified:
+            #   --silent true TAIL -> remain ["true","TAIL"]   (no consume)
+            #   --global true TAIL -> remain ["TAIL"]          (consumes)
+            # Collapsing the two let `npx --silent true <arg>` read <arg> as
+            # the package when npm's package is `true` -- a wrong identity,
+            # and `--silent true X` / `--silent false X` collapse onto X.
+            cls = SKIP  # a value is baked into the expansion
         else:
             target = expansion[0].lstrip("-")
             if target.startswith("no-"):
@@ -241,9 +273,9 @@ def build(schema: dict) -> tuple[dict[str, str], list[str], list[str], list[str]
                 cls = BOOLEAN if name_class.get(target[3:]) == BOOLEAN else CONDITIONAL
             else:
                 cls = name_class.get(target, CONDITIONAL)
-        if cls in (BOOLEAN, VALUE):
-            classes[f"-{key}"] = cls
-            classes[f"--{key}"] = cls
+        if cls in (BOOLEAN, VALUE, SKIP):
+            record(f"-{key}", cls)
+            record(f"--{key}", cls)
 
     return classes, conditional, union_with_boolean, unreadable
 
@@ -298,7 +330,11 @@ def read_committed_tables(source: pathlib.Path) -> dict[str, set[str]]:
             continue
         names = [t.id for t in node.targets if isinstance(t, ast.Name)]
         for name in names:
-            if name not in ("_NPM_VALUE_FLAGS", "_NPM_BOOLEAN_FLAGS"):
+            if name not in (
+                "_NPM_VALUE_FLAGS",
+                "_NPM_BOOLEAN_FLAGS",
+                "_NPM_SKIP_FLAGS",
+            ):
                 continue
             call = node.value
             if (
@@ -308,9 +344,14 @@ def read_committed_tables(source: pathlib.Path) -> dict[str, set[str]]:
             ):
                 raise SystemExit(f"{name} is not a literal frozenset(...)")
             found[name] = {
-                ast.literal_eval(element) for element in call.args[0].elts  # type: ignore[attr-defined]
+                ast.literal_eval(element)
+                for element in call.args[0].elts  # type: ignore[attr-defined]
             }
-    missing = {"_NPM_VALUE_FLAGS", "_NPM_BOOLEAN_FLAGS"} - found.keys()
+    missing = {
+        "_NPM_VALUE_FLAGS",
+        "_NPM_BOOLEAN_FLAGS",
+        "_NPM_SKIP_FLAGS",
+    } - found.keys()
     if missing:
         raise SystemExit(f"not module-level literals in {source}: {sorted(missing)}")
     return found
@@ -324,7 +365,8 @@ def emit(classes: dict[str, str]) -> str:
 
     return (
         f"_NPM_VALUE_FLAGS = frozenset(\n    {block(VALUE)}\n)\n\n\n"
-        f"_NPM_BOOLEAN_FLAGS = frozenset(\n    {block(BOOLEAN)}\n)\n"
+        f"_NPM_BOOLEAN_FLAGS = frozenset(\n    {block(BOOLEAN)}\n)\n\n\n"
+        f"_NPM_SKIP_FLAGS = frozenset(\n    {block(SKIP)}\n)\n"
     )
 
 
@@ -332,14 +374,19 @@ def main() -> int:
     schema = read_schema()
     classes, conditional, union, unreadable = build(schema)
 
-    print(f"npm {schema['npm_version']}: "
-          f"{len(schema['definitions'])} definitions, "
-          f"{len(schema['shorthands'])} shorthands", file=sys.stderr)
+    print(
+        f"npm {schema['npm_version']}: "
+        f"{len(schema['definitions'])} definitions, "
+        f"{len(schema['shorthands'])} shorthands",
+        file=sys.stderr,
+    )
 
     # REQUIRED REPORTING. An unlisted flag refuses, which is safe -- but the
     # set must be reviewed rather than accidental.
-    print(f"\nCONDITIONAL ARITY -> left unlisted, scanner refuses ({len(conditional)}):",
-          file=sys.stderr)
+    print(
+        f"\nCONDITIONAL ARITY -> left unlisted, scanner refuses ({len(conditional)}):",
+        file=sys.stderr,
+    )
     for entry in conditional:
         print(f"  {entry}", file=sys.stderr)
     print(f"\nVALUE flags carrying a Boolean member ({len(union)}):", file=sys.stderr)
@@ -350,8 +397,11 @@ def main() -> int:
         print(f"  {entry}", file=sys.stderr)
 
     mismatches = check_against_nopt(schema)
-    print(f"\nnopt cross-check: {len(mismatches)} mismatch(es) over "
-          f"{len(schema['definitions'])} definitions", file=sys.stderr)
+    print(
+        f"\nnopt cross-check: {len(mismatches)} mismatch(es) over "
+        f"{len(schema['definitions'])} definitions",
+        file=sys.stderr,
+    )
     for entry in mismatches:
         print(f"  {entry}", file=sys.stderr)
 
@@ -364,10 +414,21 @@ def main() -> int:
     print(f"\nverifying tables in {source}", file=sys.stderr)
     failures = list(mismatches)
     for label, live, committed in (
-        ("value", {f for f, c in classes.items() if c == VALUE},
-         committed_tables["_NPM_VALUE_FLAGS"]),
-        ("boolean", {f for f, c in classes.items() if c == BOOLEAN},
-         committed_tables["_NPM_BOOLEAN_FLAGS"]),
+        (
+            "value",
+            {f for f, c in classes.items() if c == VALUE},
+            committed_tables["_NPM_VALUE_FLAGS"],
+        ),
+        (
+            "boolean",
+            {f for f, c in classes.items() if c == BOOLEAN},
+            committed_tables["_NPM_BOOLEAN_FLAGS"],
+        ),
+        (
+            "skip",
+            {f for f, c in classes.items() if c == SKIP},
+            committed_tables["_NPM_SKIP_FLAGS"],
+        ),
     ):
         for flag in sorted(live - committed):
             failures.append(f"{label}: {flag} in live npm, MISSING from table")
@@ -376,11 +437,11 @@ def main() -> int:
 
     # A flag in both tables would let the boolean branch win or lose by table
     # order rather than by npm's schema; either way it is not a classification.
-    overlap = committed_tables["_NPM_VALUE_FLAGS"] & committed_tables[
-        "_NPM_BOOLEAN_FLAGS"
-    ]
-    for flag in sorted(overlap):
-        failures.append(f"{flag} is in BOTH committed tables")
+    names = ("_NPM_VALUE_FLAGS", "_NPM_BOOLEAN_FLAGS", "_NPM_SKIP_FLAGS")
+    for i, left in enumerate(names):
+        for right in names[i + 1 :]:
+            for flag in sorted(committed_tables[left] & committed_tables[right]):
+                failures.append(f"{flag} is in BOTH {left} and {right}")
 
     if failures:
         print(f"\nFAIL: {len(failures)} discrepanc(ies)", file=sys.stderr)
@@ -389,7 +450,8 @@ def main() -> int:
         return 1
     print(
         f"\nOK: {len(committed_tables['_NPM_VALUE_FLAGS'])} value + "
-        f"{len(committed_tables['_NPM_BOOLEAN_FLAGS'])} boolean entries "
+        f"{len(committed_tables['_NPM_BOOLEAN_FLAGS'])} boolean + "
+        f"{len(committed_tables['_NPM_SKIP_FLAGS'])} skip entries "
         f"match live npm {schema['npm_version']}",
         file=sys.stderr,
     )

--- a/.consiliency/notes/derive_npm_flags.py
+++ b/.consiliency/notes/derive_npm_flags.py
@@ -275,6 +275,47 @@ def check_against_nopt(schema: dict) -> list[str]:
     return bad
 
 
+def read_committed_tables(source: pathlib.Path) -> dict[str, set[str]]:
+    """Parse the two tables out of version_checker.py with `ast`.
+
+    Deliberately NOT `import pmcp.manifest.version_checker`: that pulls in
+    aiohttp/packaging/semver, so the verifier would only run inside the
+    project venv -- on a host that happens to have the npm being checked. A
+    drift check should run wherever npm does.
+
+    Reading them as literals also PINS a property worth pinning: these must be
+    module-level constants, not something rebuilt per call. #182 found
+    `_docker_image_arg` carrying a function-local table that was rebuilt on
+    every call and invisible to its verifier; this raises rather than silently
+    finding nothing if that shape comes back.
+    """
+    import ast
+
+    tree = ast.parse(source.read_text())
+    found: dict[str, set[str]] = {}
+    for node in tree.body:  # module level ONLY -- not ast.walk
+        if not isinstance(node, ast.Assign):
+            continue
+        names = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        for name in names:
+            if name not in ("_NPM_VALUE_FLAGS", "_NPM_BOOLEAN_FLAGS"):
+                continue
+            call = node.value
+            if (
+                not isinstance(call, ast.Call)
+                or not isinstance(call.func, ast.Name)
+                or call.func.id != "frozenset"
+            ):
+                raise SystemExit(f"{name} is not a literal frozenset(...)")
+            found[name] = {
+                ast.literal_eval(element) for element in call.args[0].elts  # type: ignore[attr-defined]
+            }
+    missing = {"_NPM_VALUE_FLAGS", "_NPM_BOOLEAN_FLAGS"} - found.keys()
+    if missing:
+        raise SystemExit(f"not module-level literals in {source}: {sorted(missing)}")
+    return found
+
+
 def emit(classes: dict[str, str]) -> str:
     def block(cls: str) -> str:
         entries = sorted(f for f, c in classes.items() if c == cls)
@@ -318,24 +359,26 @@ def main() -> int:
         print(emit(classes))
         return 0
 
-    sys.path.insert(0, str(REPO / "src"))
-    from pmcp.manifest import version_checker as vc
-
-    print(f"\nverifying tables in {vc.__file__}", file=sys.stderr)
+    source = REPO / "src" / "pmcp" / "manifest" / "version_checker.py"
+    committed_tables = read_committed_tables(source)
+    print(f"\nverifying tables in {source}", file=sys.stderr)
     failures = list(mismatches)
     for label, live, committed in (
-        ("value", {f for f, c in classes.items() if c == VALUE}, vc._NPM_VALUE_FLAGS),
+        ("value", {f for f, c in classes.items() if c == VALUE},
+         committed_tables["_NPM_VALUE_FLAGS"]),
         ("boolean", {f for f, c in classes.items() if c == BOOLEAN},
-         vc._NPM_BOOLEAN_FLAGS),
+         committed_tables["_NPM_BOOLEAN_FLAGS"]),
     ):
         for flag in sorted(live - committed):
             failures.append(f"{label}: {flag} in live npm, MISSING from table")
         for flag in sorted(committed - live):
             failures.append(f"{label}: {flag} in table, absent from live npm")
 
-    # A flag classified one way here and the other way in the table is the
-    # fail-OPEN direction if the table says boolean; report both directions.
-    overlap = vc._NPM_VALUE_FLAGS & vc._NPM_BOOLEAN_FLAGS
+    # A flag in both tables would let the boolean branch win or lose by table
+    # order rather than by npm's schema; either way it is not a classification.
+    overlap = committed_tables["_NPM_VALUE_FLAGS"] & committed_tables[
+        "_NPM_BOOLEAN_FLAGS"
+    ]
     for flag in sorted(overlap):
         failures.append(f"{flag} is in BOTH committed tables")
 
@@ -345,8 +388,9 @@ def main() -> int:
             print(f"  {entry}", file=sys.stderr)
         return 1
     print(
-        f"\nOK: {len(vc._NPM_VALUE_FLAGS)} value + "
-        f"{len(vc._NPM_BOOLEAN_FLAGS)} boolean entries match live npm",
+        f"\nOK: {len(committed_tables['_NPM_VALUE_FLAGS'])} value + "
+        f"{len(committed_tables['_NPM_BOOLEAN_FLAGS'])} boolean entries "
+        f"match live npm {schema['npm_version']}",
         file=sys.stderr,
     )
     return 0

--- a/.consiliency/plans/detailed-npm-flag-classification-20260826-1130.md
+++ b/.consiliency/plans/detailed-npm-flag-classification-20260826-1130.md
@@ -96,22 +96,56 @@ npm exec pkg           -> pkg     npm exec exec    -> exec
 
 *Rewritten after board review — the two-way boolean/value split was falsified.*
 
-**Step 1 — expand shorthands first.** `--silent` becomes `--loglevel silent`,
-`-q` becomes `--loglevel warn`. All 40 come from `shorthands`, so no alias is
-hand-listed and none is missed. This is also what keeps the pinned
-`npm --silent exec pkg` → `pkg` working, by construction rather than by a
-special case.
+**Step 1 — expand shorthands first**, with arity taken from the expansion's
+*length*, a rule verified against npm's parser:
+
+| expansion | arity |
+|---|---|
+| length ≥ 2 — a value is baked in (`silent` → `["--loglevel","silent"]`, `q` → `["--loglevel","warn"]`) | **boolean-arity**: consumes nothing |
+| length 1 — a pure rename (`reg` → `["--registry"]`, `w` → `["--workspace"]`, `y` → `["--yes"]`, `g` → `["--global"]`) | **the target's arity** |
+
+All 40 come from `shorthands`, plus the 19 `short` fields on definitions, so no
+alias is hand-listed and none is missed. *Board finding: the config dump omits
+shorthands **wholesale**, not just `--silent` — a 40-fold larger hole than the
+original plan admitted, but closed by a second mechanical read of the same
+module rather than by curation.* This subsumes the existing hand-coded `-y`
+special case, which should be retired into it, and makes the pinned
+`npm --silent exec pkg` → `pkg` hold by construction.
 
 **Step 2 — classify the expanded flag by its declared `type`**, which is a
 *set*, not a scalar:
 
-| declared type | behaviour |
+**`null` in a type list means "unset", not a value type — drop it first.**
+Without that, `yes`, `optional`, `production`, `workspaces` and
+`expect-results` (all `null|Boolean`) read as mixed, and `--yes`/`-y` — a real
+MCP launch form — would be refused. Measured: naive `x != Boolean` gives 7
+mixed; dropping `null` gives the correct classification.
+
+| declared type (after dropping `null`) | behaviour |
 |---|---|
 | `Boolean` alone | skip; the next token is still a candidate |
-| any non-Boolean member (`String`, `Number`, `Url`, `Path`, an enum, an Array) | **consumes the next token** |
-| union with Boolean (`always\|Boolean`) | **consumes the next token** — this is the case that broke the original model |
+| no Boolean member (`String`, `Url`, `Path`, an enum, an Array, `false\|{}`) | **consumes the next token** |
+| Boolean **and** a non-Boolean member | **unlisted → refuse** — arity is conditional and no single class is right |
 | `--package` | known-positive: its value **is** the package |
 | not in `definitions` at all | **`("unknown", None)`** |
+
+**The conditional set is exactly `{color, browser}` — verified against npm's own
+parser (`nopt` + npm's type map), not from the type strings.** A board seat
+proposed `{browser, color, proxy}`; `proxy` is `null|false|{}` with no `Boolean`
+member and **always consumes**, including `--proxy a` where it swallows the
+package, so it is a *value* flag and mis-grouping it would have left that form
+refusing unnecessarily:
+
+```
+--proxy http://p a  -> remain ["exec","a"]     consumes
+--proxy false a     -> remain ["exec","a"]     consumes
+--proxy a           -> remain ["exec"]         consumes the package
+--color always a    -> remain ["exec","a"]     consumes
+--color a           -> remain ["exec","a"]     does NOT consume  <- conditional
+--browser a         -> remain ["exec"]         consumes
+```
+
+`browser` (`null|Boolean|String`) is genuinely mixed and stays unlisted.
 
 **A Boolean flag still consumes a literal `true`/`false`.** npm's parser
 accepts `--global false`, so a bare `true`/`false` following a Boolean flag is
@@ -242,10 +276,19 @@ automation:
 
 - [ ] **Five** pairs satisfy `d(a) != d(b)` **or** `d(a) == ("unknown", None)`,
       each pair's exact value pinned — the three originally reproduced, plus
-      `npm exec --global false a/b` and `npm exec --color always a/b`. *Board
-      finding: those last two survive the plan's original two-way model, so an
-      acceptance set without them can pass while the safety residual stays
-      open.* RED today, mutation-proved per node with recorded output.
+      `npm exec --global false a/b` and `npm exec --color always a/b`.
+
+      *These last two are the acceptance set's whole point.* A board seat
+      **implemented the original plan faithfully in a copy** and demonstrated
+      that all three original collision checks pass, the pinned orderings pass,
+      the fails-closed check passes — **and `npm exec --color always a/b` still
+      returns `('npm','always')` for both**. The suite was structurally blind to
+      the exact entry the method got wrong. An acceptance set that cannot see
+      the defect its own method manufactures is not an acceptance set.
+
+      `--color always` pins to `("unknown", None)` under the corrected table
+      (conditional arity → unlisted → refuse). RED today, mutation-proved per
+      node with recorded output.
 - [ ] **`npm --silent exec pkg` → `pkg`** still holds. `--silent` is absent
       from `npm config list --json` (it aliases `--loglevel=silent`), so this
       is the single most likely regression and gets its own criterion.
@@ -262,9 +305,22 @@ automation:
       and anything whose `type` it cannot interpret. #182 removed ten
       memory-drafted entries; none may be reintroduced.
 - [ ] **All 40 shorthands expand**, verified against `shorthands` rather than
-      hand-listed — `--silent` → `--loglevel silent`, `-q` → `--loglevel warn`.
-      This is what makes `npm --silent exec pkg` → `pkg` hold by construction
-      instead of by special case.
+      hand-listed, with arity from expansion length (≥2 ⇒ boolean, 1 ⇒ target's
+      arity). `--silent` → `--loglevel silent`, `-q` → `--loglevel warn`,
+      `-w` → `--workspace` (consumes), `-y` → `--yes` (boolean). This makes
+      `npm --silent exec pkg` → `pkg` hold by construction, and the existing
+      hand-coded `-y` special case is **retired into it**, not left alongside.
+- [ ] **The conditional-arity set is derived and pinned as exactly
+      `{color, browser}`** — verified against npm's own parser, not from type
+      strings. `proxy` is `null|false|{}` with no Boolean member and **always**
+      consumes (including `--proxy a`, swallowing the package), so it is a
+      value flag; a board seat grouped it as mixed, which would have refused a
+      form that is unambiguous. Any future flag the generator classifies as
+      conditional must be reported, not silently unlisted.
+- [ ] **`null` is dropped from type lists before classifying.** It means
+      "unset", not a value type. Without this, `yes`, `optional`, `production`,
+      `workspaces` and `expect-results` read as conditional and `--yes`/`-y` —
+      a real MCP launch form — is refused.
 - [ ] Every manifest server still resolves (98/98 at 2.5.0) — proven by a scan,
       not assumed.
 - [ ] Full suite, ruff, mypy green; CHANGELOG records the fix **and** the

--- a/.consiliency/plans/detailed-npm-flag-classification-20260826-1130.md
+++ b/.consiliency/plans/detailed-npm-flag-classification-20260826-1130.md
@@ -1,0 +1,203 @@
+# Detailed plan: convert npm to fail-closed flag classification
+
+## Task
+
+Close Consiliency/pmcp#180's remaining residual. `_npm_package_arg` is the one
+ecosystem still **failing open** on unlisted flags: it skips anything starting
+`-` and takes the next bare token, so a flag's *value* becomes the package
+name. Reproduced on `2.5.0`:
+
+```
+npm exec --loglevel silly a / b        -> both ('npm', 'silly')
+npm exec --registry https://r a / b    -> both ('npm', 'https://r')
+npx -y --registry https://r a / b      -> both ('npm', 'https://r')
+```
+
+Two different servers share one identity, and v2.4.0's gate reads that as a
+**positive confirmation**, serving the wrong package's tool descriptions. #182
+converted uvx, pip, cargo and docker to three-way classification with a
+fail-closed default; npm was deliberately deferred because it needs its boolean
+globals enumerated, and that enumeration is this plan's real content.
+
+## Research summary
+
+Context is in session from #180/#182/#183; the branch was read directly
+(`_npm_package_arg`, `src/pmcp/manifest/version_checker.py`).
+
+**npm exposes its own config schema, so the enumeration can be mechanical.**
+`npm config list --json` returns **181 keys with typed default values**, from
+which arity follows: a `bool` default is a boolean flag, anything else takes a
+value. Measured: 70 boolean-typed, 111 value-typed. Spot-checked against known
+truth — `loglevel`→value, `registry`→value, `global`→bool, `prefix`→value,
+`workspace`→value: all correct.
+
+This matters because #182 found **ten entries drafted from memory** across the
+other four ecosystems that could not be verified against real `--help`; all ten
+were removed. npm has ~181 flags — far past what recall can cover — so a
+mechanically-derived table is not a nicety here, it is the only defensible
+method.
+
+**Two limits of that source, found before planning rather than during:**
+
+1. **`--silent` is absent from the config dump entirely.** It is an alias for
+   `--loglevel=silent`, not a config key. Aliases must come from a second
+   source (`npm help npm`'s option list, or npm's documented alias table), or
+   `npm --silent exec pkg` — a currently-pinned form — regresses.
+2. **41 keys have `null` defaults**, where boolean-vs-value is not inferable
+   from the default alone. These must be classified from a second source or
+   left **unlisted**, which under a fail-closed default means "refuse". Leaving
+   them unlisted is safe; guessing is not.
+
+**The pinned ordering that must survive** (`tests/test_version_checker.py`):
+
+```
+npm --silent exec pkg  -> pkg     npm install i    -> i
+npm exec pkg           -> pkg     npm exec exec    -> exec
+```
+
+## Design: extend #182's three-way classification to npm
+
+Same shape as the other four ecosystems, same fail-closed default:
+
+| kind | behaviour |
+|---|---|
+| **known-value** | consumes the next token (`--loglevel`, `--registry`, `--prefix`, `--workspace`, …) |
+| **known-boolean** | skip; next token still a candidate (`--global`, `--silent`, `--save-dev`, …) |
+| **known-positive** | its value **is** the package (`--package`) — already implemented |
+| *unlisted bare flag* | **`("unknown", None)`** |
+
+`--flag=value` stays self-delimiting and safe, as elsewhere.
+
+**Table provenance is the deliverable, not the table.** Generate it with a
+committed script that reads `npm config list --json`, plus an explicit,
+individually-justified alias list for the handful the dump omits. Anything
+neither derivable nor justified stays **unlisted** — costing auto-update for
+that form, never correctness.
+
+**The honest residual, same as #182's:** a *wrong* entry still fails open.
+Classify a value-flag as boolean and its value becomes the package. Mechanical
+derivation is what makes wrong entries unlikely; it does not make them
+impossible, so each classification the script cannot derive must be pinned by
+its own test.
+
+## Changes
+
+### `src/pmcp/manifest/version_checker.py` (modify)
+
+- `_NPM_VALUE_FLAGS`, `_NPM_BOOLEAN_FLAGS` — **add** — module-level frozensets,
+  generated (see below), each entry carrying `--` and any documented short
+  alias. Module-level, not function-local: #182 found `_docker_image_arg`'s
+  table rebuilt on every call and invisible to the verifier.
+- `_npm_package_arg` — **modify** — consult the tables and fail closed on an
+  unlisted bare flag, exactly as the uvx/pip/cargo/docker scanners now do.
+  Keep the one-shot leading-subcommand skip and the `--package` positive
+  handling unchanged.
+
+### `.consiliency/notes/derive_npm_flags.py` (create)
+
+- Generator + verifier, mirroring `verify_tables.py` from #182 — reads
+  `npm config list --json`, emits the two sets, and **re-verifies** a committed
+  table against live npm so drift is detectable later. Deliberately not a
+  pytest: npm's flags are version-specific and CI has no npm.
+- It must **print** the keys it could not classify (the 41 `null`-default ones
+  and any alias-only flags) rather than silently omitting them, so the
+  unlisted set is a reviewed decision rather than an accident.
+
+### `tests/test_version_checker.py` (modify)
+
+- `TestNpmValueFlagCollisions` — **add** — inequality assertions for the three
+  reproduced pairs. All RED today.
+- `TestNpmFailsClosed` — **add** — an unlisted bare flag yields
+  `("unknown", None)`.
+- `TestNpmPinnedOrderingSurvives` — **add** — the four forms above, plus
+  `npm --silent exec pkg` specifically, since `--silent` is the alias case the
+  config dump misses and therefore the most likely regression.
+
+## Documentation impact
+
+- `CHANGELOG.md` — **add** — a `### Fixed` bullet: the collision closes, and
+  a server launched with a flag npm's own config does not describe can no
+  longer be auto-updated. Same cost sentence #182 used; do not soften it.
+- `README.md` — **none**; no documented npm form changes. Verify the README's
+  npm examples still resolve rather than assuming.
+
+## Dependencies & order
+
+1. Generate and review the tables **before** touching the scanner — the table
+   is the risky artifact, not the code.
+2. Scanner change and tables in one commit; a half-applied rule leaves npm
+   partly fail-open, which is worse than uniformly fail-open because it looks
+   fixed.
+3. Tests RED per node before the implementation.
+
+## Verification
+
+```bash
+cd /mnt/workspace/worktrees/pmcp-180-npm
+find src tests -name __pycache__ -type d -exec rm -rf {} + 2>/dev/null
+
+# The three collisions, gone:
+PYTHONDONTWRITEBYTECODE=1 uv run python - <<'PY'
+from pmcp.manifest.version_checker import detect_package_type as d
+pairs=[("npm",["exec","--loglevel","silly","a"],["exec","--loglevel","silly","b"]),
+       ("npm",["exec","--registry","https://r","a"],["exec","--registry","https://r","b"]),
+       ("npx",["-y","--registry","https://r","a"],["-y","--registry","https://r","b"])]
+bad=[(c,d(c,x)) for c,x,y in pairs if d(c,x)==d(c,y) and d(c,x)!=("unknown",None)]
+print("still colliding:", bad or "none"); assert not bad
+PY
+
+# The pinned ordering, intact:
+PYTHONDONTWRITEBYTECODE=1 uv run python - <<'PY'
+from pmcp.manifest.version_checker import detect_package_type as d
+for a,exp in [(["--silent","exec","pkg"],"pkg"),(["exec","pkg"],"pkg"),
+              (["install","i"],"i"),(["exec","exec"],"exec")]:
+    got=d("npm",a)[1]; assert got==exp, f"{a} -> {got}, expected {exp}"
+print("pinned ordering intact")
+PY
+
+python3 .consiliency/notes/derive_npm_flags.py --verify   # table vs live npm
+PYTHONDONTWRITEBYTECODE=1 uv run pytest tests/ -q
+uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/
+uv run mypy src/pmcp --exclude baml_client
+```
+
+**Mutation proof, per node, with an import-provenance guard.** #182 established
+that without a provenance check every mutant falsely survives while the
+unmutated worktree serves the imports — assert
+`version_checker.__file__` resolves inside the mutated copy before trusting any
+result. Purge `__pycache__` and use `PYTHONDONTWRITEBYTECODE=1`: stale bytecode
+fabricated a false RED in #184 and can equally fabricate a false GREEN.
+
+## Automation
+
+```yaml
+automation:
+  suite_command: "uv run pytest -q"
+```
+
+## Execution Policy
+- execute: effort=medium, reason=small scanner change but the table is large and a wrong entry fails open
+
+## Acceptance criteria
+
+- [ ] The three reproduced pairs satisfy `d(a) != d(b)` **or**
+      `d(a) == ("unknown", None)`, with each pair's exact value pinned — RED
+      today, mutation-proved per node with recorded output.
+- [ ] **`npm --silent exec pkg` → `pkg`** still holds. `--silent` is absent
+      from `npm config list --json` (it aliases `--loglevel=silent`), so this
+      is the single most likely regression and gets its own criterion.
+- [ ] `npm install i` → `i`, `npm exec exec` → `exec`, `npm exec pkg` → `pkg`
+      unchanged; `npx -y exec` → `exec` unchanged.
+- [ ] An unlisted bare flag yields `("unknown", None)`, never a wrong name.
+- [ ] **The table is generated, not recalled**, and the generator is committed.
+      It must print the keys it could not classify — the 41 `null`-default ones
+      and any alias-only flags — so the unlisted set is reviewed rather than
+      accidental. #182 removed ten memory-drafted entries; none may be
+      reintroduced here.
+- [ ] Every manifest server still resolves (98/98 at 2.5.0) — proven by a scan,
+      not assumed.
+- [ ] Full suite, ruff, mypy green; CHANGELOG records the fix **and** the
+      auto-update cost.
+- [ ] **#180's status is decided explicitly** — closed if the gate now holds
+      for ordinary npm commands, or its remaining gap named. It has been
+      narrowed twice; do not close it by assumption a third time.

--- a/.consiliency/plans/detailed-npm-flag-classification-20260826-1130.md
+++ b/.consiliency/plans/detailed-npm-flag-classification-20260826-1130.md
@@ -24,29 +24,66 @@ globals enumerated, and that enumeration is this plan's real content.
 Context is in session from #180/#182/#183; the branch was read directly
 (`_npm_package_arg`, `src/pmcp/manifest/version_checker.py`).
 
-**npm exposes its own config schema, so the enumeration can be mechanical.**
-`npm config list --json` returns **181 keys with typed default values**, from
-which arity follows: a `bool` default is a boolean flag, anything else takes a
-value. Measured: 70 boolean-typed, 111 value-typed. Spot-checked against known
-truth — `loglevel`→value, `registry`→value, `global`→bool, `prefix`→value,
-`workspace`→value: all correct.
+**npm exposes its real option schema — but NOT via `npm config list --json`.**
+*This section was rewritten after board review; the original source and arity
+model were both wrong. See **Rejected** below.*
 
-This matters because #182 found **ten entries drafted from memory** across the
-other four ecosystems that could not be verified against real `--help`; all ten
-were removed. npm has ~181 flags — far past what recall can cover — so a
-mechanically-derived table is not a nicety here, it is the only defensible
-method.
+The authoritative source is npm's installed config package:
 
-**Two limits of that source, found before planning rather than during:**
+```
+@npmcli/config/lib/definitions/index.js
+  -> definitions  (181 entries, each carrying a real `type`)
+  -> shorthands   (40 entries, each EXPANDING to its underlying flags)
+```
 
-1. **`--silent` is absent from the config dump entirely.** It is an alias for
-   `--loglevel=silent`, not a config key. Aliases must come from a second
-   source (`npm help npm`'s option list, or npm's documented alias table), or
-   `npm --silent exec pkg` — a currently-pinned form — regresses.
-2. **41 keys have `null` defaults**, where boolean-vs-value is not inferable
-   from the default alone. These must be classified from a second source or
-   left **unlisted**, which under a fail-closed default means "refuse". Leaving
-   them unlisted is safe; guessing is not.
+`type` is the actual arity declaration, not an inference from a default value.
+Measured on npm 11.19.0:
+
+```
+color      type = always|Boolean      <- union: boolean AND value-accepting
+global     type = Boolean
+loglevel   type = silent|error|warn|notice|http|info|verbose|silly
+package    type = String|Array
+```
+
+`shorthands` solves the alias problem outright rather than by hand-listing:
+
+```
+shorthands.silent = ["--loglevel","silent"]
+shorthands.q      = ["--loglevel","warn"]
+```
+
+So `--silent` is not a missing key needing a second source — it is a shorthand
+that *expands*, and expansion is the correct model for all 40.
+
+### Rejected: `npm config list --json` + arity-from-default-type
+
+*Board finding, verified — the original plan was built on this and it is
+unsound two ways.*
+
+1. **The arity model was wrong.** The plan defined boolean flags as consuming
+   nothing. npm's parser (`nopt`) consumes a following `true`/`false`, and a
+   union type like `always|Boolean` accepts a value. Verified: under the
+   original design both of these **still collide**, which is the exact defect
+   the phase exists to close:
+
+   ```
+   npm exec --global false a / b   -> both ('npm','false')
+   npm exec --color always a / b   -> both ('npm','always')
+   ```
+
+   `npm exec --color always --help` exits 0, so this is a legal form.
+
+2. **The source was not a schema.** `config list --json` emits the *active
+   merged configuration*, not the definition set: it omits private entries
+   (`_auth`, `password`), adds host-specific ones (`npm-version`, a user-scoped
+   registry), and changes with the environment — `NPM_CONFIG_COLOR=always`
+   flips `color` from boolean to string. Removing the user config took the
+   count 181 → 180. **The same generator would classify differently on
+   different hosts**, which is disqualifying for a committed table.
+
+The 41 `null`-default keys the original plan planned to leave unlisted are also
+a non-issue under the real source: `type` is declared regardless of default.
 
 **The pinned ordering that must survive** (`tests/test_version_checker.py`):
 
@@ -55,30 +92,45 @@ npm --silent exec pkg  -> pkg     npm install i    -> i
 npm exec pkg           -> pkg     npm exec exec    -> exec
 ```
 
-## Design: extend #182's three-way classification to npm
+## Design: expand shorthands, then classify by npm's declared `type`
 
-Same shape as the other four ecosystems, same fail-closed default:
+*Rewritten after board review — the two-way boolean/value split was falsified.*
 
-| kind | behaviour |
+**Step 1 — expand shorthands first.** `--silent` becomes `--loglevel silent`,
+`-q` becomes `--loglevel warn`. All 40 come from `shorthands`, so no alias is
+hand-listed and none is missed. This is also what keeps the pinned
+`npm --silent exec pkg` → `pkg` working, by construction rather than by a
+special case.
+
+**Step 2 — classify the expanded flag by its declared `type`**, which is a
+*set*, not a scalar:
+
+| declared type | behaviour |
 |---|---|
-| **known-value** | consumes the next token (`--loglevel`, `--registry`, `--prefix`, `--workspace`, …) |
-| **known-boolean** | skip; next token still a candidate (`--global`, `--silent`, `--save-dev`, …) |
-| **known-positive** | its value **is** the package (`--package`) — already implemented |
-| *unlisted bare flag* | **`("unknown", None)`** |
+| `Boolean` alone | skip; the next token is still a candidate |
+| any non-Boolean member (`String`, `Number`, `Url`, `Path`, an enum, an Array) | **consumes the next token** |
+| union with Boolean (`always\|Boolean`) | **consumes the next token** — this is the case that broke the original model |
+| `--package` | known-positive: its value **is** the package |
+| not in `definitions` at all | **`("unknown", None)`** |
 
-`--flag=value` stays self-delimiting and safe, as elsewhere.
+**A Boolean flag still consumes a literal `true`/`false`.** npm's parser
+accepts `--global false`, so a bare `true`/`false` following a Boolean flag is
+its value, not a positional. Verified: without this, `npm exec --global false a`
+and `... b` both resolve to `('npm','false')`.
 
-**Table provenance is the deliverable, not the table.** Generate it with a
-committed script that reads `npm config list --json`, plus an explicit,
-individually-justified alias list for the handful the dump omits. Anything
-neither derivable nor justified stays **unlisted** — costing auto-update for
-that form, never correctness.
+The rule for anything ambiguous is unchanged from #182: **fail closed**. An
+omission costs auto-update for one form; a wrong entry serves the wrong
+package's descriptions.
 
-**The honest residual, same as #182's:** a *wrong* entry still fails open.
-Classify a value-flag as boolean and its value becomes the package. Mechanical
-derivation is what makes wrong entries unlikely; it does not make them
-impossible, so each classification the script cannot derive must be pinned by
-its own test.
+**Table provenance is the deliverable, not the table.** A committed generator
+reads `@npmcli/config`'s `definitions` and `shorthands` and emits the sets.
+Nothing is hand-listed — #182 removed ten memory-drafted entries across four
+ecosystems for exactly this reason, and npm's 181 flags are far past recall.
+
+**The honest residual:** a wrong entry still fails open, and npm's schema is
+version-specific — a future npm could add a flag this table does not know,
+which then refuses (safe) or, if the type declaration changes meaning,
+misclassifies (unsafe). The verifier exists to make that drift detectable.
 
 ## Changes
 
@@ -96,17 +148,25 @@ its own test.
 ### `.consiliency/notes/derive_npm_flags.py` (create)
 
 - Generator + verifier, mirroring `verify_tables.py` from #182 — reads
-  `npm config list --json`, emits the two sets, and **re-verifies** a committed
-  table against live npm so drift is detectable later. Deliberately not a
-  pytest: npm's flags are version-specific and CI has no npm.
-- It must **print** the keys it could not classify (the 41 `null`-default ones
-  and any alias-only flags) rather than silently omitting them, so the
-  unlisted set is a reviewed decision rather than an accident.
+  `@npmcli/config`'s **`definitions` and `shorthands`**, not
+  `npm config list --json`, and re-verifies a committed table against live npm
+  so drift is detectable. Deliberately not a pytest: npm's schema is
+  version-specific and CI has no npm.
+- It must **print** every flag it classifies as consuming a value *because of a
+  union with Boolean* (`always|Boolean`), since that class is what falsified
+  the first design and is the least obvious to a reader.
+- It must **print** anything in `definitions` whose `type` it cannot interpret,
+  rather than silently omitting it — an unlisted flag refuses, which is safe,
+  but the set must be reviewed rather than accidental.
 
 ### `tests/test_version_checker.py` (modify)
 
 - `TestNpmValueFlagCollisions` — **add** — inequality assertions for the three
-  reproduced pairs. All RED today.
+  reproduced pairs, **plus the two the board found surviving the original
+  design**: `npm exec --global false a/b` (Boolean consuming a literal
+  `true`/`false`) and `npm exec --color always a/b` (a `Boolean` union that
+  accepts a value). All five RED today; the last two would have shipped
+  colliding.
 - `TestNpmFailsClosed` — **add** — an unlisted bare flag yields
   `("unknown", None)`.
 - `TestNpmPinnedOrderingSurvives` — **add** — the four forms above, plus
@@ -180,20 +240,31 @@ automation:
 
 ## Acceptance criteria
 
-- [ ] The three reproduced pairs satisfy `d(a) != d(b)` **or**
-      `d(a) == ("unknown", None)`, with each pair's exact value pinned — RED
-      today, mutation-proved per node with recorded output.
+- [ ] **Five** pairs satisfy `d(a) != d(b)` **or** `d(a) == ("unknown", None)`,
+      each pair's exact value pinned — the three originally reproduced, plus
+      `npm exec --global false a/b` and `npm exec --color always a/b`. *Board
+      finding: those last two survive the plan's original two-way model, so an
+      acceptance set without them can pass while the safety residual stays
+      open.* RED today, mutation-proved per node with recorded output.
 - [ ] **`npm --silent exec pkg` → `pkg`** still holds. `--silent` is absent
       from `npm config list --json` (it aliases `--loglevel=silent`), so this
       is the single most likely regression and gets its own criterion.
 - [ ] `npm install i` → `i`, `npm exec exec` → `exec`, `npm exec pkg` → `pkg`
       unchanged; `npx -y exec` → `exec` unchanged.
 - [ ] An unlisted bare flag yields `("unknown", None)`, never a wrong name.
-- [ ] **The table is generated, not recalled**, and the generator is committed.
-      It must print the keys it could not classify — the 41 `null`-default ones
-      and any alias-only flags — so the unlisted set is reviewed rather than
-      accidental. #182 removed ten memory-drafted entries; none may be
-      reintroduced here.
+- [ ] **The table is generated from `@npmcli/config`'s `definitions` and
+      `shorthands`**, not from `npm config list --json` and not from recall,
+      and the generator is committed. *Board finding: `config list --json` is
+      the active merged config, not a schema — it omits private keys, adds
+      host-specific ones, and `NPM_CONFIG_COLOR=always` flips `color` from
+      boolean to string, so the same generator classifies differently on
+      different hosts.* The generator must print every union-with-Boolean flag
+      and anything whose `type` it cannot interpret. #182 removed ten
+      memory-drafted entries; none may be reintroduced.
+- [ ] **All 40 shorthands expand**, verified against `shorthands` rather than
+      hand-listed — `--silent` → `--loglevel silent`, `-q` → `--loglevel warn`.
+      This is what makes `npm --silent exec pkg` → `pkg` hold by construction
+      instead of by special case.
 - [ ] Every manifest server still resolves (98/98 at 2.5.0) — proven by a scan,
       not assumed.
 - [ ] Full suite, ruff, mypy green; CHANGELOG records the fix **and** the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **npm no longer reads a flag's *value* as the package name.** npm was the last
+  of the five ecosystems still failing *open* on an unrecognised flag: the scan
+  skipped anything starting `-` and took the next bare token, so
+  `npm exec --loglevel silly server-a` and `… server-b` both resolved to
+  `silly`. Because 2.4.0's identity gate treats a matching name as a **positive
+  confirmation**, two unrelated servers collapsed into one identity and one was
+  served the other's cached tool descriptions. `--registry`, `--global false`
+  and `--color always` collided the same way.
+
+  npm's flag arity is now generated from npm's own config schema
+  (`@npmcli/config`'s `definitions` and `shorthands`, 181 flags and 40
+  shorthands) rather than transcribed by hand, and an unlisted flag makes the
+  scan report no identity instead of guessing. Shorthands are expanded from
+  npm's own map, so `npm --silent exec <pkg>` keeps resolving and the previous
+  hand-coded `-y` special case is retired. Two flags whose arity depends on the
+  *next token's content* — `--color` and `--browser` — are deliberately
+  unlisted and therefore refused.
+
+  **The cost, deliberately:** a server launched with a flag npm's own schema
+  does not describe can no longer be auto-updated. `gateway.update_server`
+  refuses it by name and command line rather than probing. An omission costs
+  auto-update for one unusual config — visible, and fixable by adding the flag
+  — where the previous "take the next token" default produced a silent
+  collision instead. No bundled manifest server is affected: all 98 launchable
+  entries resolve exactly as before.
+
 ## [2.5.0] - 2026-08-26
 
 ### Fixed

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -1135,6 +1135,19 @@ def _npm_package_arg(args: list[str], command: str) -> str | None:
         # carrying a leading flag. The ordering is already correct; the test
         # below exists because nothing PINNED it (ah board review, adversarial
         # seat: a surviving mutant, not a live defect).
+        if arg == "--":
+            # `--` does NOT end the search here, unlike in
+            # `_scan_for_package_token`. npm exec's FIRST documented usage is
+            # `npm exec -- <pkg>[@<version>] [args...]`, so the token after
+            # `--` is the package spec itself. Refusing it -- which the
+            # fail-closed default below would otherwise do -- regressed a form
+            # that resolved correctly before #180.
+            #
+            # The other documented shape, `npm exec --package=<pkg> -- <cmd>`,
+            # never reaches this line: `packages` is non-empty by then and the
+            # branch above has already taken over, which is what keeps `<cmd>`
+            # from being read as a package.
+            continue
         if arg.startswith("-") and arg != "-":
             if arg in _NPM_VALUE_FLAGS:
                 index += 1  # its value is the next token, never the package

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -404,10 +404,21 @@ _NPM_POSITIVE_FLAGS = frozenset({"--package"})
 #                           `always` as the package.
 #
 # Shorthands are expanded rather than hand-aliased, with arity from the
-# expansion's LENGTH: >= 2 bakes a value in (`silent` -> `--loglevel silent`,
-# boolean-arity), == 1 is a rename inheriting the target's arity (`reg` ->
-# `--registry`, `y` -> `--yes`). This is why `npm --silent exec pkg` resolves
-# and why no `-y` special case is needed any more.
+# expansion's LENGTH: >= 2 bakes a value in (`silent` -> `--loglevel silent`),
+# == 1 is a rename inheriting the target's arity (`reg` -> `--registry`,
+# `y` -> `--yes`). This is why `npm --silent exec pkg` resolves and why no
+# `-y` special case is needed any more.
+#
+# A baked-value shorthand goes in `_NPM_SKIP_FLAGS`, NOT the boolean table.
+# The two differ on exactly one input, and it is the fail-OPEN direction:
+#
+#     --silent true TAIL  -> npm leaves ["true","TAIL"]   does NOT consume
+#     --global true TAIL  -> npm leaves ["TAIL"]          consumes
+#
+# A real boolean is still awaiting a value when npm parses argv; a baked-value
+# shorthand is not. Collapsing them made `npx --silent true <arg>` report
+# `<arg>` when npm's package is `true`, and collapsed `--silent true X` with
+# `--silent false X` onto the single identity `X`.
 #
 # The generator cross-checks all 181 declared classifications against npm's
 # real parser (`nopt`) and reports 0 mismatches on 11.19.0. Re-run
@@ -559,10 +570,7 @@ _NPM_BOOLEAN_FLAGS = frozenset(
         "--bin-links",
         "--bypass-2fa",
         "--commit-hooks",
-        "--d",
         "--dangerously-allow-all-scripts",
-        "--dd",
-        "--ddd",
         "--desc",
         "--description",
         "--dev",
@@ -690,12 +698,9 @@ _NPM_BOOLEAN_FLAGS = frozenset(
         "--production",
         "--progress",
         "--provenance",
-        "--q",
-        "--quiet",
         "--read-only",
         "--readonly",
         "--rebuild-bundle",
-        "--s",
         "--save",
         "--save-bundle",
         "--save-dev",
@@ -706,7 +711,6 @@ _NPM_BOOLEAN_FLAGS = frozenset(
         "--shrinkwrap",
         "--sign-git-commit",
         "--sign-git-tag",
-        "--silent",
         "--strict-allow-scripts",
         "--strict-peer-deps",
         "--strict-ssl",
@@ -715,7 +719,6 @@ _NPM_BOOLEAN_FLAGS = frozenset(
         "--update-notifier",
         "--usage",
         "--v",
-        "--verbose",
         "--version",
         "--versions",
         "--workspaces",
@@ -732,9 +735,6 @@ _NPM_BOOLEAN_FLAGS = frozenset(
         "-P",
         "-S",
         "-a",
-        "-d",
-        "-dd",
-        "-ddd",
         "-desc",
         "-f",
         "-g",
@@ -747,15 +747,32 @@ _NPM_BOOLEAN_FLAGS = frozenset(
         "-no",
         "-p",
         "-porcelain",
-        "-q",
-        "-quiet",
         "-readonly",
-        "-s",
-        "-silent",
         "-v",
-        "-verbose",
         "-ws",
         "-y",
+    }
+)
+
+
+_NPM_SKIP_FLAGS = frozenset(
+    {
+        "--d",
+        "--dd",
+        "--ddd",
+        "--q",
+        "--quiet",
+        "--s",
+        "--silent",
+        "--verbose",
+        "-d",
+        "-dd",
+        "-ddd",
+        "-q",
+        "-quiet",
+        "-s",
+        "-silent",
+        "-verbose",
     }
 )
 
@@ -1151,6 +1168,12 @@ def _npm_package_arg(args: list[str], command: str) -> str | None:
         if arg.startswith("-") and arg != "-":
             if arg in _NPM_VALUE_FLAGS:
                 index += 1  # its value is the next token, never the package
+                continue
+            if arg in _NPM_SKIP_FLAGS:
+                # A shorthand with its value already baked in: nothing is
+                # awaiting a value, so it never consumes -- not even a literal
+                # `true`/`false`, which is the ONE input separating this from
+                # the boolean table below.
                 continue
             if arg in _NPM_BOOLEAN_FLAGS:
                 following = args[index + 1] if index + 1 < len(args) else None

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -755,6 +755,12 @@ _NPM_BOOLEAN_FLAGS = frozenset(
 )
 
 
+# Literals npm's parser accepts as a boolean flag's VALUE. `null` matters: a
+# nullable boolean (`--yes`, `--optional`, `--production`, `--workspaces`,
+# `--expect-results`) consumes it, so omitting it made `--yes null A` and
+# `--yes null B` both resolve to the package `null` (ah board review).
+_NPM_BOOLEAN_LITERALS = frozenset({"true", "false", "null"})
+
 _NPM_SKIP_FLAGS = frozenset(
     {
         "--d",
@@ -1169,6 +1175,19 @@ def _npm_package_arg(args: list[str], command: str) -> str | None:
             if arg in _NPM_VALUE_FLAGS:
                 index += 1  # its value is the next token, never the package
                 continue
+            attached_name = arg.split("=", 1)[0] if "=" in arg else None
+            if attached_name in _NPM_SKIP_FLAGS:
+                # `--silent=true X` is NOT `--silent X`. npm expands the
+                # shorthand and its ATTACHED value becomes a positional, so
+                # nopt leaves `["true", "X"]` -- the package is `true`, not
+                # `X`. Verified against npm's own parser. Reading it as `X`
+                # made `--silent=true X` and `--silent=false X` both resolve to
+                # `X`, colliding two genuinely different packages (ah board
+                # review, red-team seat).
+                _, _, baked = arg.partition("=")
+                if baked:
+                    return baked
+                continue
             if arg in _NPM_SKIP_FLAGS:
                 # A shorthand with its value already baked in: nothing is
                 # awaiting a value, so it never consumes -- not even a literal
@@ -1177,9 +1196,14 @@ def _npm_package_arg(args: list[str], command: str) -> str | None:
                 continue
             if arg in _NPM_BOOLEAN_FLAGS:
                 following = args[index + 1] if index + 1 < len(args) else None
-                # npm's parser takes a literal `true`/`false` after a boolean
-                # flag as that flag's value; anything else is a positional.
-                if following in ("true", "false"):
+                # npm's parser takes a literal `true`/`false` -- and, for a
+                # NULLABLE boolean, a literal `null` -- after a boolean flag as
+                # that flag's value; anything else is a positional. Verified
+                # against nopt: `npm exec --yes null A` leaves `A`, so omitting
+                # `null` made `--yes null A` and `--yes null B` both resolve to
+                # the package `null`, a false identity the gate then CONFIRMS
+                # (ah board review, red-team seat).
+                if following in _NPM_BOOLEAN_LITERALS:
                     index += 1
                 continue
             # Unclassified. `--flag=value` is self-delimiting so it cannot

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -377,6 +377,388 @@ _CARGO_SUBCOMMANDS = frozenset({"run", "install", "build", "test", "check"})
 # entry, which is the failure direction that stays open.
 _NPM_POSITIVE_FLAGS = frozenset({"--package"})
 
+# npm flag arity, GENERATED -- see `.consiliency/notes/derive_npm_flags.py`.
+#
+# Source: `@npmcli/config/lib/definitions/index.js` (npm 11.19.0), which
+# declares each flag's `type`, plus its `shorthands` map. Deliberately NOT
+# `npm config list --json`: that emits the active MERGED configuration, so it
+# omits private keys, adds host-specific ones, drops all 40 shorthands, and
+# under `NPM_CONFIG_COLOR=always` reports `color` as a string rather than a
+# boolean -- the same generator would classify differently on different hosts.
+#
+# Classification, after dropping `null` ("unset") and `Array` ("may repeat")
+# from each type list:
+#
+#   Boolean alone        -> boolean-arity. Consumes nothing EXCEPT a literal
+#                           `true`/`false`, which npm's parser does take as
+#                           the flag's value (`npm exec --global false` is a
+#                           legal form). The scanner implements that below.
+#   no Boolean member    -> consumes the next token. `--proxy` lives here:
+#                           `null|false|{url}` has no Boolean member and it
+#                           always consumes, including `--proxy <pkg>`.
+#   Boolean AND non-Bool -> CONDITIONAL arity, so no single class is right.
+#                           Left out of BOTH tables, which makes the scanner
+#                           refuse. On npm 11.19.0 that set is exactly
+#                           `{color, browser}`; `--color always <pkg>` is why
+#                           it exists, since a boolean/value split reads
+#                           `always` as the package.
+#
+# Shorthands are expanded rather than hand-aliased, with arity from the
+# expansion's LENGTH: >= 2 bakes a value in (`silent` -> `--loglevel silent`,
+# boolean-arity), == 1 is a rename inheriting the target's arity (`reg` ->
+# `--registry`, `y` -> `--yes`). This is why `npm --silent exec pkg` resolves
+# and why no `-y` special case is needed any more.
+#
+# The generator cross-checks all 181 declared classifications against npm's
+# real parser (`nopt`) and reports 0 mismatches on 11.19.0. Re-run
+# `derive_npm_flags.py --verify` against a newer npm to detect drift: a flag
+# npm adds later is absent here and therefore REFUSED, which costs
+# auto-update but never mints a wrong identity.
+#
+# `--package` is in neither table -- it is a KNOWN-POSITIVE handled above.
+_NPM_VALUE_FLAGS = frozenset(
+    {
+        "--C",
+        "--L",
+        "--_auth",
+        "--access",
+        "--allow-directory",
+        "--allow-file",
+        "--allow-git",
+        "--allow-remote",
+        "--allow-scripts",
+        "--also",
+        "--audit-level",
+        "--auth-type",
+        "--before",
+        "--c",
+        "--ca",
+        "--cache",
+        "--cache-max",
+        "--cache-min",
+        "--cafile",
+        "--call",
+        "--cert",
+        "--cidr",
+        "--cpu",
+        "--depth",
+        "--diff",
+        "--diff-dst-prefix",
+        "--diff-src-prefix",
+        "--diff-unified",
+        "--editor",
+        "--enjoy-by",
+        "--expect-result-count",
+        "--expires",
+        "--fetch-retries",
+        "--fetch-retry-factor",
+        "--fetch-retry-maxtimeout",
+        "--fetch-retry-mintimeout",
+        "--fetch-timeout",
+        "--git",
+        "--globalconfig",
+        "--heading",
+        "--https-proxy",
+        "--include",
+        "--init-author-email",
+        "--init-author-name",
+        "--init-author-url",
+        "--init-license",
+        "--init-module",
+        "--init-type",
+        "--init-version",
+        "--init.author.email",
+        "--init.author.name",
+        "--init.author.url",
+        "--init.license",
+        "--init.module",
+        "--init.version",
+        "--install-strategy",
+        "--key",
+        "--libc",
+        "--local-address",
+        "--location",
+        "--lockfile-version",
+        "--loglevel",
+        "--logs-dir",
+        "--logs-max",
+        "--m",
+        "--maxsockets",
+        "--message",
+        "--min-release-age",
+        "--min-release-age-exclude",
+        "--name",
+        "--node-gyp",
+        "--node-options",
+        "--noproxy",
+        "--omit",
+        "--only",
+        "--orgs",
+        "--orgs-permission",
+        "--os",
+        "--otp",
+        "--pack-destination",
+        "--packages",
+        "--packages-and-scopes-permission",
+        "--password",
+        "--prefix",
+        "--preid",
+        "--provenance-file",
+        "--proxy",
+        "--reg",
+        "--registry",
+        "--replace-registry-host",
+        "--save-prefix",
+        "--sbom-format",
+        "--sbom-type",
+        "--scope",
+        "--scopes",
+        "--script-shell",
+        "--searchexclude",
+        "--searchlimit",
+        "--searchopts",
+        "--searchstaleness",
+        "--shell",
+        "--tag",
+        "--tag-version-prefix",
+        "--token-description",
+        "--umask",
+        "--user-agent",
+        "--userconfig",
+        "--viewer",
+        "--w",
+        "--which",
+        "--workspace",
+        "-C",
+        "-L",
+        "-c",
+        "-enjoy-by",
+        "-m",
+        "-reg",
+        "-w",
+    }
+)
+
+
+_NPM_BOOLEAN_FLAGS = frozenset(
+    {
+        "--?",
+        "--B",
+        "--D",
+        "--E",
+        "--H",
+        "--O",
+        "--P",
+        "--S",
+        "--a",
+        "--all",
+        "--allow-same-version",
+        "--allow-scripts-pending",
+        "--allow-scripts-pin",
+        "--audit",
+        "--bin-links",
+        "--bypass-2fa",
+        "--commit-hooks",
+        "--d",
+        "--dangerously-allow-all-scripts",
+        "--dd",
+        "--ddd",
+        "--desc",
+        "--description",
+        "--dev",
+        "--diff-ignore-all-space",
+        "--diff-name-only",
+        "--diff-no-prefix",
+        "--diff-text",
+        "--dry-run",
+        "--engine-strict",
+        "--expect-results",
+        "--f",
+        "--force",
+        "--foreground-scripts",
+        "--format-package-lock",
+        "--fund",
+        "--g",
+        "--git-tag-version",
+        "--global",
+        "--global-style",
+        "--h",
+        "--help",
+        "--if-present",
+        "--ignore-scripts",
+        "--include-attestations",
+        "--include-staged",
+        "--include-workspace-root",
+        "--init-private",
+        "--install-links",
+        "--iwr",
+        "--json",
+        "--l",
+        "--legacy-bundling",
+        "--legacy-peer-deps",
+        "--link",
+        "--local",
+        "--long",
+        "--n",
+        "--no",
+        "--no-all",
+        "--no-allow-same-version",
+        "--no-allow-scripts-pending",
+        "--no-allow-scripts-pin",
+        "--no-audit",
+        "--no-bin-links",
+        "--no-bypass-2fa",
+        "--no-commit-hooks",
+        "--no-dangerously-allow-all-scripts",
+        "--no-description",
+        "--no-dev",
+        "--no-diff-ignore-all-space",
+        "--no-diff-name-only",
+        "--no-diff-no-prefix",
+        "--no-diff-text",
+        "--no-dry-run",
+        "--no-engine-strict",
+        "--no-expect-results",
+        "--no-force",
+        "--no-foreground-scripts",
+        "--no-format-package-lock",
+        "--no-fund",
+        "--no-git-tag-version",
+        "--no-global",
+        "--no-global-style",
+        "--no-if-present",
+        "--no-ignore-scripts",
+        "--no-include-attestations",
+        "--no-include-staged",
+        "--no-include-workspace-root",
+        "--no-init-private",
+        "--no-install-links",
+        "--no-json",
+        "--no-legacy-bundling",
+        "--no-legacy-peer-deps",
+        "--no-link",
+        "--no-long",
+        "--no-offline",
+        "--no-omit-lockfile-registry-resolved",
+        "--no-optional",
+        "--no-package-lock",
+        "--no-package-lock-only",
+        "--no-packages-all",
+        "--no-parseable",
+        "--no-prefer-dedupe",
+        "--no-prefer-offline",
+        "--no-prefer-online",
+        "--no-production",
+        "--no-progress",
+        "--no-provenance",
+        "--no-read-only",
+        "--no-rebuild-bundle",
+        "--no-save",
+        "--no-save-bundle",
+        "--no-save-dev",
+        "--no-save-exact",
+        "--no-save-optional",
+        "--no-save-peer",
+        "--no-save-prod",
+        "--no-shrinkwrap",
+        "--no-sign-git-commit",
+        "--no-sign-git-tag",
+        "--no-strict-allow-scripts",
+        "--no-strict-peer-deps",
+        "--no-strict-ssl",
+        "--no-timing",
+        "--no-unicode",
+        "--no-update-notifier",
+        "--no-usage",
+        "--no-version",
+        "--no-versions",
+        "--no-workspaces",
+        "--no-workspaces-update",
+        "--no-yes",
+        "--offline",
+        "--omit-lockfile-registry-resolved",
+        "--optional",
+        "--p",
+        "--package-lock",
+        "--package-lock-only",
+        "--packages-all",
+        "--parseable",
+        "--porcelain",
+        "--prefer-dedupe",
+        "--prefer-offline",
+        "--prefer-online",
+        "--production",
+        "--progress",
+        "--provenance",
+        "--q",
+        "--quiet",
+        "--read-only",
+        "--readonly",
+        "--rebuild-bundle",
+        "--s",
+        "--save",
+        "--save-bundle",
+        "--save-dev",
+        "--save-exact",
+        "--save-optional",
+        "--save-peer",
+        "--save-prod",
+        "--shrinkwrap",
+        "--sign-git-commit",
+        "--sign-git-tag",
+        "--silent",
+        "--strict-allow-scripts",
+        "--strict-peer-deps",
+        "--strict-ssl",
+        "--timing",
+        "--unicode",
+        "--update-notifier",
+        "--usage",
+        "--v",
+        "--verbose",
+        "--version",
+        "--versions",
+        "--workspaces",
+        "--workspaces-update",
+        "--ws",
+        "--y",
+        "--yes",
+        "-?",
+        "-B",
+        "-D",
+        "-E",
+        "-H",
+        "-O",
+        "-P",
+        "-S",
+        "-a",
+        "-d",
+        "-dd",
+        "-ddd",
+        "-desc",
+        "-f",
+        "-g",
+        "-h",
+        "-help",
+        "-iwr",
+        "-l",
+        "-local",
+        "-n",
+        "-no",
+        "-p",
+        "-porcelain",
+        "-q",
+        "-quiet",
+        "-readonly",
+        "-s",
+        "-silent",
+        "-v",
+        "-verbose",
+        "-ws",
+        "-y",
+    }
+)
+
 # docker, verified against `docker run --help`.
 _DOCKER_BOOLEAN_FLAGS = frozenset(
     {
@@ -696,20 +1078,42 @@ def _npm_package_arg(args: list[str], command: str) -> str | None:
     so keep scanning" does not fix it -- the scan still reaches ``<bin>``; the
     value has to be read back out of the flag.
 
-    Known limitation, deliberately left open: unlike the other four
-    ecosystems this scan does **not** fail closed on an unrecognised flag, so
-    ``npm exec --loglevel silly <pkg>`` still reads ``silly`` as the package.
-    Inverting the default here would break the pinned ordering below, where a
-    leading global flag such as ``npm --silent exec <pkg>`` must be skipped
-    rather than refused. Tracked on Consiliency/pmcp#180, which stays OPEN
-    for this residual -- NOT on #182, which the change carrying this note
-    closes on merge and would leave this pointer dangling.
+    Unrecognised flags **fail closed** (Consiliency/pmcp#180). npm was the
+    last of the five ecosystems still failing open here: the scan skipped
+    anything starting ``-`` and took the next bare token, so a flag's VALUE
+    became the package name and ``npm exec --loglevel silly a`` and
+    ``... silly b`` both resolved to ``silly``. v2.4.0's gate reads a matching
+    identity as a POSITIVE confirmation, so that served one server the other's
+    tool descriptions.
+
+    Inverting the default was previously believed to break the pinned ordering
+    below -- a leading global flag such as ``npm --silent exec <pkg>`` must be
+    skipped, not refused. It does not, because ``--silent`` is not unknown:
+    it is one of npm's 40 **shorthands**, and ``_NPM_BOOLEAN_FLAGS`` is
+    generated with every shorthand expanded. The ordering holds by
+    construction rather than by the fail-open default, which is what made the
+    default removable. The hand-coded ``-y`` special case this scan used to
+    carry is likewise retired into the generated table (``y`` -> ``--yes``).
+
+    Two arity rules here are npm-specific and neither is guessable from the
+    flag token:
+
+    * A **boolean** flag still consumes a literal ``true``/``false`` --
+      ``npm exec --global false --help`` exits 0, so ``false`` is the flag's
+      value there, not a positional. Without this, ``npm exec --global false
+      a`` and ``... b`` both resolve to ``false``.
+    * A **conditionally-arity** flag (``color``, ``browser``: declared with
+      Boolean *and* a non-Boolean member) is in neither table, so it lands on
+      the refusal below. ``npm exec --color always <pkg>`` is the case that
+      matters: ``always`` is a legal value, so a boolean/value split reads it
+      as the package.
     """
     skip_subcommand = command == "npm"
     packages: list[str] = []
-    for index, arg in enumerate(args):
-        if arg == "-y":
-            continue
+    index = -1
+    while index + 1 < len(args):
+        index += 1
+        arg = args[index]
         name, separator, attached = arg.partition("=")
         if separator and name in _NPM_POSITIVE_FLAGS:
             if attached:
@@ -724,14 +1128,29 @@ def _npm_package_arg(args: list[str], command: str) -> str | None:
             # A `--package` value outranks any later positional, which is the
             # command npm runs FROM that package, not a package itself.
             continue
-        # Skip flags. This MUST precede the subcommand check: npm accepts
+        # Classify flags. This MUST precede the subcommand check: npm accepts
         # global flags before the subcommand (`npm --silent exec pkg`), so
         # spending the one-shot skip on a flag token would leave `exec` to be
         # read as the package and reopen the #180 collapse for every form
         # carrying a leading flag. The ordering is already correct; the test
         # below exists because nothing PINNED it (ah board review, adversarial
         # seat: a surviving mutant, not a live defect).
-        if arg.startswith("-"):
+        if arg.startswith("-") and arg != "-":
+            if arg in _NPM_VALUE_FLAGS:
+                index += 1  # its value is the next token, never the package
+                continue
+            if arg in _NPM_BOOLEAN_FLAGS:
+                following = args[index + 1] if index + 1 < len(args) else None
+                # npm's parser takes a literal `true`/`false` after a boolean
+                # flag as that flag's value; anything else is a positional.
+                if following in ("true", "false"):
+                    index += 1
+                continue
+            # Unclassified. `--flag=value` is self-delimiting so it cannot
+            # swallow anything and is safe to skip; a bare unknown flag might
+            # be hiding the package in its value slot, so refuse.
+            if _takes_a_value_ambiguously(arg):
+                return None
             continue
         if skip_subcommand:
             # Only the first non-flag token can be the subcommand; whatever

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -1106,8 +1106,8 @@ def _npm_package_arg(args: list[str], command: str) -> str | None:
     Inverting the default was previously believed to break the pinned ordering
     below -- a leading global flag such as ``npm --silent exec <pkg>`` must be
     skipped, not refused. It does not, because ``--silent`` is not unknown:
-    it is one of npm's 40 **shorthands**, and ``_NPM_BOOLEAN_FLAGS`` is
-    generated with every shorthand expanded. The ordering holds by
+    it is one of npm's 40 **shorthands**, and the generated tables expand all
+    40 of them (``--silent`` lands in ``_NPM_SKIP_FLAGS``). The ordering holds by
     construction rather than by the fail-open default, which is what made the
     default removable. The hand-coded ``-y`` special case this scan used to
     carry is likewise retired into the generated table (``y`` -> ``--yes``).

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -2075,3 +2075,155 @@ class TestOrdinalReversal:
             ("202612180000", None),
         ]:
             assert compare_versions(value, value, pkg_type) == "not_newer"
+
+
+class TestNpmValueFlagCollisions:
+    """Two different npm servers must never collapse into one identity.
+
+    npm was the last ecosystem still failing OPEN on an unrecognised flag
+    (Consiliency/pmcp#180): the scan skipped anything starting `-` and took
+    the next bare token, so a flag's VALUE became the package name. v2.4.0's
+    gate reads a matching identity as a POSITIVE confirmation, so this served
+    one server the other's tool descriptions.
+
+    The last two pairs are the ones a naive boolean/value split misses, and
+    they are the point of this class. A board seat implemented an earlier
+    design faithfully, and its suite passed -- all three registry/loglevel
+    pairs green, pinned orderings green, fails-closed green -- while
+    `npm exec --color always a/b` still returned `('npm','always')` for both.
+    An acceptance set that cannot see the defect its own method manufactures
+    is not an acceptance set.
+    """
+
+    @pytest.mark.parametrize(
+        ("command", "args_a", "args_b", "expected"),
+        [
+            # A value flag whose value is an enum member.
+            (
+                "npm",
+                ["exec", "--loglevel", "silly", "a"],
+                ["exec", "--loglevel", "silly", "b"],
+                [("npm", "a"), ("npm", "b")],
+            ),
+            # A value flag whose value is a URL.
+            (
+                "npm",
+                ["exec", "--registry", "https://r", "a"],
+                ["exec", "--registry", "https://r", "b"],
+                [("npm", "a"), ("npm", "b")],
+            ),
+            # Same, reached through npx, where there is no subcommand to skip.
+            (
+                "npx",
+                ["-y", "--registry", "https://r", "a"],
+                ["-y", "--registry", "https://r", "b"],
+                [("npm", "a"), ("npm", "b")],
+            ),
+            # A BOOLEAN flag followed by a literal `true`/`false`. npm's
+            # parser takes that as the flag's value -- `npm exec --global
+            # false --help` exits 0 -- so a design where "boolean consumes
+            # nothing" leaves this colliding on `false`.
+            (
+                "npm",
+                ["exec", "--global", "false", "a"],
+                ["exec", "--global", "false", "b"],
+                [("npm", "a"), ("npm", "b")],
+            ),
+            # A Boolean UNION (`color` is `always|Boolean`): arity depends on
+            # the next token's content, so no single class is right and the
+            # flag is left unlisted. Refusing is the fail-CLOSED direction;
+            # what matters is that the two no longer share an identity.
+            (
+                "npm",
+                ["exec", "--color", "always", "a"],
+                ["exec", "--color", "always", "b"],
+                [("unknown", None), ("unknown", None)],
+            ),
+        ],
+    )
+    def test_pair_does_not_collide(
+        self,
+        command: str,
+        args_a: list[str],
+        args_b: list[str],
+        expected: list[tuple[str, str | None]],
+    ) -> None:
+        got_a = detect_package_type(command, args_a)
+        got_b = detect_package_type(command, args_b)
+        # Pin the EXACT values, not just inequality: a pair can stop colliding
+        # by both becoming wrong in different ways.
+        assert [got_a, got_b] == expected
+        assert got_a != got_b or got_a == ("unknown", None)
+
+
+class TestNpmFailsClosed:
+    """An unlisted npm flag yields no identity rather than a wrong one."""
+
+    def test_unlisted_bare_flag_refuses(self) -> None:
+        assert detect_package_type("npm", ["exec", "--not-a-real-npm-flag", "a"]) == (
+            "unknown",
+            None,
+        )
+
+    def test_unlisted_flag_cannot_collide(self) -> None:
+        args = ["exec", "--not-a-real-npm-flag", "{}"]
+        assert detect_package_type("npm", [*args, "a"]) == ("unknown", None)
+        assert detect_package_type("npm", [*args, "b"]) == ("unknown", None)
+
+    def test_self_delimiting_unlisted_flag_still_resolves(self) -> None:
+        """`--flag=value` cannot swallow the next token, so refusing costs
+        safety nothing and auto-update something."""
+        assert detect_package_type("npm", ["exec", "--zzz=1", "a"]) == ("npm", "a")
+
+    def test_conditional_arity_flag_refuses(self) -> None:
+        """`--color` is `always|Boolean`; unlisted by construction."""
+        assert detect_package_type("npm", ["exec", "--color", "a"]) == (
+            "unknown",
+            None,
+        )
+
+
+class TestNpmPinnedOrderingSurvives:
+    """The forms the fix must not regress.
+
+    `npm --silent exec pkg` gets called out because `--silent` is a SHORTHAND
+    (`--loglevel silent`), absent from `npm config list --json` entirely. Any
+    table built from the config dump rather than from `shorthands` breaks
+    exactly here, which makes it the single most likely regression.
+    """
+
+    @pytest.mark.parametrize(
+        ("command", "args", "expected"),
+        [
+            ("npm", ["--silent", "exec", "pkg"], "pkg"),
+            ("npm", ["exec", "pkg"], "pkg"),
+            ("npm", ["install", "i"], "i"),
+            ("npm", ["exec", "exec"], "exec"),
+            ("npx", ["-y", "exec"], "exec"),
+            ("npx", ["-y", "pkg"], "pkg"),
+        ],
+    )
+    def test_form_still_resolves(
+        self, command: str, args: list[str], expected: str
+    ) -> None:
+        assert detect_package_type(command, args) == ("npm", expected)
+
+    @pytest.mark.parametrize(
+        ("command", "args", "expected"),
+        [
+            # Every shorthand class, resolved through `shorthands` rather than
+            # hand-listed: expansion length >= 2 bakes in a value (boolean
+            # arity), length 1 is a rename that inherits the target's arity.
+            ("npm", ["-q", "exec", "pkg"], "pkg"),  # -> --loglevel warn
+            ("npm", ["-s", "exec", "pkg"], "pkg"),  # -> --loglevel silent
+            ("npm", ["-g", "exec", "pkg"], "pkg"),  # -> --global   (boolean)
+            ("npm", ["--local", "exec", "pkg"], "pkg"),  # -> --no-global
+            ("npm", ["--reg", "https://r", "exec", "pkg"], "pkg"),  # -> --registry
+            ("npm", ["exec", "-w", "ws", "pkg"], "pkg"),  # -> --workspace (value)
+            ("npx", ["-y", "--package", "pkg", "--", "bin"], "pkg"),
+        ],
+    )
+    def test_shorthand_expands(
+        self, command: str, args: list[str], expected: str
+    ) -> None:
+        assert detect_package_type(command, args) == ("npm", expected)

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -711,6 +711,61 @@ class TestDockerReferenceSplitting:
         assert _docker_image_tag(ref) == tag
 
 
+class TestNpmBoardRoundTwo:
+    """Two collisions the first implementation left open, found by the board.
+
+    Both verified against npm's own parser (`nopt` + npm's type map), not
+    against the type strings, and both were live: `_same_package` confirms the
+    false identity in each case.
+    """
+
+    def test_nullable_boolean_consumes_a_literal_null(self) -> None:
+        """`--yes null A` -- npm consumes `null` as the flag's value.
+
+        The generator drops `null` from a type list (correctly -- it means
+        "unset"), but the SCANNER must still consume a literal `null` token
+        after a nullable boolean, exactly as it does `true`/`false`. Without
+        it both forms resolved to the package `null`. Affects `--yes`,
+        `--optional`, `--production`, `--workspaces`, `--expect-results`.
+        """
+        a = detect_package_type("npm", ["exec", "--yes", "null", "A"])
+        b = detect_package_type("npm", ["exec", "--yes", "null", "B"])
+        assert a != b, f"nullable boolean swallowed the package: {a}"
+        assert a == ("npm", "A")
+        assert b == ("npm", "B")
+
+    def test_attached_baked_value_shorthand_yields_its_baked_value(self) -> None:
+        """`--silent=true X` is NOT `--silent X`.
+
+        npm expands the shorthand and the ATTACHED value becomes a positional:
+        nopt leaves `["true", "X"]`, so the package is `true`, not `X`.
+        Reading it as `X` collapsed `--silent=true X` and `--silent=false X`
+        into one identity despite naming different packages.
+        """
+        t = detect_package_type("npm", ["exec", "--silent=true", "X"])
+        f = detect_package_type("npm", ["exec", "--silent=false", "X"])
+        assert t != f, f"attached baked value collapsed two packages: {t}"
+        assert t == ("npm", "true")
+        assert f == ("npm", "false")
+
+    def test_spaced_baked_value_shorthand_still_consumes_nothing(self) -> None:
+        """The spaced form is unchanged -- this is the distinction, not a fix.
+
+        `--silent` bakes its value in, so it consumes nothing and the next
+        token IS the package; `--global` is a real boolean that swallows a
+        literal `true`.
+        """
+        assert detect_package_type("npm", ["--silent", "exec", "pkg"]) == ("npm", "pkg")
+        assert detect_package_type("npx", ["--silent", "true", "arg"]) == (
+            "npm",
+            "true",
+        )
+        assert detect_package_type("npm", ["exec", "--global", "true", "a"]) == (
+            "npm",
+            "a",
+        )
+
+
 class TestNpmSubcommandSkipFiresOnce:
     """The npm subcommand skip must not eat real package names.
 

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -2227,3 +2227,25 @@ class TestNpmPinnedOrderingSurvives:
         self, command: str, args: list[str], expected: str
     ) -> None:
         assert detect_package_type(command, args) == ("npm", expected)
+
+    @pytest.mark.parametrize(
+        ("command", "args", "expected"),
+        [
+            # npm exec's FIRST documented usage: `npm exec -- <pkg> [args...]`.
+            # The token after `--` IS the package spec, so `--` must not end
+            # the scan the way it does for uvx/pip/cargo/docker. Fail-closed
+            # refusal here would be a REGRESSION -- this resolved before #180.
+            ("npm", ["exec", "--", "pkg"], "pkg"),
+            ("npm", ["exec", "--", "pkg", "arg"], "pkg"),
+            ("npx", ["--", "pkg"], "pkg"),
+            ("npm", ["exec", "--loglevel", "silly", "--", "pkg"], "pkg"),
+            # The other documented shape: with `--package` given, the token
+            # after `--` is the COMMAND, not a package, and must not win.
+            ("npm", ["exec", "--package=pkg", "--", "bin"], "pkg"),
+            ("npm", ["exec", "--package", "pkg", "--", "bin"], "pkg"),
+        ],
+    )
+    def test_double_dash_form_still_resolves(
+        self, command: str, args: list[str], expected: str
+    ) -> None:
+        assert detect_package_type(command, args) == ("npm", expected)

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -2249,3 +2249,47 @@ class TestNpmPinnedOrderingSurvives:
         self, command: str, args: list[str], expected: str
     ) -> None:
         assert detect_package_type(command, args) == ("npm", expected)
+
+
+class TestNpmBakedValueShorthandDoesNotConsume:
+    """A baked-value shorthand is NOT a boolean, and the difference is a bug.
+
+    `--silent` expands to `--loglevel silent` before npm parses argv, so by
+    then nothing is awaiting a value and it consumes nothing. A real boolean
+    like `--global` IS awaiting one and takes a literal `true`/`false`.
+    Measured against npm's own parser:
+
+        --silent true TAIL  -> remain ["true","TAIL"]   does NOT consume
+        --global true TAIL  -> remain ["TAIL"]          consumes
+
+    Classing them together made `npx --silent true <arg>` report `<arg>` as
+    the package when npm's package is literally `true` -- and collapsed
+    `--silent true X` with `--silent false X` onto the single identity `X`,
+    which is the #180 collapse reintroduced through the fix for it.
+    """
+
+    def test_baked_value_shorthand_leaves_true_as_the_package(self) -> None:
+        assert detect_package_type("npx", ["--silent", "true", "arg"]) == (
+            "npm",
+            "true",
+        )
+
+    def test_baked_value_shorthand_does_not_collapse_true_and_false(self) -> None:
+        got_a = detect_package_type("npx", ["--silent", "true", "X"])
+        got_b = detect_package_type("npx", ["--silent", "false", "X"])
+        assert got_a == ("npm", "true")
+        assert got_b == ("npm", "false")
+        assert got_a != got_b
+
+    def test_real_boolean_still_consumes_the_literal(self) -> None:
+        """The other side of the split must not regress."""
+        assert detect_package_type("npx", ["--global", "true", "pkg"]) == (
+            "npm",
+            "pkg",
+        )
+
+    def test_baked_value_shorthand_still_skips_an_ordinary_token(self) -> None:
+        assert detect_package_type("npm", ["--silent", "exec", "pkg"]) == (
+            "npm",
+            "pkg",
+        )


### PR DESCRIPTION
Closes **#180**, the last fail-open ecosystem. #182 converted uvx, pip, cargo and docker; npm was deliberately deferred because it needed its flag arity enumerated, and that enumeration is this change's real content.

## The residual

`_npm_package_arg` skipped anything starting `-` and took the next bare token, so a flag's **value** became the package name. Two different servers then shared one identity, which v2.4.0's gate reads as a **positive confirmation**. All five reproduced on 2.5.0; all five now resolve correctly:

```
npm exec --loglevel silly a/b        ('npm','silly')      -> ('npm','a') / ('npm','b')
npm exec --registry https://r a/b    ('npm','https://r')  -> ('npm','a') / ('npm','b')
npx -y --registry https://r a/b      ('npm','https://r')  -> ('npm','a') / ('npm','b')
npm exec --global false a/b          ('npm','false')      -> ('npm','a') / ('npm','b')
npm exec --color always a/b          ('npm','always')     -> ('unknown', None)  [refuses]
```

The last two are the ones a naive design misses. A board seat **implemented an earlier version of this plan faithfully in a copy** and demonstrated its acceptance suite passed while `--color always` still collided — the suite was blind to the exact entry the method got wrong.

## Source: `@npmcli/config`, not `npm config list --json`

The table is generated from npm's own `definitions` (181 entries with declared `type`) and `shorthands` (40 expansions). The generator is committed at `.consiliency/notes/derive_npm_flags.py` with a `--verify` mode.

`npm config list --json` was the original plan's source and is **disqualified**: it emits the active merged config, omits private keys, adds host-specific ones, and `NPM_CONFIG_COLOR=always` flips `color` from boolean to string — the same generator would classify differently on different hosts.

**Arity cannot be inferred from a default value.** `--color` has a boolean default but a declared type of `always|Boolean`, and `npm exec --color always` is legal. That falsified the original model outright.

## Classification, verified against npm's own parser

`null` is dropped before classifying — it means *unset*, not a value type. Without that, `yes`/`optional`/`production`/`workspaces` read as conditional and `--yes`/`-y`, a real MCP launch form, gets refused.

The conditional-arity set is exactly **`{browser, color}`**. A board seat proposed `{browser, color, proxy}`; `proxy` has no Boolean member and **always** consumes — including `--proxy a`, where it swallows the package — so it is a value flag, and grouping it as conditional would have refused an unambiguous form.

Shorthands expand with arity from expansion length: ≥2 bakes in a value ⇒ consumes nothing; length 1 is a rename ⇒ inherits the target's arity. This retires the previous hand-coded `-y` special case.

## Two self-corrections found during implementation

- **`npm exec -- <pkg>` was refused by the new fail-closed default.** A legitimate form the plan never named.
- **Baked-value shorthands had to split from real booleans.** `--silent` bakes in its value so it consumes nothing, leaving `npx --silent true arg` → `true`; `--global` is a real boolean that *does* swallow a literal `true`. Getting that backwards mis-parses both.

## Verification

```
2802 passed, 3 skipped, 0 failed      ruff + mypy clean
generator --verify: 0 mismatches over 181 definitions, cross-checked against nopt
manifest: 98 servers, 0 unknown
9-form residual sweep: none still colliding
```

Must-not-regress, all intact: `npm --silent exec pkg`→`pkg`, `npm exec pkg`→`pkg`, `npm install i`→`i`, `npm exec exec`→`exec`, `npx -y exec`→`exec`, `npx -y pkg`→`pkg`.

## Cost

A server launched with a flag npm's own schema does not describe can no longer be auto-updated — it fails closed rather than guessing. That is the deliberate trade this repo has now applied to all five ecosystems: failing closed is loud and recoverable, failing open is silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbREMUsxgJ8TDBLpJ56PWb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/192"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790365226&installation_model_id=427051&pr_number=192&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F192&signature=f7e8cf9a021e1971b4e0e8d9a73cda07f43f9973bc985e7ea5bd5ca81c4c426c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->