### PR TITLE
chore: v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-08-27
+
 ### Added
 - **The release-path workflow guards now run in CI.** `release.yml` triggers
   only on tag push — the tag push *is* the publish — so it never appeared in a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "2.5.2"
+version = "2.6.0"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "2.5.2"
+__version__ = "2.6.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "2.5.2"
+version = "2.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts 2.6.0. Ships #195 (PR #199) and #189 (PR #198).

## Why minor, not patch

Behaviour visibly changes. A server launched with an unusual config can no longer be auto-updated — `gateway.update_server` refuses it by name rather than probing. That is deliberate: guessing is what produced five consecutive identity defects, and a refusal fails every freshness comparison closed.

All **79** bundled npm servers still resolve, and match the real binary, so the shipped fleet is unaffected.

## Contents

- **#195** — npm identity from npm's own parser (`nopt` + `@npmcli/config` + `npm-package-arg`) in a persistent node child, loaded from the npm the command actually resolves to. Gates are an allowlist, not a denylist.
- **#189** — release-path workflow guards run on every PR: structural invariants, job-set drift, and a `release-change-approved` label tripwire. 37 committed mutants, 31 killed, `actionlint` kills only 4 of them.

## Verification

- 227-row differential corpus against the **real binary** on **npm 10.8.2 and 11.19.0**, 0 unsafe, 89/89 required rows resolving and matching.
- 0 of 208 rows diverge in resolver output between the two npm majors.
- 98/98 manifest entries byte-identical to 2.5.2 on a node-less host.

## Known residual

User and global `.npmrc` are invisible to the resolver, so a `package=` or `registry=` line there can still redirect what npm fetches. Stated here rather than discovered later.

## CHANGELOG

`[Unreleased]` folded into `## [2.6.0]`; extraction verified to yield one `### Added` and one `### Fixed`, no duplicate headings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T61zMNiPF4K29186r3uqc3

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790440733&installation_model_id=427051&pr_number=201&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F201&signature=972b0b769c23052affda1a9c7246b83e1cc4d127c14a31378c96fb9ba94e84ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->