### PR TITLE
chore: v2.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- **A literal `null` after an npm boolean flag no longer mints a wrong package
-  identity.** npm's parser consumes `null` after only the five *nullable*
-  booleans (`--yes`, `--optional`, `--production`, `--workspaces`,
-  `--expect-results`); after any other boolean, `null` is the package — and
-  `null` is a real published npm package. A blanket rule applied it to all ~198
-  boolean entries, so `npm exec --global null pkg-a` and `... pkg-b` both
-  resolved to `null` and the identity gate confirmed them as one package.
-- **`npx` no longer guesses when a boolean flag is followed by a literal.**
-  `npx` pre-scans its arguments and inserts `--` before the first positional, so
-  a boolean switch consumes nothing there — the opposite of `npm`. Confirmed
-  against the real binary: `npx --global true pkg` runs the package `true`.
-  Because the `--no-` family behaves differently again, these forms now report
-  no identity rather than a modelled guess, which refreshes rather than
-  confirming a wrong one.
-
-  Known remaining gap, tracked separately: the same class survives in rarer
-  spellings — an attached value (`--global=pkg`), nopt's abbreviation matching
-  (`-n`, `--y`), and `npx`'s own rewriting of `-p=` and removal of `-n`. No
-  server in the bundled manifest uses any of them.
+## [2.5.1] - 2026-08-26
 
 ### Fixed
 - **npm no longer reads a flag's *value* as the package name.** npm was the last
@@ -54,6 +35,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   — where the previous "take the next token" default produced a silent
   collision instead. No bundled manifest server is affected: all 98 launchable
   entries resolve exactly as before.
+
+  Two places where the boolean rule is subtler than "a switch takes no value":
+
+  - **`null` is a real published npm package.** npm's parser consumes a literal
+    `null` after only the five *nullable* booleans (`--yes`, `--optional`,
+    `--production`, `--workspaces`, `--expect-results`); after any other
+    boolean, `null` is the package. The rule is scoped to those five, so
+    `npm exec --global null pkg-a` and `… pkg-b` stay distinct.
+  - **`npx` behaves the opposite way to `npm`.** It pre-scans its arguments and
+    inserts `--` before the first positional, so a boolean switch there consumes
+    nothing — verified against the real binary: `npx --global true pkg` runs the
+    package `true`. Because the `--no-` family differs again, `npx` reports no
+    identity for these forms rather than a modelled guess.
+
+  Known remaining gap, tracked in
+  [#195](https://github.com/Consiliency/pmcp/issues/195): the same class
+  survives in rarer spellings — an attached value (`--global=pkg`), nopt's
+  abbreviation matching (`-n`, `--y`), and `npx`'s own rewriting of `-p=` and
+  removal of `-n`. No server in the bundled manifest uses any of them.
 
 ## [2.5.0] - 2026-08-26
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "2.5.0"
+version = "2.5.1"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "2.5.0"
+version = "2.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts 2.5.1. Ships #180 (npm fail-closed flag parsing, PR #192) and #194, which repaired two defects #192 introduced before they ever shipped.

## Contents

- **#192 / #180** — npm was the last ecosystem failing *open* on an unrecognised flag. Arity is now generated from `@npmcli/config`'s own `definitions` + `shorthands` (181 + 40, cross-checked against nopt with 0 mismatches); an unlisted flag reports no identity rather than guessing.
- **#194** — two defects live on `main` after #192: a blanket `null`-means-unset rule (npm consumes `null` after only 5 nullable booleans, and `null` is a real published package), and npx's inverted boolean handling (npx inserts `--` before the first positional, so `npx --global true pkg` runs `true`).

## Why patch, not minor

No bundled manifest server changes identity — all 98 launchable entries resolve exactly as before. The only user-reachable behaviour change is a *refusal* to auto-update a server launched with a flag npm's own schema does not describe, which is strictly safer than the previous silent collision.

## CHANGELOG

The two `### Fixed` blocks that accumulated under `[Unreleased]` are folded into one coherent entry — #194's fixes are described as part of the #180 change rather than as a repair of an unshipped bug. Verified the release workflow's awk extraction yields a single 47-line section with one `### Fixed` heading.

## Known gap

Filed as #195: the same collision class survives in rarer spellings (attached `--global=pkg`, nopt abbreviations `-n`/`--y`, npx's own `-p=` rewriting and `-n` removal). No bundled server uses any of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T61zMNiPF4K29186r3uqc3

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790370984&installation_model_id=427051&pr_number=196&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F196&signature=2f26d04401ab3350c2a18983d89a1f26e071d9a22db746710b0f8ec86519cb80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->