### PR TITLE
fix(tooling): stop --verify reporting host-enumerated types as drift (#193)

### DIFF
--- a/.consiliency/notes/derive_npm_flags.py
+++ b/.consiliency/notes/derive_npm_flags.py
@@ -136,6 +136,7 @@ Usage:
                                                   # freeze read_schema() output
 """
 
+import ipaddress
 import json
 import pathlib
 import subprocess
@@ -598,6 +599,10 @@ def emit(classes: dict[str, str], nullable: dict[str, bool]) -> str:
     )
 
 
+# Stands in for a recorded probe token that is one of the recording machine's
+# own addresses. Only the KEY is masked; the probe result it maps to is real.
+_MASKED_PROBE = "<host-address>"
+
 _FIXTURE_README = (
     "RECORDED OUTPUT of read_schema() in .consiliency/notes/derive_npm_flags.py, "
     "captured against a real npm on a maintainer machine. CI has no npm and no "
@@ -606,8 +611,39 @@ _FIXTURE_README = (
     "--record-schema tests/fixtures/npm/schema.json. Ignored by the generator, "
     "which reads only npm_version/definitions/shorthands/null_spellings. NOTE "
     "local-address's `type` here is this machine's address list reduced to "
-    "'<literal>' labels; its LENGTH is a host fact and the tests patch it."
+    "'<literal>' labels; its LENGTH is a host fact and the tests patch it. Its "
+    "recorded PROBE keys are masked to " + _MASKED_PROBE + " for the same reason: "
+    "the node script probes with the type's first literal member, which for a "
+    "host-enumerated flag is one of the recording machine's own addresses."
 )
+
+
+def _mask_host_addresses(schema: dict) -> dict:
+    """Replace a host-enumerated flag's address-valued PROBE key with a constant.
+
+    The node script probes each definition with the first literal member of its
+    `type`; for `local-address` that is whatever `os.networkInterfaces()` put
+    first, so a re-record on a laptop would commit that machine's LAN address
+    into the repo. The probe RESULT is what the nopt cross-check reads, and it
+    is preserved -- only the key's spelling is normalised, which also stops a
+    re-record from churning the fixture on every host.
+    """
+    for info in schema["definitions"].values():
+        if not _host_enumerated(info):
+            continue
+        info["probes"] = {
+            (_MASKED_PROBE if _is_ip_literal(probe) else probe): consumed
+            for probe, consumed in info["probes"].items()
+        }
+    return schema
+
+
+def _is_ip_literal(token: str) -> bool:
+    try:
+        ipaddress.ip_address(token.split("%", 1)[0])
+    except ValueError:
+        return False
+    return True
 
 
 def record_schema(dest: pathlib.Path) -> int:
@@ -616,8 +652,14 @@ def record_schema(dest: pathlib.Path) -> int:
     The tests this feeds are the ones that would otherwise only ever run on a
     maintainer's machine -- and a check that never runs in CI is the same
     ignored check that #193 is about.
+
+    What this recording CANNOT pin is npm's own version: it freezes npm 11.19.0
+    and the CI tests check the committed tables against that. Version skew --
+    tables recorded on one npm, a real npm that has since moved -- is still
+    caught only by running `--verify` against a live npm, which is the whole
+    point of that mode and is deliberately unchanged.
     """
-    payload = {"_README": _FIXTURE_README, **read_schema()}
+    payload = {"_README": _FIXTURE_README, **_mask_host_addresses(read_schema())}
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
     print(f"recorded {dest} ({dest.stat().st_size} bytes)", file=sys.stderr)
@@ -626,9 +668,10 @@ def record_schema(dest: pathlib.Path) -> int:
 
 def main() -> int:
     if "--record-schema" in sys.argv:
-        return record_schema(
-            pathlib.Path(sys.argv[sys.argv.index("--record-schema") + 1])
-        )
+        argv_rest = sys.argv[sys.argv.index("--record-schema") + 1 :]
+        if not argv_rest:
+            raise SystemExit("--record-schema needs a destination path")
+        return record_schema(pathlib.Path(argv_rest[0]))
 
     schema = read_schema()
     classes, nullable, conditional, union, unreadable = build(schema)

--- a/.consiliency/notes/derive_npm_flags.py
+++ b/.consiliency/notes/derive_npm_flags.py
@@ -21,7 +21,8 @@ preference. It emits the *active merged configuration*, not the definition set:
 
 The same generator would therefore classify differently on different hosts. The
 definitions module, by contrast, declares each flag's `type` -- the real arity
-declaration, independent of environment and of any default value.
+declaration, independent of any default value. Independent of the environment
+too, with ONE measured exception handled under HOST-ENUMERATED TYPES below.
 
 WHAT `type` MEANS, AND THE TWO MEMBERS THAT ARE NOT VALUE TYPES
 --------------------------------------------------------------
@@ -51,6 +52,41 @@ Classification, after the drop:
   Boolean AND non-Bool  -> CONDITIONAL: arity depends on the next token's
                            content, so no single class is right. Left UNLISTED,
                            which makes the scanner refuse. Fail closed.
+
+HOST-ENUMERATED TYPES: MEMBERS THAT ARE MACHINE FACTS (#193)
+------------------------------------------------------------
+One definition's `type` is not declared -- it is enumerated from the host.
+`local-address` is `null` plus every address `os.networkInterfaces()` reports,
+51 members on this machine and a different set on the next one. Classifying off
+the members therefore made `--verify` green on one machine and red on another
+with identical npm and identical source, and a drift check with false positives
+gets ignored -- which is how real drift ships.
+
+The failure is not merely "a different address list". `getLocalAddresses()`
+CATCHES a `networkInterfaces()` throw and returns exactly `[null]`; the member
+rule above strips `null` and calls the remainder UNINTERPRETABLE, which is the
+report #193 was filed with. So an IP-presence test cannot detect this class --
+on the very host that has the bug there is no IP to find.
+
+The fix normalises the CLASS and changes nothing else:
+
+  * detection happens in the NODE script, the only place the raw members still
+    exist -- the serializer maps every string member to '<literal>', so no
+    Python-side predicate can tell 51 addresses from `loglevel`'s 8 fixed
+    words. Signals: `typeDescription === 'IP Address'` (npm's own label, and
+    the one that survives the `[null]` case) or a `net.isIP` member scan.
+  * `classify(..., host_enumerated=True)` returns VALUE regardless of members.
+    `--local-address` consumes the next token on every host; only the member
+    list varies, and it carries no classification information.
+  * the flag is NOT exempted from `--verify`. Skipping it would blind the check
+    to a real arity change on the flag most likely to drift; `--verify` reports
+    which flags it normalised instead, so the behaviour is visible without
+    removing anything from the comparison.
+
+If npm ever renames the label AND the enumeration fails on the same host,
+detection stops and the flag falls back to member classification --
+UNINTERPRETABLE, i.e. a loud red verify rather than a silent wrong answer.
+That is the correct direction and is stated here so it is not read as a gap.
 
 SHORTHANDS EXPAND; ARITY COMES FROM THE EXPANSION'S LENGTH
 ----------------------------------------------------------
@@ -125,6 +161,7 @@ _POSITIVE = frozenset({"package"})
 # than trusted -- the type strings alone are what falsified an earlier design.
 _NODE = r"""
 const path = require('path');
+const net = require('net');
 const root = process.argv[1];
 const defsPath = path.join(
   root, 'node_modules', '@npmcli', 'config', 'lib', 'definitions', 'index.js');
@@ -149,6 +186,24 @@ const remain = (argv) => nopt(types, m.shorthands, argv, 0).argv.remain;
 // member, since that is exactly where a conditional flag reveals itself.
 const consumes = (flag, probe) => !remain(['--' + flag, probe, 'TAIL']).includes(probe);
 
+// Is this definition's `type` enumerated from the HOST rather than declared?
+// This question can only be answered HERE. `label` below maps every string or
+// number member to the literal '<literal>', so by the time the type array
+// reaches Python no real address survives and no Python-side predicate can
+// distinguish `local-address`'s 51 machine addresses from `loglevel`'s 8 fixed
+// words. Two independent signals, either sufficient:
+//   * npm's own `typeDescription` label for the class ('IP Address'). Primary,
+//     because it is the one signal that still holds when the enumeration FAILS:
+//     `getLocalAddresses()` catches a `networkInterfaces()` throw and returns
+//     exactly `[null]`, and a member scan sees nothing at all in that case.
+//   * a `net.isIP` scan over the raw members, as a backstop for a future
+//     host-derived type npm does not label. Note `net.isIP` rejects a
+//     link-local address carrying a `%zone` suffix, which is the other reason
+//     the label is primary rather than the scan.
+const hostEnumerated = (v, t) =>
+  v.typeDescription === 'IP Address' ||
+  t.some((x) => typeof x === 'string' && net.isIP(x) !== 0);
+
 const definitions = {};
 for (const [k, v] of Object.entries(m.definitions)) {
   const t = Array.isArray(v.type) ? v.type : [v.type];
@@ -161,6 +216,11 @@ for (const [k, v] of Object.entries(m.definitions)) {
   if (lit !== undefined) probes.push(String(lit));
   definitions[k] = {
     type: t.map(label),
+    // Emitted so the CI-side tests -- which have neither npm nor node -- can
+    // assert on the real strings that drive the detection above, instead of
+    // on a hand-written guess at what they say.
+    typeDescription: v.typeDescription === undefined ? null : v.typeDescription,
+    hostEnumerated: hostEnumerated(v, t),
     short: v.short === undefined ? [] : [].concat(v.short),
     probes: Object.fromEntries(probes.map((p) => [p, consumes(k, p)])),
   };
@@ -214,8 +274,40 @@ def read_schema() -> dict:
     return json.loads(out.stdout)
 
 
-def classify(type_labels: list[str]) -> str:
-    """npm's declared `type` -> one of BOOLEAN / VALUE / CONDITIONAL."""
+def _host_enumerated(info: dict) -> bool:
+    """The node side's verdict for one definition, defaulting to False.
+
+    `.get` rather than `[...]` so a schema recorded before this field existed
+    still classifies by members instead of raising.
+    """
+    return bool(info.get("hostEnumerated", False))
+
+
+def host_enumerated_flags(schema: dict) -> list[str]:
+    """Definition names whose `type` npm builds from this machine."""
+    return sorted(
+        name for name, info in schema["definitions"].items() if _host_enumerated(info)
+    )
+
+
+def classify(type_labels: list[str], *, host_enumerated: bool = False) -> str:
+    """npm's declared `type` -> one of BOOLEAN / VALUE / CONDITIONAL.
+
+    `host_enumerated` short-circuits to VALUE REGARDLESS of the members,
+    including the bare `["null"]` case. A host-enumerated type's members are
+    facts about the machine -- `local-address` is npm's own network addresses
+    -- so they carry no classification information and vary between two hosts
+    running identical npm. The classification does not vary: `--local-address`
+    consumes the next token everywhere.
+
+    The `["null"]` case is not hypothetical and is why this cannot be a
+    member-filtering rule: `getLocalAddresses()` catches a
+    `networkInterfaces()` failure and returns exactly `[null]`, which the
+    member rule below strips to nothing and calls UNINTERPRETABLE. That is
+    precisely the false drift report Consiliency/pmcp#193 filed.
+    """
+    if host_enumerated:
+        return VALUE
     members = [t for t in type_labels if t not in _NOT_A_VALUE_TYPE]
     has_boolean = "Boolean" in members
     others = [t for t in members if t != "Boolean"]
@@ -288,7 +380,7 @@ def build(
 
     name_class: dict[str, str] = {}
     for name, info in defs.items():
-        cls = classify(info["type"])
+        cls = classify(info["type"], host_enumerated=_host_enumerated(info))
         name_class[name] = cls
         if cls == UNINTERPRETABLE:
             unreadable.append(f"{name}: type={info['type']}")
@@ -371,7 +463,7 @@ def check_against_nopt(schema: dict) -> list[str]:
     """
     bad: list[str] = []
     for name, info in schema["definitions"].items():
-        cls = classify(info["type"])
+        cls = classify(info["type"], host_enumerated=_host_enumerated(info))
         for probe, observed in info["probes"].items():
             if cls == BOOLEAN:
                 predicted = probe in ("true", "false") or (
@@ -527,6 +619,20 @@ def main() -> int:
     print(f"\nUNINTERPRETABLE type ({len(unreadable)}):", file=sys.stderr)
     for entry in unreadable:
         print(f"  {entry}", file=sys.stderr)
+
+    # NOT an exemption. These flags stay in the comparison below; what is
+    # normalised is their CLASS, which is host-independent even though their
+    # declared members are not. Deliberately prints no member count -- that is
+    # the host fact, and printing it would make this line differ between two
+    # machines running identical npm, which is the bug being fixed.
+    normalised = host_enumerated_flags(schema)
+    print(
+        f"\nHOST-ENUMERATED type -> normalised to {VALUE}, still verified "
+        f"({len(normalised)}):",
+        file=sys.stderr,
+    )
+    for name in normalised:
+        print(f"  --{name}", file=sys.stderr)
 
     mismatches = check_against_nopt(schema)
     print(

--- a/.consiliency/notes/derive_npm_flags.py
+++ b/.consiliency/notes/derive_npm_flags.py
@@ -124,11 +124,16 @@ probe alone would not have caught a spelling omission.
 
 Deliberately NOT a pytest: npm's schema is version-specific and CI has no npm.
 Behaviour is pinned by the pure unit tests in tests/test_version_checker.py;
-this script is what keeps those pins honest against a real npm.
+this script is what keeps those pins honest against a real npm. Its own
+classification logic IS pytested there, against a RECORDED `read_schema()`
+(`--record-schema`, frozen in tests/fixtures/npm/schema.json) rather than a
+live one -- a maintainer-only check is an unrun check.
 
 Usage:
     python3 .consiliency/notes/derive_npm_flags.py            # emit the tables
     python3 .consiliency/notes/derive_npm_flags.py --verify   # check committed
+    python3 .consiliency/notes/derive_npm_flags.py --record-schema PATH
+                                                  # freeze read_schema() output
 """
 
 import json
@@ -593,7 +598,38 @@ def emit(classes: dict[str, str], nullable: dict[str, bool]) -> str:
     )
 
 
+_FIXTURE_README = (
+    "RECORDED OUTPUT of read_schema() in .consiliency/notes/derive_npm_flags.py, "
+    "captured against a real npm on a maintainer machine. CI has no npm and no "
+    "node, so tests that would otherwise be maintainer-only mock read_schema() "
+    "with this. Regenerate with: python3 .consiliency/notes/derive_npm_flags.py "
+    "--record-schema tests/fixtures/npm/schema.json. Ignored by the generator, "
+    "which reads only npm_version/definitions/shorthands/null_spellings. NOTE "
+    "local-address's `type` here is this machine's address list reduced to "
+    "'<literal>' labels; its LENGTH is a host fact and the tests patch it."
+)
+
+
+def record_schema(dest: pathlib.Path) -> int:
+    """Freeze `read_schema()` to JSON so the CI tests can run without npm.
+
+    The tests this feeds are the ones that would otherwise only ever run on a
+    maintainer's machine -- and a check that never runs in CI is the same
+    ignored check that #193 is about.
+    """
+    payload = {"_README": _FIXTURE_README, **read_schema()}
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(f"recorded {dest} ({dest.stat().st_size} bytes)", file=sys.stderr)
+    return 0
+
+
 def main() -> int:
+    if "--record-schema" in sys.argv:
+        return record_schema(
+            pathlib.Path(sys.argv[sys.argv.index("--record-schema") + 1])
+        )
+
     schema = read_schema()
     classes, nullable, conditional, union, unreadable = build(schema)
     live_nullable = nullable_table(classes, nullable)

--- a/.consiliency/plans/detailed-verify-host-enumerated-types-20260827-1730.md
+++ b/.consiliency/plans/detailed-verify-host-enumerated-types-20260827-1730.md
@@ -1,5 +1,11 @@
 # Detailed plan: stop `--verify` reporting host-enumerated types as drift
 
+> **Revision 2 (2026-08-27).** Rev 1 boarded **3 DISAGREE** and they were right on
+> all three counts. Rev 1's detector could never have fired, its normalization
+> produced UNINTERPRETABLE on the very host that filed the bug, its headline test
+> was vacuous, and it specified two mutually contradictory strategies. Corrected
+> below; rev 1's errors are kept as `WAS WRONG` because each one is a trap.
+
 ## Task
 
 Close Consiliency/pmcp#193. `.consiliency/notes/derive_npm_flags.py --verify` is green on
@@ -37,38 +43,79 @@ the *classification* (`local-address` takes a value) is stable everywhere.
 
 ### `.consiliency/notes/derive_npm_flags.py` (modify)
 
-- `_is_host_enumerated(type_labels)` — add — returns True when a type's members
-  include a **host fact**, detected by property rather than by name:
-  any member that parses as an IPv4 or IPv6 address via Python's `ipaddress`
-  module. Today that selects exactly `local-address` and leaves `audit-level`,
-  `lockfile-version` and `loglevel` alone — verified above. Detecting by
-  *shape* means a future npm type built from hostnames or interface names is
-  caught by extending this one predicate, not by editing a name list.
-- `classify(type_labels)` (`:217`) — modify — when `_is_host_enumerated` is
-  true, classify from the **stable** part of the type only: drop the
-  address-shaped members, then classify what remains. `local-address` is a value
-  flag on every host; this makes that answer machine-independent instead of
-  depending on which interfaces happen to be up.
-- `--verify` comparison (`:558-585`) — modify — record host-enumerated flags in a
-  `skipped_host_enumerated` list and **print them**, with the reason and the
-  member count seen on this host. Silence is what made the original failure
-  confusing; the generator already prints its conditional-arity exemptions, so
-  this matches an existing convention rather than inventing one.
-- Module docstring (`:86-95`) — modify — state that member lists are not
-  comparable across hosts and that classification is what `--verify` pins.
+**WAS WRONG (rev 1), three ways:**
+
+1. *The predicate was blind.* Rev 1 detected host-enumerated types in Python by
+   parsing members with `ipaddress`. But `read_schema`'s node-side serializer maps
+   **every string or number member to the literal `'<literal>'`**
+   (`derive_npm_flags.py:~134`), so no real IP string ever reaches Python. The
+   predicate could not have fired once, and synthetic tests feeding it raw IP
+   strings would have bypassed the production contract entirely.
+2. *It targeted the wrong case.* npm's `getLocalAddresses()` **catches and returns
+   `[null]`** when `networkInterfaces()` throws
+   (`@npmcli/config/lib/definitions/definitions.js:65-71`). The host that filed
+   this bug therefore has `local-address: [null]` — **no addresses at all** — which
+   an IP-presence test cannot see. Worse, rev 1's "drop the address members and
+   classify the remainder" also leaves `[null]`, and `classify()` strips `null` and
+   returns UNINTERPRETABLE — so rev 1 would have produced the reported failure
+   rather than fixing it, and the tables could not regenerate byte-identical.
+3. *It specified two contradictory strategies.* Normalizing `classify()` to a
+   stable `VALUE` makes an exemption unnecessary; exempting the flag from
+   `--verify` removes it from the comparison and would **hide a future genuine
+   arity change** — the opposite of this check's purpose. Rev 1 did both.
+
+**Corrected design — detect where the raw members live, normalize, and keep
+verifying:**
+
+- `read_schema`'s node-side script (`:~128-165`) — modify — emit a per-definition
+  boolean `hostEnumerated`, computed in **JavaScript, where the raw type array is
+  still intact**, as either of:
+  - `typeDescription === 'IP Address'` — npm's own label for this class. Verified
+    stable and host-independent, and verified *not* to match the fixed
+    enumerations: `audit-level`, `loglevel` and `lockfile-version` all carry
+    enumerated descriptions listing their literals.
+  - a `net.isIP()` scan over the raw members returning true for any of them —
+    a second, independent signal for a future host-derived type npm does not
+    label.
+
+  Either alone is sufficient; both are cheap. If npm renames the label *and* the
+  member list is `[null]`, detection stops and the flag falls back to member-based
+  classification, which on that host is UNINTERPRETABLE → a **loud red verify**,
+  not a silent wrong answer. That is the correct failure direction and is stated
+  here so the next reader does not mistake it for a gap.
+- `classify(type_labels, *, host_enumerated=False)` (`:217`) — modify — when
+  `host_enumerated` is true, return `VALUE` **regardless of members, including the
+  bare `[null]` case**. `local-address` takes a value on every host; the member
+  list is a host fact and carries no classification information.
+- `--verify` — modify — **`local-address` stays in the comparison.** No skip list,
+  no exemption. What is printed instead is a one-line note that the flag was
+  *normalized* as host-enumerated, so the exemption-shaped behaviour is visible
+  without removing anything from the check.
+  **WAS WRONG (rev 1):** a `skipped_host_enumerated` list. Once classification is
+  stable there is nothing to skip, and skipping would blind the check to a real
+  arity change on the one flag most likely to drift.
+- Module docstring — modify — the host-independence discussion belongs at
+  `:22-24` / `:42-53`; rev 1 cited `:86-95`, which is the nullable-spelling
+  paragraph.
 
 ### `tests/test_version_checker.py` (modify)
 
+`tests/test_version_checker.py` does **not** import the generator; load it with
+the `importlib.util.spec_from_file_location` pattern already used in
+`tests/test_workflow_guards.py`. **CI has no npm**, so every test here must mock
+`read_schema()` rather than shelling out — otherwise it is a maintainer-only
+check that never runs.
+
 - `TestVerifyIsHostIndependent` — add:
-  - `_is_host_enumerated` is True for a synthetic type carrying IPv4 and IPv6
-    literals, and **False** for `audit-level`, `lockfile-version`, `loglevel`
-    member lists copied verbatim from npm — so a future edit cannot quietly
-    start exempting fixed enumerations.
-  - `classify` returns the same class for a `local-address`-shaped type built
-    with **two different fake interface sets**. This is the actual bug: same
-    npm, different machine, different answer.
-  - The exemption is **reported**, not silent — assert the printed output names
-    the skipped flag.
+  - `classify(..., host_enumerated=True)` returns `VALUE` for **`[null]`** (the
+    enumeration-failure host), for a one-address list, and for a
+    fifty-address list. All three must be `VALUE` — not merely equal to each
+    other. **WAS WRONG (rev 1):** the test compared two non-empty address sets,
+    which the *current* code already classifies identically; it would have passed
+    against unchanged code.
+  - `hostEnumerated` is true for `local-address` and **false** for `audit-level`,
+    `loglevel` and `lockfile-version`, using their real `typeDescription` strings.
+  - `--verify` output names the normalized flag.
 
 ## Documentation impact
 
@@ -112,19 +159,21 @@ members and re-open the false positive.
 
 ## Acceptance criteria
 
-- [ ] `--verify` exits 0 **and produces identical failure output** under two
-      different simulated interface sets — proven by running it twice with the
-      `local-address` type patched to different address lists, and diffing.
-      Running it once on this machine proves nothing, which is the whole bug.
-- [ ] `_is_host_enumerated` is False for `audit-level`, `lockfile-version` and
-      `loglevel` with their real member lists — so the exemption cannot silently
-      widen to fixed enumerations.
-- [ ] Regenerating the tables produces output **byte-identical** to the committed
-      `_NPM_VALUE_FLAGS` / `_NPM_BOOLEAN_FLAGS` / `_NPM_SKIP_FLAGS` /
-      `_NPM_NULLABLE_BOOLEAN_FLAGS`.
-- [ ] `--verify` **prints** every exempted flag with its reason; asserted by a
-      test on the output, not by reading the code.
-- [ ] Link-local members with a `%zone` suffix are still detected as host facts.
+- [ ] With `local-address`'s type patched to **`[null]`**, to one address, and to
+      fifty addresses, `classify` returns **`VALUE`** in all three and `--verify`
+      exits 0 with **identical** output. The `[null]` case is the one that filed
+      this bug and is non-negotiable; rev 1's two-non-empty-lists test passed
+      against unchanged code.
+- [ ] `local-address` is still **present in the `--verify` comparison** — proven
+      by patching its live classification to `BOOLEAN` and asserting `--verify`
+      goes red. An exemption would pass a naive "no false positives" check while
+      blinding the tool to real drift.
+- [ ] `hostEnumerated` is false for `audit-level`, `loglevel` and
+      `lockfile-version` with their real `typeDescription` values.
+- [ ] Regenerating produces output **byte-identical** to the four committed
+      tables.
+- [ ] Every test mocks `read_schema()` and passes with **no npm on PATH**, so the
+      checks run in CI rather than only on a maintainer's machine.
 
 ## Non-goals
 

--- a/.consiliency/plans/detailed-verify-host-enumerated-types-20260827-1730.md
+++ b/.consiliency/plans/detailed-verify-host-enumerated-types-20260827-1730.md
@@ -120,28 +120,32 @@ check that never runs.
 ## Documentation impact
 
 - `CHANGELOG.md` — add — a `### Fixed` entry under `[Unreleased]`: `--verify` no
-  longer reports host-enumerated config types as table drift, and now prints what
-  it exempted.
+  longer reports host-enumerated config types as table drift. It normalises them
+  to their stable classification and says so; it does **not** exempt them from the
+  comparison.
 - No README change: `derive_npm_flags.py` is a maintainer tool, not user-facing.
 
 ## Dependencies & order
 
-1. `_is_host_enumerated` + `classify` change.
-2. Tests, including the two-fake-interface-sets case.
-3. `--verify` reporting.
-4. Regenerate the tables and confirm they are **byte-identical** to what is
+1. Node-side `hostEnumerated` emission in `read_schema` — nothing else can be
+   built until the raw-member signal survives into Python.
+2. `classify(..., host_enumerated=...)`.
+3. Tests, including the **`[null]`** case, all mocking `read_schema()`.
+4. `--verify` normalization note.
+5. Regenerate the tables and confirm they are **byte-identical** to what is
    committed — if the classification change alters any committed table, that is a
    real finding and must be investigated before proceeding, not absorbed.
 
 ## Verification
 
 ```bash
-uv run python .consiliency/notes/derive_npm_flags.py --verify     # exit 0, prints exemptions
+uv run python .consiliency/notes/derive_npm_flags.py --verify   # exit 0, names normalised flags
 uv run pytest -q tests/test_version_checker.py -k host_independent
 
-# The real test: simulate another machine. Monkeypatch the definitions so
-# local-address carries a DIFFERENT address set, and assert --verify still
-# passes and the committed tables are unchanged.
+# The real test: simulate the host that filed the bug. Patch the schema so
+# local-address is [null] -- an enumeration FAILURE, not a different address
+# set -- and assert classify() is still VALUE, --verify still exits 0, and the
+# committed tables are unchanged. Repeat with one address and with fifty.
 uv run python - <<'PY'   # (spelled out in the test, this is the manual form)
 # ... patch definitions -> local-address type = [null, "10.0.0.5", "fe80::1"]
 # ... assert classify() == VALUE and no drift failure is emitted
@@ -151,11 +155,12 @@ uv run pytest -q                      # full suite
 uv run ruff check . && uv run ruff format --check . && uv run mypy src/
 ```
 
-Edge cases: a type with **only** `null` and addresses; a host with no network
-interfaces at all (the enumeration collapses to `[null]`); an IPv6 address with a
-zone suffix (`fe80::1%eth0`) — Python's `ipaddress` rejects the zone form, so the
-predicate must strip a `%…` suffix before parsing or it will miss link-local
-members and re-open the false positive.
+Edge cases: `local-address: [null]` (enumeration failure — the reported case);
+a single-address host; a container with only a loopback; and `net.isIP` on a
+link-local address carrying a `%zone` suffix, which it rejects — which is why
+`typeDescription` is the primary signal and the `isIP` scan only a backstop.
+Rev 1 planned to strip `%…` in Python, which was moot since no raw member ever
+reached Python at all.
 
 ## Acceptance criteria
 

--- a/.consiliency/plans/detailed-verify-host-enumerated-types-20260827-1730.md
+++ b/.consiliency/plans/detailed-verify-host-enumerated-types-20260827-1730.md
@@ -1,0 +1,140 @@
+# Detailed plan: stop `--verify` reporting host-enumerated types as drift
+
+## Task
+
+Close Consiliency/pmcp#193. `.consiliency/notes/derive_npm_flags.py --verify` is green on
+one machine and red on another with identical npm and identical source, because
+some npm config types are **enumerated from the host**. A drift check with false
+positives gets ignored, and an ignored check is how real drift ships.
+
+## Research summary
+
+Measured on this host (npm 11.19.0):
+
+- `local-address`'s declared `type` has **51 members** — `null` plus this
+  machine's own IPv4/IPv6 addresses and interface addresses
+  (`127.0.0.1`, `::1`, `178.156.237.237`, `2a01:4ff:f0:f633::1`, `fe80::…`, …).
+  npm builds it from `os.networkInterfaces()`, so it is different on every
+  machine and changes when an interface appears or a lease renews.
+- The only other definitions with more than six type members are
+  **`audit-level` (7), `lockfile-version` (7), `loglevel` (8)** — all *fixed*
+  enumerations that are byte-identical on every host.
+
+So "many members" is **not** the signal; "members that are host facts" is. A
+name-based exemption for `local-address` would work today and silently fail the
+next time npm adds a host-derived type, which is the same
+fix-the-instance-not-the-class error this project has hit repeatedly (see the
+`WAS WRONG` history in the #195 plan).
+
+`--verify`'s comparison is a set difference per class
+(`derive_npm_flags.py:558-585`): `live - committed` → "MISSING from table",
+`committed - live` → "in table, absent from live npm". The reviewer's host
+produced `value: --local-address in table, absent from live npm`, which means
+`classify()` did not put it in `VALUE` there. The member list is what varies;
+the *classification* (`local-address` takes a value) is stable everywhere.
+
+## Changes
+
+### `.consiliency/notes/derive_npm_flags.py` (modify)
+
+- `_is_host_enumerated(type_labels)` — add — returns True when a type's members
+  include a **host fact**, detected by property rather than by name:
+  any member that parses as an IPv4 or IPv6 address via Python's `ipaddress`
+  module. Today that selects exactly `local-address` and leaves `audit-level`,
+  `lockfile-version` and `loglevel` alone — verified above. Detecting by
+  *shape* means a future npm type built from hostnames or interface names is
+  caught by extending this one predicate, not by editing a name list.
+- `classify(type_labels)` (`:217`) — modify — when `_is_host_enumerated` is
+  true, classify from the **stable** part of the type only: drop the
+  address-shaped members, then classify what remains. `local-address` is a value
+  flag on every host; this makes that answer machine-independent instead of
+  depending on which interfaces happen to be up.
+- `--verify` comparison (`:558-585`) — modify — record host-enumerated flags in a
+  `skipped_host_enumerated` list and **print them**, with the reason and the
+  member count seen on this host. Silence is what made the original failure
+  confusing; the generator already prints its conditional-arity exemptions, so
+  this matches an existing convention rather than inventing one.
+- Module docstring (`:86-95`) — modify — state that member lists are not
+  comparable across hosts and that classification is what `--verify` pins.
+
+### `tests/test_version_checker.py` (modify)
+
+- `TestVerifyIsHostIndependent` — add:
+  - `_is_host_enumerated` is True for a synthetic type carrying IPv4 and IPv6
+    literals, and **False** for `audit-level`, `lockfile-version`, `loglevel`
+    member lists copied verbatim from npm — so a future edit cannot quietly
+    start exempting fixed enumerations.
+  - `classify` returns the same class for a `local-address`-shaped type built
+    with **two different fake interface sets**. This is the actual bug: same
+    npm, different machine, different answer.
+  - The exemption is **reported**, not silent — assert the printed output names
+    the skipped flag.
+
+## Documentation impact
+
+- `CHANGELOG.md` — add — a `### Fixed` entry under `[Unreleased]`: `--verify` no
+  longer reports host-enumerated config types as table drift, and now prints what
+  it exempted.
+- No README change: `derive_npm_flags.py` is a maintainer tool, not user-facing.
+
+## Dependencies & order
+
+1. `_is_host_enumerated` + `classify` change.
+2. Tests, including the two-fake-interface-sets case.
+3. `--verify` reporting.
+4. Regenerate the tables and confirm they are **byte-identical** to what is
+   committed — if the classification change alters any committed table, that is a
+   real finding and must be investigated before proceeding, not absorbed.
+
+## Verification
+
+```bash
+uv run python .consiliency/notes/derive_npm_flags.py --verify     # exit 0, prints exemptions
+uv run pytest -q tests/test_version_checker.py -k host_independent
+
+# The real test: simulate another machine. Monkeypatch the definitions so
+# local-address carries a DIFFERENT address set, and assert --verify still
+# passes and the committed tables are unchanged.
+uv run python - <<'PY'   # (spelled out in the test, this is the manual form)
+# ... patch definitions -> local-address type = [null, "10.0.0.5", "fe80::1"]
+# ... assert classify() == VALUE and no drift failure is emitted
+PY
+
+uv run pytest -q                      # full suite
+uv run ruff check . && uv run ruff format --check . && uv run mypy src/
+```
+
+Edge cases: a type with **only** `null` and addresses; a host with no network
+interfaces at all (the enumeration collapses to `[null]`); an IPv6 address with a
+zone suffix (`fe80::1%eth0`) — Python's `ipaddress` rejects the zone form, so the
+predicate must strip a `%…` suffix before parsing or it will miss link-local
+members and re-open the false positive.
+
+## Acceptance criteria
+
+- [ ] `--verify` exits 0 **and produces identical failure output** under two
+      different simulated interface sets — proven by running it twice with the
+      `local-address` type patched to different address lists, and diffing.
+      Running it once on this machine proves nothing, which is the whole bug.
+- [ ] `_is_host_enumerated` is False for `audit-level`, `lockfile-version` and
+      `loglevel` with their real member lists — so the exemption cannot silently
+      widen to fixed enumerations.
+- [ ] Regenerating the tables produces output **byte-identical** to the committed
+      `_NPM_VALUE_FLAGS` / `_NPM_BOOLEAN_FLAGS` / `_NPM_SKIP_FLAGS` /
+      `_NPM_NULLABLE_BOOLEAN_FLAGS`.
+- [ ] `--verify` **prints** every exempted flag with its reason; asserted by a
+      test on the output, not by reading the code.
+- [ ] Link-local members with a `%zone` suffix are still detected as host facts.
+
+## Non-goals
+
+- Changing what the committed tables contain. This fixes the *comparison*, not
+  the data.
+- Making the member lists themselves reproducible — they cannot be; they are
+  host facts by construction.
+
+## Execution Policy
+
+- execute: effort=low, reason=one predicate plus a reporting change in a
+  maintainer script; the subtlety is entirely in the test that simulates a
+  second machine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`derive_npm_flags.py --verify` no longer reports host-enumerated npm config
+  types as table drift.** The npm flag tables are the node-less fallback for
+  npm package identity, and `--verify` is what keeps them honest against a real
+  npm — but it was green on one machine and red on another with identical npm
+  and identical source. npm builds `local-address`'s declared `type` from
+  `os.networkInterfaces()`, so its 51 members here are facts about *this*
+  machine; and when `networkInterfaces()` throws, npm's `getLocalAddresses()`
+  catches it and returns exactly `[null]`, which the member rule stripped to
+  nothing and reported as `value: --local-address in table, absent from live
+  npm`. A drift check with false positives gets ignored, and an ignored check
+  is how real drift ships.
+
+  Detection now happens in the node script, the only place the raw members
+  still exist — the serializer maps every string member to `'<literal>'`, so no
+  Python-side predicate could tell 51 addresses from `loglevel`'s 8 fixed
+  words. It uses npm's own `typeDescription === 'IP Address'` label (the one
+  signal that survives the `[null]` case) with a `net.isIP` member scan as an
+  independent backstop, and `classify()` then returns `value` regardless of the
+  members. The flag is **not** exempted from the comparison: skipping it would
+  blind the check to a real arity change on the flag most likely to drift, so
+  `--verify` reports which flags it normalised instead — without printing the
+  member count, which is the host fact. The committed tables are unchanged;
+  this fixes the comparison, not the data. (#193)
+
 ## [2.6.0] - 2026-08-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   blind the check to a real arity change on the flag most likely to drift, so
   `--verify` reports which flags it normalised instead — without printing the
   member count, which is the host fact. The committed tables are unchanged;
-  this fixes the comparison, not the data. (#193)
+  this fixes the comparison, not the data.
+
+  **Scope, so the next red `--verify` is not waved off as another false
+  positive:** this makes the *comparison logic* host-independent, not the
+  tables' *freshness*. Version skew — tables derived from one npm, checked
+  against a newer one — still turns `--verify` red, correctly and by design.
+  That is the signal the check exists to produce. What is gone is only the
+  redness that two machines running the *same* npm could disagree about. A CI
+  test now also holds the recorded schema fixture and the committed tables to
+  each other, so regenerating one without the other cannot pass silently.
+  (#193)
 
 ## [2.6.0] - 2026-08-27
 

--- a/tests/fixtures/npm/schema.json
+++ b/tests/fixtures/npm/schema.json
@@ -1,5 +1,5 @@
 {
-  "_README": "RECORDED OUTPUT of read_schema() in .consiliency/notes/derive_npm_flags.py, captured against a real npm on a maintainer machine. CI has no npm and no node, so tests that would otherwise be maintainer-only mock read_schema() with this. Regenerate with: python3 .consiliency/notes/derive_npm_flags.py --record-schema tests/fixtures/npm/schema.json. Ignored by the generator, which reads only npm_version/definitions/shorthands/null_spellings. NOTE local-address's `type` here is this machine's address list reduced to '<literal>' labels; its LENGTH is a host fact and the tests patch it.",
+  "_README": "RECORDED OUTPUT of read_schema() in .consiliency/notes/derive_npm_flags.py, captured against a real npm on a maintainer machine. CI has no npm and no node, so tests that would otherwise be maintainer-only mock read_schema() with this. Regenerate with: python3 .consiliency/notes/derive_npm_flags.py --record-schema tests/fixtures/npm/schema.json. Ignored by the generator, which reads only npm_version/definitions/shorthands/null_spellings. NOTE local-address's `type` here is this machine's address list reduced to '<literal>' labels; its LENGTH is a host fact and the tests patch it. Its recorded PROBE keys are masked to <host-address> for the same reason: the node script probes with the type's first literal member, which for a host-enumerated flag is one of the recording machine's own addresses.",
   "definitions": {
     "_auth": {
       "hostEnumerated": false,
@@ -1362,7 +1362,7 @@
     "local-address": {
       "hostEnumerated": true,
       "probes": {
-        "127.0.0.1": true,
+        "<host-address>": true,
         "false": true,
         "null": true,
         "true": true,

--- a/tests/fixtures/npm/schema.json
+++ b/tests/fixtures/npm/schema.json
@@ -1,0 +1,3335 @@
+{
+  "_README": "RECORDED OUTPUT of read_schema() in .consiliency/notes/derive_npm_flags.py, captured against a real npm on a maintainer machine. CI has no npm and no node, so tests that would otherwise be maintainer-only mock read_schema() with this. Regenerate with: python3 .consiliency/notes/derive_npm_flags.py --record-schema tests/fixtures/npm/schema.json. Ignored by the generator, which reads only npm_version/definitions/shorthands/null_spellings. NOTE local-address's `type` here is this machine's address list reduced to '<literal>' labels; its LENGTH is a host fact and the tests patch it.",
+  "definitions": {
+    "_auth": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String"
+      ],
+      "typeDescription": "null or String"
+    },
+    "access": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "restricted": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "<literal>",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "null, \"restricted\", \"public\", or \"private\""
+    },
+    "all": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [
+        "a"
+      ],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "allow-directory": {
+      "hostEnumerated": false,
+      "probes": {
+        "all": true,
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "<literal>",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "\"all\", \"none\", or \"root\""
+    },
+    "allow-file": {
+      "hostEnumerated": false,
+      "probes": {
+        "all": true,
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "<literal>",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "\"all\", \"none\", or \"root\""
+    },
+    "allow-git": {
+      "hostEnumerated": false,
+      "probes": {
+        "all": true,
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "<literal>",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "\"all\", \"none\", or \"root\""
+    },
+    "allow-remote": {
+      "hostEnumerated": false,
+      "probes": {
+        "all": true,
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "<literal>",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "\"all\", \"none\", or \"root\""
+    },
+    "allow-same-version": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "allow-scripts": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String",
+        "Array"
+      ],
+      "typeDescription": "String (can be set multiple times)"
+    },
+    "allow-scripts-pending": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "allow-scripts-pin": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "also": {
+      "hostEnumerated": false,
+      "probes": {
+        "dev": true,
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "null, \"dev\", or \"development\""
+    },
+    "audit": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "audit-level": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "info": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "null, \"info\", \"low\", \"moderate\", \"high\", \"critical\", or \"none\""
+    },
+    "auth-type": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "legacy": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "\"legacy\" or \"web\""
+    },
+    "before": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "Date"
+      ],
+      "typeDescription": "null or Date"
+    },
+    "bin-links": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "browser": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "Boolean",
+        "String"
+      ],
+      "typeDescription": "null, Boolean, or String"
+    },
+    "bypass-2fa": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "ca": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String",
+        "Array"
+      ],
+      "typeDescription": "null or String (can be set multiple times)"
+    },
+    "cache": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "path"
+      ],
+      "typeDescription": "Path"
+    },
+    "cache-max": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Number"
+      ],
+      "typeDescription": "Number"
+    },
+    "cache-min": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Number"
+      ],
+      "typeDescription": "Number"
+    },
+    "cafile": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "path"
+      ],
+      "typeDescription": "Path"
+    },
+    "call": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [
+        "c"
+      ],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "cert": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String"
+      ],
+      "typeDescription": "null or String"
+    },
+    "cidr": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String",
+        "Array"
+      ],
+      "typeDescription": "null or String (can be set multiple times)"
+    },
+    "color": {
+      "hostEnumerated": false,
+      "probes": {
+        "always": true,
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "<literal>",
+        "Boolean"
+      ],
+      "typeDescription": "\"always\" or Boolean"
+    },
+    "commit-hooks": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "cpu": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String"
+      ],
+      "typeDescription": "null or String"
+    },
+    "dangerously-allow-all-scripts": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "depth": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "Number"
+      ],
+      "typeDescription": "null or Number"
+    },
+    "description": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "dev": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "diff": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String",
+        "Array"
+      ],
+      "typeDescription": "String (can be set multiple times)"
+    },
+    "diff-dst-prefix": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "diff-ignore-all-space": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "diff-name-only": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "diff-no-prefix": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "diff-src-prefix": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "diff-text": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "diff-unified": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Number"
+      ],
+      "typeDescription": "Number"
+    },
+    "dry-run": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "editor": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "engine-strict": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "expect-result-count": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "Number"
+      ],
+      "typeDescription": "null or Number"
+    },
+    "expect-results": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "null",
+        "Boolean"
+      ],
+      "typeDescription": "null or Boolean"
+    },
+    "expires": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "Number"
+      ],
+      "typeDescription": "null or Number"
+    },
+    "fetch-retries": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Number"
+      ],
+      "typeDescription": "Number"
+    },
+    "fetch-retry-factor": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Number"
+      ],
+      "typeDescription": "Number"
+    },
+    "fetch-retry-maxtimeout": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Number"
+      ],
+      "typeDescription": "Number"
+    },
+    "fetch-retry-mintimeout": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Number"
+      ],
+      "typeDescription": "Number"
+    },
+    "fetch-timeout": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Number"
+      ],
+      "typeDescription": "Number"
+    },
+    "force": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [
+        "f"
+      ],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "foreground-scripts": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "format-package-lock": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "fund": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "git": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "git-tag-version": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "global": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [
+        "g"
+      ],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "global-style": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "globalconfig": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "path"
+      ],
+      "typeDescription": "Path"
+    },
+    "heading": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "https-proxy": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "url"
+      ],
+      "typeDescription": "null or URL"
+    },
+    "if-present": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "ignore-scripts": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "include": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "prod": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Array",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "\"prod\", \"dev\", \"optional\", or \"peer\" (can be set multiple times)"
+    },
+    "include-attestations": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "include-staged": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "include-workspace-root": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "init-author-email": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "init-author-name": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "init-author-url": {
+      "hostEnumerated": false,
+      "probes": {
+        "": true,
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "<literal>",
+        "url"
+      ],
+      "typeDescription": "\"\" or URL"
+    },
+    "init-license": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "init-module": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "path"
+      ],
+      "typeDescription": "Path"
+    },
+    "init-private": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "init-type": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "init-version": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Semver"
+      ],
+      "typeDescription": "SemVer string"
+    },
+    "init.author.email": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "init.author.name": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "init.author.url": {
+      "hostEnumerated": false,
+      "probes": {
+        "": true,
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "<literal>",
+        "url"
+      ],
+      "typeDescription": "\"\" or URL"
+    },
+    "init.license": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "init.module": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "path"
+      ],
+      "typeDescription": "Path"
+    },
+    "init.version": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Semver"
+      ],
+      "typeDescription": "SemVer string"
+    },
+    "install-links": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "install-strategy": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "hoisted": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "\"hoisted\", \"nested\", \"shallow\", or \"linked\""
+    },
+    "json": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "key": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String"
+      ],
+      "typeDescription": "null or String"
+    },
+    "legacy-bundling": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "legacy-peer-deps": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "libc": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String"
+      ],
+      "typeDescription": "null or String"
+    },
+    "link": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "local-address": {
+      "hostEnumerated": true,
+      "probes": {
+        "127.0.0.1": true,
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "IP Address"
+    },
+    "location": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "global": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [
+        "L"
+      ],
+      "type": [
+        "<literal>",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "\"global\", \"user\", or \"project\""
+    },
+    "lockfile-version": {
+      "hostEnumerated": false,
+      "probes": {
+        "1": true,
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "null, 1, 2, 3, \"1\", \"2\", or \"3\""
+    },
+    "loglevel": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "silent": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "\"silent\", \"error\", \"warn\", \"notice\", \"http\", \"info\", \"verbose\", or \"silly\""
+    },
+    "logs-dir": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "path"
+      ],
+      "typeDescription": "null or Path"
+    },
+    "logs-max": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Number"
+      ],
+      "typeDescription": "Number"
+    },
+    "long": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [
+        "l"
+      ],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "maxsockets": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Number"
+      ],
+      "typeDescription": "Number"
+    },
+    "message": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [
+        "m"
+      ],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "min-release-age": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "Number"
+      ],
+      "typeDescription": "null or Number"
+    },
+    "min-release-age-exclude": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Array",
+        "String"
+      ],
+      "typeDescription": "String (can be set multiple times)"
+    },
+    "name": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String"
+      ],
+      "typeDescription": "null or String"
+    },
+    "node-gyp": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "path"
+      ],
+      "typeDescription": "Path"
+    },
+    "node-options": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String"
+      ],
+      "typeDescription": "null or String"
+    },
+    "noproxy": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String",
+        "Array"
+      ],
+      "typeDescription": "String (can be set multiple times)"
+    },
+    "offline": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "omit": {
+      "hostEnumerated": false,
+      "probes": {
+        "dev": true,
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Array",
+        "<literal>",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "\"dev\", \"optional\", or \"peer\" (can be set multiple times)"
+    },
+    "omit-lockfile-registry-resolved": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "only": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "prod": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "null, \"prod\", or \"production\""
+    },
+    "optional": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "null",
+        "Boolean"
+      ],
+      "typeDescription": "null or Boolean"
+    },
+    "orgs": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String",
+        "Array"
+      ],
+      "typeDescription": "null or String (can be set multiple times)"
+    },
+    "orgs-permission": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "read-only": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "<literal>",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "null, \"read-only\", \"read-write\", or \"no-access\""
+    },
+    "os": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String"
+      ],
+      "typeDescription": "null or String"
+    },
+    "otp": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String"
+      ],
+      "typeDescription": "null or String"
+    },
+    "pack-destination": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "package": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String",
+        "Array"
+      ],
+      "typeDescription": "String (can be set multiple times)"
+    },
+    "package-lock": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "package-lock-only": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "packages": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String",
+        "Array"
+      ],
+      "typeDescription": "null or String (can be set multiple times)"
+    },
+    "packages-all": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "packages-and-scopes-permission": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "read-only": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "<literal>",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "null, \"read-only\", \"read-write\", or \"no-access\""
+    },
+    "parseable": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [
+        "p"
+      ],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "password": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String"
+      ],
+      "typeDescription": "null or String"
+    },
+    "prefer-dedupe": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "prefer-offline": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "prefer-online": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "prefix": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [
+        "C"
+      ],
+      "type": [
+        "path"
+      ],
+      "typeDescription": "Path"
+    },
+    "preid": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "production": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "null",
+        "Boolean"
+      ],
+      "typeDescription": "null or Boolean"
+    },
+    "progress": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "provenance": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "provenance-file": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "path"
+      ],
+      "typeDescription": "Path"
+    },
+    "proxy": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "false",
+        "url"
+      ],
+      "typeDescription": "null, false, or URL"
+    },
+    "read-only": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "rebuild-bundle": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "registry": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "url"
+      ],
+      "typeDescription": "URL"
+    },
+    "replace-registry-host": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "npmjs": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "<literal>",
+        "<literal>",
+        "<literal>",
+        "String"
+      ],
+      "typeDescription": "\"npmjs\", \"never\", \"always\", or String"
+    },
+    "save": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [
+        "S"
+      ],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "save-bundle": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [
+        "B"
+      ],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "save-dev": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [
+        "D"
+      ],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "save-exact": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [
+        "E"
+      ],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "save-optional": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [
+        "O"
+      ],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "save-peer": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "save-prefix": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "save-prod": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [
+        "P"
+      ],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "sbom-format": {
+      "hostEnumerated": false,
+      "probes": {
+        "cyclonedx": true,
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "\"cyclonedx\" or \"spdx\""
+    },
+    "sbom-type": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "library": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "<literal>",
+        "<literal>",
+        "<literal>"
+      ],
+      "typeDescription": "\"library\", \"application\", or \"framework\""
+    },
+    "scope": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "scopes": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String",
+        "Array"
+      ],
+      "typeDescription": "null or String (can be set multiple times)"
+    },
+    "script-shell": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String"
+      ],
+      "typeDescription": "null or String"
+    },
+    "searchexclude": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "searchlimit": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Number"
+      ],
+      "typeDescription": "Number"
+    },
+    "searchopts": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "searchstaleness": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Number"
+      ],
+      "typeDescription": "Number"
+    },
+    "shell": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "shrinkwrap": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "sign-git-commit": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "sign-git-tag": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "strict-allow-scripts": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "strict-peer-deps": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "strict-ssl": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "tag": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "tag-version-prefix": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "timing": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "token-description": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "String"
+      ],
+      "typeDescription": "null or String"
+    },
+    "umask": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "Umask"
+      ],
+      "typeDescription": "Octal numeric string in range 0000..0777 (0..511)"
+    },
+    "unicode": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "update-notifier": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "usage": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [
+        "?",
+        "H",
+        "h"
+      ],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "user-agent": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "userconfig": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "path"
+      ],
+      "typeDescription": "Path"
+    },
+    "version": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [
+        "v"
+      ],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "versions": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "viewer": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "String"
+      ],
+      "typeDescription": "String"
+    },
+    "which": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [],
+      "type": [
+        "null",
+        "Number"
+      ],
+      "typeDescription": "null or Number"
+    },
+    "workspace": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": true
+      },
+      "short": [
+        "w"
+      ],
+      "type": [
+        "String",
+        "Array"
+      ],
+      "typeDescription": "String (can be set multiple times)"
+    },
+    "workspaces": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "null",
+        "Boolean"
+      ],
+      "typeDescription": "null or Boolean"
+    },
+    "workspaces-update": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": false,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [],
+      "type": [
+        "Boolean"
+      ],
+      "typeDescription": "Boolean"
+    },
+    "yes": {
+      "hostEnumerated": false,
+      "probes": {
+        "false": true,
+        "null": true,
+        "true": true,
+        "zzarbitrary": false
+      },
+      "short": [
+        "y"
+      ],
+      "type": [
+        "null",
+        "Boolean"
+      ],
+      "typeDescription": "null or Boolean"
+    }
+  },
+  "npm_version": "11.19.0",
+  "null_spellings": {
+    "--?": false,
+    "--B": false,
+    "--C": true,
+    "--D": false,
+    "--E": false,
+    "--H": false,
+    "--L": true,
+    "--O": false,
+    "--P": false,
+    "--S": false,
+    "--_auth": true,
+    "--a": false,
+    "--access": true,
+    "--all": false,
+    "--allow-directory": true,
+    "--allow-file": true,
+    "--allow-git": true,
+    "--allow-remote": true,
+    "--allow-same-version": false,
+    "--allow-scripts": true,
+    "--allow-scripts-pending": false,
+    "--allow-scripts-pin": false,
+    "--also": true,
+    "--audit": false,
+    "--audit-level": true,
+    "--auth-type": true,
+    "--before": true,
+    "--bin-links": false,
+    "--browser": true,
+    "--bypass-2fa": false,
+    "--c": true,
+    "--ca": true,
+    "--cache": true,
+    "--cache-max": true,
+    "--cache-min": true,
+    "--cafile": true,
+    "--call": true,
+    "--cert": true,
+    "--cidr": true,
+    "--color": false,
+    "--commit-hooks": false,
+    "--cpu": true,
+    "--d": false,
+    "--dangerously-allow-all-scripts": false,
+    "--dd": false,
+    "--ddd": false,
+    "--depth": true,
+    "--desc": false,
+    "--description": false,
+    "--dev": false,
+    "--diff": true,
+    "--diff-dst-prefix": true,
+    "--diff-ignore-all-space": false,
+    "--diff-name-only": false,
+    "--diff-no-prefix": false,
+    "--diff-src-prefix": true,
+    "--diff-text": false,
+    "--diff-unified": true,
+    "--dry-run": false,
+    "--editor": true,
+    "--engine-strict": false,
+    "--enjoy-by": true,
+    "--expect-result-count": true,
+    "--expect-results": true,
+    "--expires": true,
+    "--f": false,
+    "--fetch-retries": true,
+    "--fetch-retry-factor": true,
+    "--fetch-retry-maxtimeout": true,
+    "--fetch-retry-mintimeout": true,
+    "--fetch-timeout": true,
+    "--force": false,
+    "--foreground-scripts": false,
+    "--format-package-lock": false,
+    "--fund": false,
+    "--g": false,
+    "--git": true,
+    "--git-tag-version": false,
+    "--global": false,
+    "--global-style": false,
+    "--globalconfig": true,
+    "--h": false,
+    "--heading": true,
+    "--help": false,
+    "--https-proxy": true,
+    "--if-present": false,
+    "--ignore-scripts": false,
+    "--include": true,
+    "--include-attestations": false,
+    "--include-staged": false,
+    "--include-workspace-root": false,
+    "--init-author-email": true,
+    "--init-author-name": true,
+    "--init-author-url": true,
+    "--init-license": true,
+    "--init-module": true,
+    "--init-private": false,
+    "--init-type": true,
+    "--init-version": true,
+    "--init.author.email": true,
+    "--init.author.name": true,
+    "--init.author.url": true,
+    "--init.license": true,
+    "--init.module": true,
+    "--init.version": true,
+    "--install-links": false,
+    "--install-strategy": true,
+    "--iwr": false,
+    "--json": false,
+    "--key": true,
+    "--l": false,
+    "--legacy-bundling": false,
+    "--legacy-peer-deps": false,
+    "--libc": true,
+    "--link": false,
+    "--local": false,
+    "--local-address": true,
+    "--location": true,
+    "--lockfile-version": true,
+    "--loglevel": true,
+    "--logs-dir": true,
+    "--logs-max": true,
+    "--long": false,
+    "--m": true,
+    "--maxsockets": true,
+    "--message": true,
+    "--min-release-age": true,
+    "--min-release-age-exclude": true,
+    "--n": true,
+    "--name": true,
+    "--no": true,
+    "--no-_auth": true,
+    "--no-access": true,
+    "--no-all": false,
+    "--no-allow-directory": false,
+    "--no-allow-file": false,
+    "--no-allow-git": false,
+    "--no-allow-remote": false,
+    "--no-allow-same-version": false,
+    "--no-allow-scripts": true,
+    "--no-allow-scripts-pending": false,
+    "--no-allow-scripts-pin": false,
+    "--no-also": true,
+    "--no-audit": false,
+    "--no-audit-level": true,
+    "--no-auth-type": false,
+    "--no-before": true,
+    "--no-bin-links": false,
+    "--no-browser": true,
+    "--no-bypass-2fa": false,
+    "--no-ca": true,
+    "--no-cache": false,
+    "--no-cache-max": false,
+    "--no-cache-min": false,
+    "--no-cafile": false,
+    "--no-call": false,
+    "--no-cert": true,
+    "--no-cidr": true,
+    "--no-color": false,
+    "--no-commit-hooks": false,
+    "--no-cpu": true,
+    "--no-dangerously-allow-all-scripts": false,
+    "--no-depth": true,
+    "--no-description": false,
+    "--no-dev": false,
+    "--no-diff": true,
+    "--no-diff-dst-prefix": false,
+    "--no-diff-ignore-all-space": false,
+    "--no-diff-name-only": false,
+    "--no-diff-no-prefix": false,
+    "--no-diff-src-prefix": false,
+    "--no-diff-text": false,
+    "--no-diff-unified": false,
+    "--no-dry-run": false,
+    "--no-editor": false,
+    "--no-engine-strict": false,
+    "--no-expect-result-count": true,
+    "--no-expect-results": true,
+    "--no-expires": true,
+    "--no-fetch-retries": false,
+    "--no-fetch-retry-factor": false,
+    "--no-fetch-retry-maxtimeout": false,
+    "--no-fetch-retry-mintimeout": false,
+    "--no-fetch-timeout": false,
+    "--no-force": false,
+    "--no-foreground-scripts": false,
+    "--no-format-package-lock": false,
+    "--no-fund": false,
+    "--no-git": false,
+    "--no-git-tag-version": false,
+    "--no-global": false,
+    "--no-global-style": false,
+    "--no-globalconfig": false,
+    "--no-heading": false,
+    "--no-https-proxy": true,
+    "--no-if-present": false,
+    "--no-ignore-scripts": false,
+    "--no-include": false,
+    "--no-include-attestations": false,
+    "--no-include-staged": false,
+    "--no-include-workspace-root": false,
+    "--no-init-author-email": false,
+    "--no-init-author-name": false,
+    "--no-init-author-url": false,
+    "--no-init-license": false,
+    "--no-init-module": false,
+    "--no-init-private": false,
+    "--no-init-type": false,
+    "--no-init-version": false,
+    "--no-init.author.email": false,
+    "--no-init.author.name": false,
+    "--no-init.author.url": false,
+    "--no-init.license": false,
+    "--no-init.module": false,
+    "--no-init.version": false,
+    "--no-install-links": false,
+    "--no-install-strategy": false,
+    "--no-json": false,
+    "--no-key": true,
+    "--no-legacy-bundling": false,
+    "--no-legacy-peer-deps": false,
+    "--no-libc": true,
+    "--no-link": false,
+    "--no-local-address": true,
+    "--no-location": false,
+    "--no-lockfile-version": true,
+    "--no-loglevel": false,
+    "--no-logs-dir": true,
+    "--no-logs-max": false,
+    "--no-long": false,
+    "--no-maxsockets": false,
+    "--no-message": false,
+    "--no-min-release-age": true,
+    "--no-min-release-age-exclude": true,
+    "--no-name": true,
+    "--no-node-gyp": false,
+    "--no-node-options": true,
+    "--no-noproxy": true,
+    "--no-offline": false,
+    "--no-omit": false,
+    "--no-omit-lockfile-registry-resolved": false,
+    "--no-only": true,
+    "--no-optional": true,
+    "--no-orgs": true,
+    "--no-orgs-permission": true,
+    "--no-os": true,
+    "--no-otp": true,
+    "--no-pack-destination": false,
+    "--no-package": true,
+    "--no-package-lock": false,
+    "--no-package-lock-only": false,
+    "--no-packages": true,
+    "--no-packages-all": false,
+    "--no-packages-and-scopes-permission": true,
+    "--no-parseable": false,
+    "--no-password": true,
+    "--no-prefer-dedupe": false,
+    "--no-prefer-offline": false,
+    "--no-prefer-online": false,
+    "--no-prefix": false,
+    "--no-preid": false,
+    "--no-production": true,
+    "--no-progress": false,
+    "--no-provenance": false,
+    "--no-provenance-file": false,
+    "--no-proxy": true,
+    "--no-read-only": false,
+    "--no-rebuild-bundle": false,
+    "--no-registry": false,
+    "--no-replace-registry-host": true,
+    "--no-save": false,
+    "--no-save-bundle": false,
+    "--no-save-dev": false,
+    "--no-save-exact": false,
+    "--no-save-optional": false,
+    "--no-save-peer": false,
+    "--no-save-prefix": false,
+    "--no-save-prod": false,
+    "--no-sbom-format": false,
+    "--no-sbom-type": false,
+    "--no-scope": false,
+    "--no-scopes": true,
+    "--no-script-shell": true,
+    "--no-searchexclude": false,
+    "--no-searchlimit": false,
+    "--no-searchopts": false,
+    "--no-searchstaleness": false,
+    "--no-shell": false,
+    "--no-shrinkwrap": false,
+    "--no-sign-git-commit": false,
+    "--no-sign-git-tag": false,
+    "--no-strict-allow-scripts": false,
+    "--no-strict-peer-deps": false,
+    "--no-strict-ssl": false,
+    "--no-tag": false,
+    "--no-tag-version-prefix": false,
+    "--no-timing": false,
+    "--no-token-description": true,
+    "--no-umask": false,
+    "--no-unicode": false,
+    "--no-update-notifier": false,
+    "--no-usage": false,
+    "--no-user-agent": false,
+    "--no-userconfig": false,
+    "--no-version": false,
+    "--no-versions": false,
+    "--no-viewer": false,
+    "--no-which": true,
+    "--no-workspace": true,
+    "--no-workspaces": true,
+    "--no-workspaces-update": false,
+    "--no-yes": true,
+    "--node-gyp": true,
+    "--node-options": true,
+    "--noproxy": true,
+    "--offline": false,
+    "--omit": true,
+    "--omit-lockfile-registry-resolved": false,
+    "--only": true,
+    "--optional": true,
+    "--orgs": true,
+    "--orgs-permission": true,
+    "--os": true,
+    "--otp": true,
+    "--p": false,
+    "--pack-destination": true,
+    "--package": true,
+    "--package-lock": false,
+    "--package-lock-only": false,
+    "--packages": true,
+    "--packages-all": false,
+    "--packages-and-scopes-permission": true,
+    "--parseable": false,
+    "--password": true,
+    "--porcelain": false,
+    "--prefer-dedupe": false,
+    "--prefer-offline": false,
+    "--prefer-online": false,
+    "--prefix": true,
+    "--preid": true,
+    "--production": true,
+    "--progress": false,
+    "--provenance": false,
+    "--provenance-file": true,
+    "--proxy": true,
+    "--q": false,
+    "--quiet": false,
+    "--read-only": false,
+    "--readonly": false,
+    "--rebuild-bundle": false,
+    "--reg": true,
+    "--registry": true,
+    "--replace-registry-host": true,
+    "--s": false,
+    "--save": false,
+    "--save-bundle": false,
+    "--save-dev": false,
+    "--save-exact": false,
+    "--save-optional": false,
+    "--save-peer": false,
+    "--save-prefix": true,
+    "--save-prod": false,
+    "--sbom-format": true,
+    "--sbom-type": true,
+    "--scope": true,
+    "--scopes": true,
+    "--script-shell": true,
+    "--searchexclude": true,
+    "--searchlimit": true,
+    "--searchopts": true,
+    "--searchstaleness": true,
+    "--shell": true,
+    "--shrinkwrap": false,
+    "--sign-git-commit": false,
+    "--sign-git-tag": false,
+    "--silent": false,
+    "--strict-allow-scripts": false,
+    "--strict-peer-deps": false,
+    "--strict-ssl": false,
+    "--tag": true,
+    "--tag-version-prefix": true,
+    "--timing": false,
+    "--token-description": true,
+    "--umask": true,
+    "--unicode": false,
+    "--update-notifier": false,
+    "--usage": false,
+    "--user-agent": true,
+    "--userconfig": true,
+    "--v": false,
+    "--verbose": false,
+    "--version": false,
+    "--versions": false,
+    "--viewer": true,
+    "--w": true,
+    "--which": true,
+    "--workspace": true,
+    "--workspaces": true,
+    "--workspaces-update": false,
+    "--ws": true,
+    "--y": true,
+    "--yes": true,
+    "-?": false,
+    "-B": false,
+    "-C": true,
+    "-D": false,
+    "-E": false,
+    "-H": false,
+    "-L": true,
+    "-O": false,
+    "-P": false,
+    "-S": false,
+    "-a": false,
+    "-c": true,
+    "-d": false,
+    "-dd": false,
+    "-ddd": false,
+    "-desc": false,
+    "-enjoy-by": true,
+    "-f": false,
+    "-g": false,
+    "-h": false,
+    "-help": false,
+    "-iwr": false,
+    "-l": false,
+    "-local": false,
+    "-m": true,
+    "-n": true,
+    "-no": true,
+    "-p": false,
+    "-porcelain": false,
+    "-q": false,
+    "-quiet": false,
+    "-readonly": false,
+    "-reg": true,
+    "-s": false,
+    "-silent": false,
+    "-v": false,
+    "-verbose": false,
+    "-w": true,
+    "-ws": true,
+    "-y": true
+  },
+  "shorthands": {
+    "?": [
+      "--usage"
+    ],
+    "B": [
+      "--save-bundle"
+    ],
+    "C": [
+      "--prefix"
+    ],
+    "D": [
+      "--save-dev"
+    ],
+    "E": [
+      "--save-exact"
+    ],
+    "H": [
+      "--usage"
+    ],
+    "L": [
+      "--location"
+    ],
+    "O": [
+      "--save-optional"
+    ],
+    "P": [
+      "--save-prod"
+    ],
+    "S": [
+      "--save"
+    ],
+    "a": [
+      "--all"
+    ],
+    "c": [
+      "--call"
+    ],
+    "d": [
+      "--loglevel",
+      "info"
+    ],
+    "dd": [
+      "--loglevel",
+      "verbose"
+    ],
+    "ddd": [
+      "--loglevel",
+      "silly"
+    ],
+    "desc": [
+      "--description"
+    ],
+    "enjoy-by": [
+      "--before"
+    ],
+    "f": [
+      "--force"
+    ],
+    "g": [
+      "--global"
+    ],
+    "h": [
+      "--usage"
+    ],
+    "help": [
+      "--usage"
+    ],
+    "iwr": [
+      "--include-workspace-root"
+    ],
+    "l": [
+      "--long"
+    ],
+    "local": [
+      "--no-global"
+    ],
+    "m": [
+      "--message"
+    ],
+    "n": [
+      "--no-yes"
+    ],
+    "no": [
+      "--no-yes"
+    ],
+    "p": [
+      "--parseable"
+    ],
+    "porcelain": [
+      "--parseable"
+    ],
+    "q": [
+      "--loglevel",
+      "warn"
+    ],
+    "quiet": [
+      "--loglevel",
+      "warn"
+    ],
+    "readonly": [
+      "--read-only"
+    ],
+    "reg": [
+      "--registry"
+    ],
+    "s": [
+      "--loglevel",
+      "silent"
+    ],
+    "silent": [
+      "--loglevel",
+      "silent"
+    ],
+    "v": [
+      "--version"
+    ],
+    "verbose": [
+      "--loglevel",
+      "verbose"
+    ],
+    "w": [
+      "--workspace"
+    ],
+    "ws": [
+      "--workspaces"
+    ],
+    "y": [
+      "--yes"
+    ]
+  }
+}

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -4,6 +4,14 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import contextlib
+import copy
+import importlib.util
+import io
+import json
+import pathlib
+import sys
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -2821,3 +2829,240 @@ class TestOnlyNullableBooleansConsumeNull:
                 "-y",
             }
         )
+
+
+# ---------------------------------------------------------------------------
+# `.consiliency/notes/derive_npm_flags.py --verify` must not depend on the host
+# ---------------------------------------------------------------------------
+
+_TESTS_DIR = pathlib.Path(__file__).resolve().parent
+_REPO_ROOT = _TESTS_DIR.parent
+_GENERATOR = _REPO_ROOT / ".consiliency" / "notes" / "derive_npm_flags.py"
+
+# A RECORDED `read_schema()` from a real npm 11.19.0. CI has neither npm nor
+# node, so a test that shelled out would never run there -- and #193 is a bug
+# in a check that only ever ran on one maintainer's machine. Refresh with
+# `derive_npm_flags.py --record-schema tests/fixtures/npm/schema.json`.
+_SCHEMA_FIXTURE = _TESTS_DIR / "fixtures" / "npm" / "schema.json"
+
+
+def _load_generator() -> Any:
+    """Import the generator by path -- it is a maintainer script, not a module.
+
+    Same `spec_from_file_location` shape as tests/test_workflow_guards.py uses
+    for scripts/check_workflows.py.
+    """
+    spec = importlib.util.spec_from_file_location("derive_npm_flags", _GENERATOR)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+dnf = _load_generator()
+_NPM_SCHEMA = json.loads(_SCHEMA_FIXTURE.read_text())
+
+# The three shapes `local-address`'s declared type takes across machines. Every
+# string member is already `'<literal>'` by the time Python sees it -- the node
+# serializer maps it -- so the ONLY thing that varies host to host is how many
+# there are, and whether there are any at all.
+#
+# `["null"]` is not a synthetic edge case: npm's `getLocalAddresses()` catches a
+# `networkInterfaces()` throw and returns exactly `[null]`, and that host is the
+# one that filed #193. The member rule strips `null` and calls the remainder
+# UNINTERPRETABLE, which is the false drift report.
+_ENUMERATION_FAILED = ["null"]
+_ONE_ADDRESS = ["null", "<literal>"]
+_FIFTY_ADDRESSES = ["null"] + ["<literal>"] * 50
+
+
+def _no_npm() -> str:
+    """Tripwire: these tests must never reach a real npm."""
+    raise AssertionError(
+        "shelled out to npm -- this test would then be maintainer-only and "
+        "would never run in CI, which is the failure mode #193 is about"
+    )
+
+
+def _schema_with_local_address(type_labels: list[str]) -> dict:
+    """The recorded schema, with only the host-varying member list replaced."""
+    schema = copy.deepcopy(_NPM_SCHEMA)
+    schema["definitions"]["local-address"]["type"] = list(type_labels)
+    return schema
+
+
+def _write_tables(repo: pathlib.Path, schema: dict) -> pathlib.Path:
+    """Generate the four tables from `schema` into a stand-in version_checker."""
+    classes, nullable, *_ = dnf.build(schema)
+    source = repo / "src" / "pmcp" / "manifest" / "version_checker.py"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text(dnf.emit(classes, nullable))
+    return source
+
+
+def _run_verify(
+    monkeypatch: pytest.MonkeyPatch, repo: pathlib.Path, schema: dict
+) -> tuple[int, str]:
+    """Run `main() --verify` against `schema` and the tables under `repo`."""
+    monkeypatch.setattr(dnf, "REPO", repo)
+    monkeypatch.setattr(dnf, "read_schema", lambda: schema)
+    monkeypatch.setattr(dnf, "npm_root", _no_npm)
+    monkeypatch.setattr(sys, "argv", ["derive_npm_flags.py", "--verify"])
+    err = io.StringIO()
+    with contextlib.redirect_stderr(err), contextlib.redirect_stdout(io.StringIO()):
+        rc = dnf.main()
+    return rc, err.getvalue()
+
+
+class TestVerifyIsHostIndependent:
+    """#193: `--verify` was green on one machine and red on another.
+
+    npm builds `local-address`'s declared `type` from `os.networkInterfaces()`,
+    so its members are facts about the machine. Its CLASS is not: it consumes
+    the next token everywhere. A drift check with false positives gets ignored,
+    and an ignored check is how real drift ships.
+    """
+
+    @pytest.mark.parametrize(
+        "type_labels",
+        [_ENUMERATION_FAILED, _ONE_ADDRESS, _FIFTY_ADDRESSES],
+        ids=["enumeration-failed", "one-address", "fifty-addresses"],
+    )
+    def test_host_enumerated_is_value_whatever_the_host_reports(
+        self, type_labels: list[str]
+    ) -> None:
+        """VALUE for all three -- not merely equal to each other.
+
+        Comparing two non-empty address lists would pass against the unfixed
+        code, which already classifies those two identically. The bare `["null"]`
+        is the case that fails, and it is asserted here by name.
+        """
+        assert dnf.classify(type_labels, host_enumerated=True) == dnf.VALUE
+
+    def test_the_bug_is_the_enumeration_failing_not_a_different_address_set(
+        self,
+    ) -> None:
+        """Pins WHY a member-inspecting fix cannot work.
+
+        On the host that filed #193 there is no address to find: the member
+        rule sees `["null"]`, strips it, and reports UNINTERPRETABLE -- which
+        is the drift line that was reported. Two non-empty address lists, by
+        contrast, already agreed before this fix.
+        """
+        assert dnf.classify(_ENUMERATION_FAILED) == dnf.UNINTERPRETABLE
+        assert dnf.classify(_ONE_ADDRESS) == dnf.VALUE
+        assert dnf.classify(_FIFTY_ADDRESSES) == dnf.VALUE
+
+    def test_recorded_npm_marks_only_local_address_as_host_enumerated(self) -> None:
+        info = _NPM_SCHEMA["definitions"]["local-address"]
+        assert info["typeDescription"] == "IP Address"
+        assert info["hostEnumerated"] is True
+        assert dnf.host_enumerated_flags(_NPM_SCHEMA) == ["local-address"]
+
+    @pytest.mark.parametrize(
+        "name,type_description",
+        [
+            (
+                "audit-level",
+                'null, "info", "low", "moderate", "high", "critical", or "none"',
+            ),
+            (
+                "loglevel",
+                '"silent", "error", "warn", "notice", "http", "info", '
+                '"verbose", or "silly"',
+            ),
+            ("lockfile-version", 'null, 1, 2, 3, "1", "2", or "3"'),
+        ],
+    )
+    def test_fixed_enumerations_are_not_host_enumerated(
+        self, name: str, type_description: str
+    ) -> None:
+        """ "Many members" is not the signal; "members that are host facts" is.
+
+        These three are the only other definitions with more than six type
+        members, and they are byte-identical on every host. Asserted against
+        npm's REAL `typeDescription` strings, recorded in the fixture, so this
+        cannot drift into agreeing with a hand-written guess.
+        """
+        info = _NPM_SCHEMA["definitions"][name]
+        assert info["typeDescription"] == type_description
+        assert info["hostEnumerated"] is False
+        assert len(info["type"]) >= 7
+
+    def test_verify_is_byte_identical_across_host_address_counts(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The headline criterion: three hosts, one answer.
+
+        The committed tables are generated ONCE, from the unpatched recording,
+        and the same path is reused for all three runs -- `main()` prints the
+        source path, so a per-run tmpdir would defeat the comparison for the
+        wrong reason.
+        """
+        tables = _write_tables(tmp_path, _NPM_SCHEMA)
+        expected_tables = tables.read_text()
+
+        outputs: list[str] = []
+        for type_labels in (_ENUMERATION_FAILED, _ONE_ADDRESS, _FIFTY_ADDRESSES):
+            schema = _schema_with_local_address(type_labels)
+            rc, err = _run_verify(monkeypatch, tmp_path, schema)
+            assert rc == 0, err
+            outputs.append(err)
+
+            # Not just the report -- the emitted tables themselves must not
+            # move, or "no drift" would be true only of what we chose to print.
+            classes, nullable, *_ = dnf.build(schema)
+            assert dnf.emit(classes, nullable) == expected_tables
+
+        assert outputs[1] == outputs[0]
+        assert outputs[2] == outputs[0]
+
+    def test_verify_names_the_flag_it_normalised(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The exemption-shaped behaviour is reported, not hidden.
+
+        And the note carries no member COUNT: that is the host fact, and
+        printing it would put the #193 divergence straight back into the
+        output it is meant to have removed.
+        """
+        _write_tables(tmp_path, _NPM_SCHEMA)
+        rc, err = _run_verify(
+            monkeypatch, tmp_path, _schema_with_local_address(_ENUMERATION_FAILED)
+        )
+        assert rc == 0, err
+        assert "HOST-ENUMERATED type -> normalised to value, still verified (1):" in err
+        assert "  --local-address\n" in err
+        assert "51" not in err.split("nopt cross-check")[0].split("HOST-ENUMERATED")[1]
+
+    def test_local_address_is_still_in_the_comparison(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Normalising the class must not become exempting the flag.
+
+        An exemption would pass every test above -- no false positive can come
+        from a flag that is never compared -- while blinding the tool to a real
+        arity change on the flag most likely to drift. So: keep the recording
+        exactly as npm reported it, corrupt the LIVE classification of whatever
+        is host-enumerated to BOOLEAN, and require `--verify` to notice.
+
+        Patching the classification rather than the schema is what makes this
+        discriminating: a skip list keyed on `hostEnumerated` would still be
+        skipping this flag here, and would stay green.
+        """
+        _write_tables(tmp_path, _NPM_SCHEMA)
+        real_classify = dnf.classify
+
+        def misclassify(
+            type_labels: list[str], *, host_enumerated: bool = False
+        ) -> str:
+            if host_enumerated:
+                return dnf.BOOLEAN
+            return real_classify(type_labels, host_enumerated=False)
+
+        monkeypatch.setattr(dnf, "classify", misclassify)
+        rc, err = _run_verify(monkeypatch, tmp_path, copy.deepcopy(_NPM_SCHEMA))
+
+        assert rc == 1
+        assert "value: --local-address in table, absent from live npm" in err
+        assert "boolean: --local-address in live npm, MISSING from table" in err

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -3028,12 +3028,19 @@ class TestVerifyIsHostIndependent:
         """
         _write_tables(tmp_path, _NPM_SCHEMA)
         rc, err = _run_verify(
-            monkeypatch, tmp_path, _schema_with_local_address(_ENUMERATION_FAILED)
+            monkeypatch, tmp_path, _schema_with_local_address(_FIFTY_ADDRESSES)
         )
         assert rc == 0, err
         assert "HOST-ENUMERATED type -> normalised to value, still verified (1):" in err
         assert "  --local-address\n" in err
-        assert "51" not in err.split("nopt cross-check")[0].split("HOST-ENUMERATED")[1]
+
+        # Asserted on the FIFTY-address host on purpose: a count leak is only
+        # visible where the count is distinctive. `_ENUMERATION_FAILED` has one
+        # member, so "no 51 in the output" would hold there whatever the code
+        # did. The count that leaked would be 51 members, or 50 addresses.
+        section = err.split("HOST-ENUMERATED type")[1].split("\n\n")[0]
+        assert "51" not in section
+        assert "50" not in section
 
     def test_local_address_is_still_in_the_comparison(
         self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_version_checker.py
+++ b/tests/test_version_checker.py
@@ -3073,3 +3073,72 @@ class TestVerifyIsHostIndependent:
         assert rc == 1
         assert "value: --local-address in table, absent from live npm" in err
         assert "boolean: --local-address in live npm, MISSING from table" in err
+
+    def test_the_recording_still_agrees_with_the_committed_tables(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The fixture is an oracle, so something has to keep it honest.
+
+        Every test above mocks `read_schema()` with a recording of npm 11.19.0.
+        Nothing else in the suite notices if that recording goes stale -- so a
+        maintainer who regenerates the tables against a newer npm and forgets
+        to re-record would leave CI green forever against a frozen npm while
+        the real one had moved. This runs the REAL `--verify` path against the
+        REAL `src/pmcp/manifest/version_checker.py`, fed by the recording, and
+        goes red the moment the two stop describing the same npm.
+
+        What it deliberately does NOT do is make the tables version-proof.
+        Skew between the recorded npm and a live one is caught only by running
+        `--verify` against a live npm, and that redness is a real signal.
+        """
+        rc, err = _run_verify(monkeypatch, _REPO_ROOT, copy.deepcopy(_NPM_SCHEMA))
+        assert rc == 0, err
+        assert "match live npm" in err
+
+    def test_record_schema_reproduces_the_committed_fixture(
+        self, tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`--record-schema` generates the oracle, so it is tested too.
+
+        Round-tripping the committed fixture back through the recorder pins
+        three things at once: the CLI flag dispatches, the writer's exact
+        serialisation (indent, key order, trailing newline), and that nobody
+        hand-edited the fixture into a shape `--record-schema` would not
+        produce -- which would make the oracle a fiction.
+        """
+        recorded = {k: v for k, v in _NPM_SCHEMA.items() if k != "_README"}
+        monkeypatch.setattr(dnf, "read_schema", lambda: copy.deepcopy(recorded))
+        monkeypatch.setattr(dnf, "npm_root", _no_npm)
+        dest = tmp_path / "nested" / "schema.json"
+        monkeypatch.setattr(
+            sys, "argv", ["derive_npm_flags.py", "--record-schema", str(dest)]
+        )
+
+        with contextlib.redirect_stderr(io.StringIO()):
+            assert dnf.main() == 0
+
+        assert dest.read_text() == _SCHEMA_FIXTURE.read_text()
+
+    def test_recorded_probe_keys_carry_no_machine_address(self) -> None:
+        """A re-record on a laptop must not commit that laptop's LAN address.
+
+        The node script probes each definition with the first literal member of
+        its `type`, which for a host-enumerated flag is one of the recording
+        machine's own addresses. Masking the KEY keeps the fixture stable
+        across recording hosts; the probe RESULT is untouched, so the nopt
+        cross-check still reads real data.
+        """
+        info = _NPM_SCHEMA["definitions"]["local-address"]
+        assert dnf._MASKED_PROBE in info["probes"]
+        assert not any(dnf._is_ip_literal(probe) for probe in info["probes"])
+        # Fixed enumerations are not masked -- `loglevel` keeps its real
+        # `silent` probe, which is the member that reveals a conditional flag.
+        assert "silent" in _NPM_SCHEMA["definitions"]["loglevel"]["probes"]
+
+    def test_record_schema_without_a_path_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(dnf, "npm_root", _no_npm)
+        monkeypatch.setattr(sys, "argv", ["derive_npm_flags.py", "--record-schema"])
+        with pytest.raises(SystemExit, match="needs a destination path"):
+            dnf.main()


### PR DESCRIPTION
See #193.

## The bug

`.consiliency/notes/derive_npm_flags.py --verify` checks pmcp's committed npm
flag tables against live npm. Those tables are the node-less fallback for npm
package identity, which the freshness gate uses to decide whether a cached tool
description still describes the configured package.

It was **green on one machine and red on another** with identical npm and
identical source. npm builds `local-address`'s declared `type` from
`os.networkInterfaces()` — 51 members on the machine this was developed on, a
different set on the next one — so the members are facts about the host. The
classification is not: `--local-address` consumes the next token everywhere.

A drift check with false positives gets ignored, and an ignored check is how
real drift ships.

## Three things that make this harder than it looks

1. **A Python-side predicate cannot see the raw members.** `read_schema`'s
   node-side serializer maps every string or number member to the literal
   `'<literal>'`, so no real address ever reaches Python and nothing there can
   tell 51 machine addresses from `loglevel`'s 8 fixed words. Detection has to
   happen in the JavaScript.
2. **The failing host has `[null]`, not a different address list.** npm's
   `getLocalAddresses()` catches a `networkInterfaces()` failure and returns
   exactly `[null]` (`@npmcli/config/lib/definitions/definitions.js:65-71`).
   An IP-presence test cannot see that — there is no IP to find — and the
   member rule strips the `null` and returns UNINTERPRETABLE, which *is* the
   reported failure: `value: --local-address in table, absent from live npm`.
3. **"Many members" is not the signal.** The only other definitions with more
   than six type members — `audit-level` (7), `lockfile-version` (7),
   `loglevel` (8) — are fixed enumerations, byte-identical on every host.

## The fix

- **Node side** emits a per-definition `hostEnumerated`, computed where the raw
  type array is still intact, from npm's own `typeDescription === 'IP Address'`
  label — the one signal that survives the `[null]` case — with a `net.isIP()`
  scan over the raw members as an independent backstop for a future host-derived
  type npm does not label. Only `local-address` matches on npm 11.19.0.
- **`classify(..., host_enumerated=True)`** returns `value` regardless of the
  members, including the bare `[null]`.
- **No exemption.** `local-address` stays in the comparison; skipping it would
  blind the check to a real arity change on the flag most likely to drift.
  `--verify` reports which flags it *normalised* instead — and deliberately
  prints no member count, since that is the host fact whose divergence started
  this.

If npm ever renames the label *and* the enumeration fails on the same host,
detection stops and the flag falls back to member classification →
UNINTERPRETABLE → a loud red verify, not a silent wrong answer. That direction
is intentional and is written down in the module docstring.

## Tests

CI has neither npm nor node, so `--record-schema` freezes `read_schema()`'s
output from a real npm 11.19.0 into `tests/fixtures/npm/schema.json` and every
test mocks `read_schema()` against it, tripping an assertion if anything reaches
npm. A maintainer-only check is an unrun check — which is the shape of this bug.

- With `local-address`'s type patched to **`[null]`**, to one address, and to
  fifty, `classify` returns `value` in all three, the emitted tables are
  identical, and `--verify` exits 0 with byte-identical output.
- `hostEnumerated` is true for `local-address` and false for `audit-level`,
  `loglevel` and `lockfile-version`, asserted against npm's real
  `typeDescription` strings as recorded.
- `--verify` names the flag it normalised.
- `local-address` is proven **still in the comparison** by corrupting its live
  classification to `boolean` and requiring `--verify` to go red on the specific
  line.

Both directions verified RED before landing: with `classify` ignoring
`host_enumerated` the suite reproduces the reported failure exactly; with a
skip-list exemption — the trap this fix must not become — *only* the
still-in-the-comparison test fails, which is why that test corrupts the
classification rather than the schema.

## Verification

- `python3 .consiliency/notes/derive_npm_flags.py --verify` → exit 0, `OK: 118
  value + 198 boolean (18 of them nullable) + 16 skip entries match live npm
  11.19.0`
- Regenerating the four tables is **byte-identical** to what is committed
  (2768 / 4861 / 420 / 311 bytes). The committed tables are unchanged; this
  fixes the comparison, not the data.
- `pytest -q` → 3200 passed, 3 skipped
- `ruff check .` clean; `ruff format --check` clean on all changed files;
  `mypy src/` → no issues in 43 source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018W2e4mGLxCfQeKqQ1P6CPB

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790547578&installation_model_id=427051&pr_number=203&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F203&signature=d6948cfbaadf9bb3fae0c9d8d573c022116c9d59087e8d5ca454cc559831844d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->