### PR TITLE
fix(parser): scope null to nullable booleans; refuse npx boolean literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A literal `null` after an npm boolean flag no longer mints a wrong package
+  identity.** npm's parser consumes `null` after only the five *nullable*
+  booleans (`--yes`, `--optional`, `--production`, `--workspaces`,
+  `--expect-results`); after any other boolean, `null` is the package — and
+  `null` is a real published npm package. A blanket rule applied it to all ~198
+  boolean entries, so `npm exec --global null pkg-a` and `... pkg-b` both
+  resolved to `null` and the identity gate confirmed them as one package.
+- **`npx` no longer guesses when a boolean flag is followed by a literal.**
+  `npx` pre-scans its arguments and inserts `--` before the first positional, so
+  a boolean switch consumes nothing there — the opposite of `npm`. Confirmed
+  against the real binary: `npx --global true pkg` runs the package `true`.
+  Because the `--no-` family behaves differently again, these forms now report
+  no identity rather than a modelled guess, which refreshes rather than
+  confirming a wrong one.
+
+  Known remaining gap, tracked separately: the same class survives in rarer
+  spellings — an attached value (`--global=pkg`), nopt's abbreviation matching
+  (`-n`, `--y`), and `npx`'s own rewriting of `-p=` and removal of `-n`. No
+  server in the bundled manifest uses any of them.
+
+### Fixed
 - **npm no longer reads a flag's *value* as the package name.** npm was the last
   of the five ecosystems still failing *open* on an unrecognised flag: the scan
   skipped anything starting `-` and took the next bare token, so

--- a/src/pmcp/manifest/version_checker.py
+++ b/src/pmcp/manifest/version_checker.py
@@ -759,7 +759,30 @@ _NPM_BOOLEAN_FLAGS = frozenset(
 # nullable boolean (`--yes`, `--optional`, `--production`, `--workspaces`,
 # `--expect-results`) consumes it, so omitting it made `--yes null A` and
 # `--yes null B` both resolve to the package `null` (ah board review).
-_NPM_BOOLEAN_LITERALS = frozenset({"true", "false", "null"})
+_NPM_BOOLEAN_LITERALS = frozenset({"true", "false"})
+
+# Booleans whose declared type is `null|Boolean` -- these, and ONLY these, also
+# consume a literal `null`. Verified against nopt: `npm exec --yes null zz`
+# leaves `zz`, but `npm exec --global null zz` leaves `null zz`, so `null` is
+# the package for every NON-nullable boolean. A blanket `null` rule therefore
+# minted a wrong identity across the other ~180 boolean entries -- and `null`
+# is a real published npm package (ah board review, correctness seat).
+_NPM_NULLABLE_BOOLEAN_FLAGS = frozenset(
+    {
+        "--expect-results",
+        "--no-expect-results",
+        "--no-optional",
+        "--no-production",
+        "--no-workspaces",
+        "--no-yes",
+        "--optional",
+        "--production",
+        "--workspaces",
+        "--ws",
+        "--yes",
+        "-y",
+    }
+)
 
 _NPM_SKIP_FLAGS = frozenset(
     {
@@ -1196,6 +1219,25 @@ def _npm_package_arg(args: list[str], command: str) -> str | None:
                 continue
             if arg in _NPM_BOOLEAN_FLAGS:
                 following = args[index + 1] if index + 1 < len(args) else None
+                if command == "npx":
+                    # npx-cli.js pre-scans argv and inserts `--` before the
+                    # first positional, so a plain-name boolean switch never
+                    # consumes a following literal under npx. Confirmed against
+                    # the real binary: `npx --offline --global true zz` fetches
+                    # registry.npmjs.org/true -- the package is `true`, not the
+                    # trailing token. The `--no-` family behaves differently
+                    # again (the pre-scan does not recognise `no-X` as a switch,
+                    # so nopt still consumes), so rather than model a rule that
+                    # differs per spelling, REFUSE: a refusal can never mint a
+                    # wrong identity, and a real config with a bare
+                    # true/false/null after a boolean is vanishingly rare
+                    # (ah board review, correctness seat).
+                    if following in ("true", "false", "null"):
+                        return None
+                    # Otherwise a boolean switch consumes nothing under npx --
+                    # the next token is still a package candidate. (`npx -y pkg`
+                    # must keep resolving to `pkg`.)
+                    continue
                 # npm's parser takes a literal `true`/`false` -- and, for a
                 # NULLABLE boolean, a literal `null` -- after a boolean flag as
                 # that flag's value; anything else is a positional. Verified
@@ -1203,7 +1245,10 @@ def _npm_package_arg(args: list[str], command: str) -> str | None:
                 # `null` made `--yes null A` and `--yes null B` both resolve to
                 # the package `null`, a false identity the gate then CONFIRMS
                 # (ah board review, red-team seat).
-                if following in _NPM_BOOLEAN_LITERALS:
+                literals = _NPM_BOOLEAN_LITERALS
+                if arg in _NPM_NULLABLE_BOOLEAN_FLAGS:
+                    literals = literals | {"null"}
+                if following in literals:
                     index += 1
                 continue
             # Unclassified. `--flag=value` is self-delimiting so it cannot

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -2337,10 +2337,72 @@ class TestNpmBakedValueShorthandDoesNotConsume:
         assert got_a != got_b
 
     def test_real_boolean_still_consumes_the_literal(self) -> None:
-        """The other side of the split must not regress."""
-        assert detect_package_type("npx", ["--global", "true", "pkg"]) == (
+        """The other side of the split must not regress -- under `npm`.
+
+        This test previously used `npx` and asserted `pkg`, which **pinned the
+        wrong behaviour**. Confirmed against the real binary:
+        `npx --offline --global true zz` fetches `registry.npmjs.org/true`, so
+        the package is `true`. npx-cli.js pre-scans argv and inserts `--`
+        before the first positional, so a plain-name boolean switch never
+        consumes a literal under npx (ah board review, correctness seat).
+        The npx case is now covered by `TestNpxBooleanLiterals` below.
+        """
+        assert detect_package_type("npm", ["exec", "--global", "true", "pkg"]) == (
             "npm",
             "pkg",
+        )
+
+
+class TestNpxBooleanLiterals:
+    """npx parses boolean switches differently from npm, so pmcp refuses.
+
+    `bin/npx-cli.js` pre-scans argv and inserts `--` ahead of the first
+    positional, so a plain-name boolean switch consumes nothing -- while the
+    `--no-` family still does, because the pre-scan does not recognise `no-X`
+    as a switch. Rather than model a rule that differs per spelling, refuse:
+    a refusal can never mint a wrong identity, and a real config carrying a
+    bare `true`/`false`/`null` after a boolean is vanishingly rare.
+    """
+
+    def test_npx_refuses_a_literal_after_a_boolean(self) -> None:
+        assert detect_package_type("npx", ["--global", "true", "zz"]) == (
+            "unknown",
+            None,
+        )
+        assert detect_package_type("npx", ["--yes", "null", "zz"]) == ("unknown", None)
+
+    def test_npx_boolean_without_a_literal_still_resolves(self) -> None:
+        """The refusal is scoped to the literal, not to boolean flags."""
+        assert detect_package_type("npx", ["-y", "pkg"]) == ("npm", "pkg")
+        assert detect_package_type("npx", ["-y", "exec"]) == ("npm", "exec")
+        assert detect_package_type("npx", ["--global", "pkg"]) == ("npm", "pkg")
+
+
+class TestOnlyNullableBooleansConsumeNull:
+    """`null` is a real published npm package, and only 5 flags consume it.
+
+    Verified against nopt: `npm exec --yes null zz` leaves `zz` (nullable
+    consumes), while `npm exec --global null zz` leaves `null zz` -- so `null`
+    is the package. A blanket rule applying `null` to all ~198 boolean entries
+    minted a wrong identity for the other ~193 (ah board review).
+    """
+
+    def test_nullable_boolean_consumes_null(self) -> None:
+        assert detect_package_type("npm", ["exec", "--yes", "null", "zz"]) == (
+            "npm",
+            "zz",
+        )
+
+    def test_non_nullable_boolean_does_not_consume_null(self) -> None:
+        assert detect_package_type("npm", ["exec", "--global", "null", "zz"]) == (
+            "npm",
+            "null",
+        )
+
+    def test_true_and_false_are_consumed_by_any_boolean(self) -> None:
+        assert detect_package_type("npm", ["exec", "--global", "false", "a"]) == (
+            "npm",
+            "a",
         )
 
     def test_baked_value_shorthand_still_skips_an_ordinary_token(self) -> None:


### PR DESCRIPTION
Fixes two **live defects on `main`**, both introduced by #192. The correctness seat reported them after that PR merged — I had not frozen the branch, which is my process error, not the seat's.

Both confirmed against nopt **and the real npm binary** before acting.

## 1. A blanket `null` rule minted wrong identities across ~193 boolean entries

#192 added `"null"` to the boolean-literal set for the whole table. nopt consumes `null` after only the **5 nullable booleans** (`null|Boolean`): `expect-results`, `optional`, `production`, `workspaces`, `yes`. For every other boolean, `null` is the **positional** — and `null` is a real published npm package.

```
nopt: npm exec --global null zz  -> remain ["null","zz"]    package is null
nopt: npm exec --yes    null zz  -> remain ["zz"]           package is zz
main: both returned zz
```

A fourth set, `_NPM_NULLABLE_BOOLEAN_FLAGS`, is derived from the same `null|Boolean` test the generator already performs — 12 spellings including `--no-` negations and the `-y` / `--ws` shorthands.

Worth naming: my plan-round correction — *"drop `null`, it means unset"* — was right about **classification** and I wrongly generalised it to **parsing**. The same word means different things in the two places.

## 2. npx inverts literal consumption, and #192 regressed it

`bin/npx-cli.js` pre-scans argv and inserts `--` before the first positional, so a plain-name boolean switch **never consumes a literal under npx**. Confirmed against the real binary, not just the parser:

```
npx --offline --global true zz-not-a-real-pkg  ->  fetches registry.npmjs.org/true
```

The package is `true`. #192 returned the trailing token — and **its own test pinned that wrong behaviour** (`test_real_boolean_still_consumes_the_literal`, with `command="npx"`). That test now uses `npm`; the npx case is covered separately.

npx now **refuses** on a literal rather than modelling the rule, because the `--no-` family behaves differently again — the pre-scan doesn't recognise `no-X` as a switch, so nopt still consumes there. A refusal cannot mint a wrong identity, and a config carrying a bare `true`/`false`/`null` after a boolean is vanishingly rare.

## My first cut broke `npx -y pkg`

The most common MCP launch form. I consumed a token in the non-literal path. **The new tests passed** — only re-running the full regression set caught it. That is the fourth time this session a fix for a board finding introduced its own defect, and precisely why the regression set is maintained separately from the tests.

## Verification

```
2810 passed, 3 skipped, 0 failed      ruff + mypy clean
manifest: 98 servers, 0 unknown
```

All 8 regression forms intact — `npm --silent exec pkg`, `npm exec pkg`, `npm install i`, `npm exec exec`, `npx -y exec`, `npx -y pkg`, `npm exec -- pkg`, `npm exec --global false a`.

All 5 of #180's original collisions still closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbREMUsxgJ8TDBLpJ56PWb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790367309&installation_model_id=427051&pr_number=194&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F194&signature=7cc079fb7c50e6fbbb67cc4bc486026b492ab8afb3f5d0094fdc8c1352a3f7e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->