### PR TITLE
fix(policy): an auto-discovered policy that parses must not fail open (#202)

### DIFF
--- a/.consiliency/plans/detailed-policy-fail-open-20260829-1200.md
+++ b/.consiliency/plans/detailed-policy-fail-open-20260829-1200.md
@@ -1,5 +1,12 @@
 # Detailed plan: an auto-discovered policy that is a policy must not fail open
 
+> **Revision 2 (2026-08-29).** Boarded 2 AGREE / 1 DISAGREE. The DISAGREE was
+> right and the two AGREEs endorsed the error: rev 1 classified a non-mapping
+> root as a *parse* failure, but a list, a scalar and an empty file all **parse
+> successfully** — they are only invalid against the object-shaped schema. That
+> contradicted rev 1's own rule and its own acceptance criterion, and left a
+> fail-open for a policy file that is accidentally a list.
+
 ## Task
 
 Close Consiliency/pmcp#202. A policy file at a default location that fails to load
@@ -13,6 +20,11 @@ is discarded, and the gateway falls back to `GatewayPolicy()` — which is
 | does not exist | no policy, silent | unchanged — legitimately "no policy" |
 | exists, cannot be parsed at all | warn, allow-all | **unchanged** — see below |
 | parses as a document, fails schema validation | warn, allow-all | **refuse to start** |
+
+"Parses as a document" means `yaml.safe_load`/`json.loads` returned **without
+raising** — including when it returns a list, a scalar, or `None` for an empty
+file. Verified: all three parse cleanly and differ from a valid policy only by
+failing the object schema. They therefore belong on the **fatal** side.
 
 ## Research summary
 
@@ -71,11 +83,20 @@ file" is legitimately silent.
 - `_load_policy` (`:59`) — modify — separate *parse* from *validate* so the
   caller can tell them apart. Read + parse in one `try`; `model_validate` in a
   second. On the auto-discovery path:
-  - parse failure (including `read_text` failure and the non-mapping root) →
-    warn and continue, exactly as today;
+  - parse failure — `read_text` raising, or the parser raising — → warn and
+    continue, exactly as today;
   - **validation failure → raise**, with a message naming the path and the
     validation error, distinct from the explicit-policy message so the two are
-    not confused in a log.
+    not confused in a log. **The non-mapping root check belongs here**, on the
+    fatal side, not with the parse failures.
+
+  **WAS WRONG (rev 1):** it put the non-mapping root with the parse failures.
+  Verified: `yaml.safe_load` returns a `list` for a list root, a `str` for a
+  scalar, and `None` for an empty file — all *without raising*. Classifying them
+  as parse failures contradicted this plan's own stated rule and its own
+  schema-invalid acceptance criterion, and would have left a policy file that is
+  accidentally a list still yielding allow-all. Two of three seats endorsed the
+  error; only the red-team seat caught it.
 - The `except` message (`:78`) — modify — the current warning says "Failed to
   load policy from …". Once the two cases diverge it must say which one happened
   and, for the surviving warn-path, state plainly that **no policy is in effect**.
@@ -89,10 +110,22 @@ file" is legitimately silent.
   (best-effort applies to *unparseable*, not to *invalid*), because the current
   name will otherwise assert something broader than the code does.
 
+### `README.md` (modify)
+
+Lines ~1337-1340 currently read: *"Best-effort fallback applies only to
+automatically discovered default locations when the operator did not request a
+policy."* That becomes **false** for schema-invalid files. Narrow it to say
+best-effort now covers only a file that cannot be parsed, and that a discovered
+file which parses but is not a valid policy terminates startup like an explicit
+one. Rev 1 said "modify only if it documents auto-discovery" — it does.
+
 ### `tests/test_policy_fail_open.py` (create)
 
 - A schema-invalid file at a default path → `PolicyManager()` **raises**, and the
   message names the path.
+- **A list root, a scalar root, and an empty file** at a default path each
+  → `PolicyManager()` **raises**. These are the cases rev 1 mislabelled; without
+  them the fix is not proven for the shapes most likely to occur by accident.
 - An unparseable file at a default path → does **not** raise, and the warning
   says no policy is in effect.
 - A **valid** file at a default path → loads, and a deny rule in it is actually
@@ -144,7 +177,10 @@ first is invalid and the second is valid — the loop `break`s at the first
 - [ ] A **schema-invalid** file at a default path makes `PolicyManager()` raise,
       and the error names the path. Proven by a test that fails against `main`.
 - [ ] An **unparseable** file at a default path still does not raise — the
-      existing tested intent, asserted by the original test's own case.
+      existing tested intent, asserted by the original test's own case. This
+      means a file the parser *rejects*, not one that parses to a non-mapping.
+- [ ] A **list root**, a **scalar root** and an **empty file** at a default path
+      each raise. Rev 1 would have let all three through.
 - [ ] A **valid** file at a default path still loads *and enforces*, proven by a
       deny rule actually denying. A change that refuses everything must not pass.
 - [ ] `Path.cwd()` is read at construction: `chdir` after import into a directory
@@ -164,6 +200,12 @@ first is invalid and the second is valid — the loop `break`s at the first
   at all; that is not in question here.
 - Auditing other fail-open fallbacks elsewhere in the codebase. If any exist they
   deserve their own issue rather than being swept in.
+- Updating the comments that currently describe the old behaviour
+  (`types.py:957-970`, `client/manager.py:2174-2177`,
+  `test_client_manager.py:6076-6083`). They become inaccurate once validation is
+  fatal, and — worth recording — **`Field(ge=1)` on `max_tools_per_server`
+  becomes safe to add after this change**, which is the #175 item that had to be
+  dropped. Both belong in a follow-up so this diff stays on one subject.
 
 ## Execution Policy
 

--- a/.consiliency/plans/detailed-policy-fail-open-20260829-1200.md
+++ b/.consiliency/plans/detailed-policy-fail-open-20260829-1200.md
@@ -1,0 +1,171 @@
+# Detailed plan: an auto-discovered policy that is a policy must not fail open
+
+## Task
+
+Close Consiliency/pmcp#202. A policy file at a default location that fails to load
+is discarded, and the gateway falls back to `GatewayPolicy()` — which is
+**allow-all**. Allow/deny lists, limits and redaction all revert to permissive.
+
+**The fix splits by failure mode**, because the two are not the same event:
+
+| the file… | today | after |
+|---|---|---|
+| does not exist | no policy, silent | unchanged — legitimately "no policy" |
+| exists, cannot be parsed at all | warn, allow-all | **unchanged** — see below |
+| parses as a document, fails schema validation | warn, allow-all | **refuse to start** |
+
+## Research summary
+
+Verified in this worktree.
+
+**The fallback is `GatewayPolicy()`, and it is allow-all.** Every field is a
+`default_factory` (`types.py:988-999`), so a discarded policy is not a partial
+policy — it is no policy.
+
+**`_load_policy` (`policy/policy.py:59-78`) has one `try` covering three distinct
+failures**: `read_text`, the YAML/JSON parse, and `GatewayPolicy.model_validate`.
+Only `fatal` distinguishes the caller, not the failure. The split below needs the
+parse boundary made explicit — it already exists in the code's structure, it is
+simply not observable to the caller.
+
+**`fatal=False` appears exactly once in `src/`** (`policy.py:54`), inside the
+auto-discovery loop, which `break`s at the first existing path. Explicit
+`--policy` uses `fatal=True` and raises correctly. Four constructors pass a
+possibly-`None` path (`server.py:146`, `cli.py:874`, `:1135`, `:2433`), so
+auto-discovery is the common path in practice.
+
+**The current behaviour is deliberate and pinned by a test.**
+`test_scoped_advisor_audit.py:87`,
+`test_explicit_policy_failures_are_fatal_but_default_discovery_is_best_effort`
+(added in `5ec4545`), asserts all three failure modes are fatal for `--policy`
+and that a **malformed — i.e. unparseable — file** (`"{"`) at a default path
+falls back with `is_gateway_tool_allowed("gateway.provision") is True`.
+
+That is why this plan does **not** simply make everything fatal. A file that
+cannot be parsed at all could be anything — a half-written file, an unrelated
+`.json` someone dropped at the repo root, a merge conflict. A file that parses as
+a mapping but fails `GatewayPolicy` validation is unmistakably *a policy with a
+mistake in it*, and that is the case where falling back to allow-all is
+indefensible. The existing test's intent is preserved exactly; only the case it
+does not cover changes.
+
+**`DEFAULT_POLICY_PATHS` is built at import time** (`policy.py:31-36`), so its two
+`Path.cwd()` entries freeze the working directory as of module import rather than
+`PolicyManager()` construction. That reaches the same unrestricted state by a
+different road — and **that road has no warning at all**, because "no policy
+file" is legitimately silent.
+
+## Changes
+
+### `src/pmcp/policy/policy.py` (modify)
+
+- `DEFAULT_POLICY_PATHS` (`:31`) — modify — replace the module-level list with
+  `_default_policy_paths()` evaluated at construction, so `Path.cwd()` is read
+  when the manager is built. Keep the name exported as a function or keep a
+  module-level constant for the two `Path.home()` entries; the two `cwd` entries
+  are the ones that must move.
+  **Compatibility note:** `test_scoped_advisor_audit.py:104` monkeypatches
+  `pmcp.policy.policy.DEFAULT_POLICY_PATHS`. Whatever shape is chosen must keep
+  that patch point working, or that test must be updated in the same change —
+  silently breaking a test's seam is how a guard stops guarding.
+- `_load_policy` (`:59`) — modify — separate *parse* from *validate* so the
+  caller can tell them apart. Read + parse in one `try`; `model_validate` in a
+  second. On the auto-discovery path:
+  - parse failure (including `read_text` failure and the non-mapping root) →
+    warn and continue, exactly as today;
+  - **validation failure → raise**, with a message naming the path and the
+    validation error, distinct from the explicit-policy message so the two are
+    not confused in a log.
+- The `except` message (`:78`) — modify — the current warning says "Failed to
+  load policy from …". Once the two cases diverge it must say which one happened
+  and, for the surviving warn-path, state plainly that **no policy is in effect**.
+  A reader of that line today cannot tell that the gateway is now unrestricted.
+
+### `tests/test_scoped_advisor_audit.py` (modify)
+
+- `test_explicit_policy_failures_are_fatal_but_default_discovery_is_best_effort`
+  — modify — keep its unparseable-file case asserting the fallback, since that
+  intent is preserved. Rename it so the name states the new, narrower rule
+  (best-effort applies to *unparseable*, not to *invalid*), because the current
+  name will otherwise assert something broader than the code does.
+
+### `tests/test_policy_fail_open.py` (create)
+
+- A schema-invalid file at a default path → `PolicyManager()` **raises**, and the
+  message names the path.
+- An unparseable file at a default path → does **not** raise, and the warning
+  says no policy is in effect.
+- A **valid** file at a default path → loads, and a deny rule in it is actually
+  enforced. Without this the suite cannot tell "refused correctly" from "refused
+  everything".
+- No file at any default path → no raise, no warning (unchanged).
+- `Path.cwd()` is honoured at **construction**: `chdir` into a directory
+  containing a valid policy after import, construct, and assert the policy
+  applies. This test must fail against `main`.
+- The explicit `--policy` path still raises for all three modes (unchanged).
+
+## Documentation impact
+
+- `CHANGELOG.md` — add — `### Changed`, not `### Fixed`: a gateway that starts
+  today can refuse to start after this. Name the exact condition (an
+  auto-discovered file that parses but fails validation) and say that an
+  unparseable file still warns and continues.
+- `README.md` — modify **only if** it documents policy auto-discovery; check
+  before editing.
+
+## Dependencies & order
+
+1. The cwd fix first — it is independent, and doing it first means the
+   discovery-path tests are written against the corrected path resolution.
+2. The parse/validate split.
+3. Tests, including the must-fail-on-`main` cwd test.
+4. CHANGELOG.
+
+## Verification
+
+```bash
+uv run pytest -q tests/test_policy_fail_open.py tests/test_scoped_advisor_audit.py
+uv run pytest -q
+uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/
+
+# The cwd test must fail against main -- prove it rather than assume:
+#   stash nothing; run the new test with PYTHONPATH pointed at a clean
+#   `git archive` export of main, expect RED, then against this branch, GREEN.
+```
+
+Edge cases: a default path that exists but is unreadable (permissions); a YAML
+file whose root is a list; an empty file (`yaml.safe_load` → `None`); a file
+whose suffix is `.json` but whose content is YAML; two default paths where the
+first is invalid and the second is valid — the loop `break`s at the first
+*existing* path, so the second is never reached, and that should stay true.
+
+## Acceptance criteria
+
+- [ ] A **schema-invalid** file at a default path makes `PolicyManager()` raise,
+      and the error names the path. Proven by a test that fails against `main`.
+- [ ] An **unparseable** file at a default path still does not raise — the
+      existing tested intent, asserted by the original test's own case.
+- [ ] A **valid** file at a default path still loads *and enforces*, proven by a
+      deny rule actually denying. A change that refuses everything must not pass.
+- [ ] `Path.cwd()` is read at construction: `chdir` after import into a directory
+      holding a valid policy, construct, and the policy applies. **This test must
+      be shown RED against `main`** — the import-time freeze is invisible to any
+      test that does not chdir between import and construction.
+- [ ] The surviving warn-path message states that **no policy is in effect**;
+      asserted on the emitted text, not on the log level alone.
+- [ ] `pmcp.policy.policy.DEFAULT_POLICY_PATHS` remains monkeypatchable, or
+      `test_scoped_advisor_audit.py:104` is updated in the same change.
+- [ ] Full suite green.
+
+## Non-goals
+
+- Changing explicit `--policy` behaviour. It already raises on all three modes.
+- A policy *merge* or partial-application model. A policy is applied whole or not
+  at all; that is not in question here.
+- Auditing other fail-open fallbacks elsewhere in the codebase. If any exist they
+  deserve their own issue rather than being swept in.
+
+## Execution Policy
+
+- execute: effort=medium, reason=small diff on a security control, where the
+  risk is a change that refuses too much rather than too little

--- a/.consiliency/plans/detailed-policy-fail-open-20260829-1200.md
+++ b/.consiliency/plans/detailed-policy-fail-open-20260829-1200.md
@@ -143,8 +143,8 @@ one. Rev 1 said "modify only if it documents auto-discovery" — it does.
   today can refuse to start after this. Name the exact condition (an
   auto-discovered file that parses but fails validation) and say that an
   unparseable file still warns and continues.
-- `README.md` — modify **only if** it documents policy auto-discovery; check
-  before editing.
+- `README.md` — modify — see the dedicated section above. It **does** document
+  the best-effort fallback (~:1337-1340) and that sentence becomes false.
 
 ## Dependencies & order
 
@@ -166,11 +166,14 @@ uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv ru
 #   `git archive` export of main, expect RED, then against this branch, GREEN.
 ```
 
-Edge cases: a default path that exists but is unreadable (permissions); a YAML
-file whose root is a list; an empty file (`yaml.safe_load` → `None`); a file
-whose suffix is `.json` but whose content is YAML; two default paths where the
-first is invalid and the second is valid — the loop `break`s at the first
-*existing* path, so the second is never reached, and that should stay true.
+Edge cases: a default path that exists but is unreadable (permissions — a
+`read_text` raise, so warn-path); a file whose suffix is `.json` but whose
+content is YAML; two default paths where the first is invalid and the second is
+valid — the loop `break`s at the first *existing* path, so the second is never
+reached, and **that stays true**: an invalid file at the higher-priority path
+must fail closed rather than silently falling through to a lower-priority
+policy. (List roots, scalar roots and empty files are no longer edge cases here —
+they are first-class fatal cases with their own acceptance criterion.)
 
 ## Acceptance criteria
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   previously survived the whole of `tests/test_client_manager.py`. (#175)
 
 ### Changed
+- **A policy file found by auto-discovery that parses but is not a valid policy
+  now terminates startup instead of being discarded.** This can stop a gateway
+  that starts today, and that is the point: the discarded policy was replaced by
+  the default `GatewayPolicy()`, and that default is **allow-all** — every field
+  is a `default_factory`, so a policy with one mistake in it did not degrade to a
+  partial policy, it degraded to no policy. Allow/deny lists, limits and
+  redaction all silently reverted to permissive behind a single warning line that
+  did not say so. The condition is exact: the file exists, `yaml.safe_load` /
+  `json.loads` returned **without raising**, and the result is not a valid
+  `GatewayPolicy` — which includes a list root, a scalar root and an empty YAML
+  file, all of which parse cleanly and fail only the object schema. A file the
+  parser *rejects*, or one that cannot be read at all, still warns and continues
+  as before: it could be a half-written file, an unrelated `.json` at the repo
+  root, or a merge conflict, and that fallback is deliberate. The surviving
+  warning now states plainly that no policy is in effect. Explicit `--policy` /
+  `PMCP_POLICY` is unchanged — it was already fatal for every mode. (#202)
+- **The default policy search paths now follow the working directory.** The two
+  project-local entries in `DEFAULT_POLICY_PATHS` were joined with `Path.cwd()`
+  at module import, freezing the directory as of first import; a gateway that
+  changed directory before constructing its `PolicyManager` looked for a policy
+  somewhere else, found none, and ran unrestricted — by that road with no warning
+  at all, since "no policy file" is legitimately silent. They are resolved at
+  construction now. The module attribute remains patchable for tests, and
+  absolute entries pass through unchanged. (#202)
 - **A downstream tool that declares no `inputSchema` is now skipped instead of
   indexed.** This is a behaviour change, and the only one in this set. The
   indexer used to substitute `{}` for a missing `inputSchema` — and `{}` is not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,9 +104,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unparseable" — blaming the downstream for a decision the gateway's own policy
   file made. Both that message and the parser's truncation warning now name the
   limit. Deliberately *not* fixed by adding a schema bound: `LimitsPolicy` still
-  accepts `0`, because policy auto-discovery swallows validation errors and
-  falls back to an allow-all default, so rejecting the value would silently
-  discard the operator's entire policy file (#202). (#175)
+  accepts `0`, because at the time policy auto-discovery swallowed validation
+  errors and fell back to an allow-all default, so rejecting the value would
+  have silently discarded the operator's entire policy file. #202 — see the
+  entry above, which ships in this same release — has since made that case
+  fatal, so `Field(ge=1)` is now safe to add; it is left to a follow-up rather
+  than folded in here. (#175)
 
 ## [2.6.0] - 2026-08-27
 

--- a/README.md
+++ b/README.md
@@ -1340,13 +1340,20 @@ startup.
 
 An automatically discovered policy at a default location is fail-closed too,
 with one deliberate exception. A discovered file that **parses but is not a valid
-policy** — including a list root, a scalar root, or an empty file, all of which
-parse cleanly and fail only the schema — terminates startup exactly like an
-explicit one, because falling back would replace it with the default allow-all
-policy and silently unrestrict the gateway. Best-effort fallback now covers only
-a file that cannot be read or cannot be parsed at all, which could be anything
-rather than a policy; that case warns, says that no policy is in effect, and
-continues.
+policy** terminates startup exactly like an explicit one, because falling back
+would replace it with the default allow-all policy and silently unrestrict the
+gateway. Best-effort fallback now covers only a file that cannot be read, or that
+the parser **rejects outright** — which could be anything rather than a policy;
+that case warns, says that no policy is in effect, and continues.
+
+The line between the two is drawn by the parser, not by the file's shape, so it
+falls in different places for the two formats. In a `.yaml` file a list root, a
+scalar root and an **empty file** all load cleanly — `yaml.safe_load` returns a
+`list`, a `str` and `None` — and so all three are fatal. In a `.json` file, a
+document whose root is valid JSON but not an object (`[]`, `42`, `null`) is
+likewise fatal, but an **empty `.json` file is not valid JSON at all**, so it
+takes the warn-and-continue path. If you are testing this behaviour, use an empty
+`.yaml` file to see the refusal.
 
 #### Scoped advisor research
 

--- a/README.md
+++ b/README.md
@@ -1336,8 +1336,17 @@ redaction:
 
 An explicitly requested policy (`--policy` or `PMCP_POLICY`) is a fail-closed
 boundary: a missing, unreadable, malformed, or schema-invalid file terminates
-startup. Best-effort fallback applies only to automatically discovered default
-locations when the operator did not request a policy.
+startup.
+
+An automatically discovered policy at a default location is fail-closed too,
+with one deliberate exception. A discovered file that **parses but is not a valid
+policy** — including a list root, a scalar root, or an empty file, all of which
+parse cleanly and fail only the schema — terminates startup exactly like an
+explicit one, because falling back would replace it with the default allow-all
+policy and silently unrestrict the gateway. Best-effort fallback now covers only
+a file that cannot be read or cannot be parsed at all, which could be anything
+rather than a policy; that case warns, says that no policy is in effect, and
+continues.
 
 #### Scoped advisor research
 

--- a/src/pmcp/policy/policy.py
+++ b/src/pmcp/policy/policy.py
@@ -77,7 +77,26 @@ class PolicyManager:
         self._compile_redaction_patterns()
 
     def _load_policy(self, policy_path: Path, *, fatal: bool) -> None:
-        """Load policy from file."""
+        """Load policy from file.
+
+        Reading/parsing and validating are separate steps because an
+        auto-discovered policy treats them differently (Consiliency/pmcp#202):
+
+        * a file that cannot be read, or that the parser *rejects*, could be
+          anything -- a half-written file, an unrelated ``.json`` dropped at the
+          repo root, a merge conflict. That warns and continues, which is the
+          long-standing deliberate behaviour.
+        * a file that parses without raising but is not a valid policy is
+          unmistakably *a policy with a mistake in it*. Falling back to
+          ``GatewayPolicy()`` there is indefensible -- that default is allow-all,
+          so a restrictive policy on disk would stop applying. That refuses to
+          start.
+
+        Note that "parses without raising" includes a list root, a scalar root
+        and an empty YAML file: ``yaml.safe_load`` returns ``list``, ``str`` and
+        ``None`` for those without raising. They are schema-invalid, not
+        unparseable, so they are fatal.
+        """
         try:
             content = policy_path.read_text()
 
@@ -85,17 +104,35 @@ class PolicyManager:
                 data = yaml.safe_load(content)
             else:
                 data = json.loads(content)
-
-            if not isinstance(data, dict):
-                raise ValueError("policy root must be an object")
-            self._policy = GatewayPolicy.model_validate(data)
-            logger.info(f"Loaded policy from {policy_path}")
         except Exception as e:
             if fatal:
                 raise ValueError(
                     f"Failed to load explicit policy {policy_path}: {e}"
                 ) from e
-            logger.warning(f"Failed to load policy from {policy_path}: {e}")
+            logger.warning(
+                f"Could not parse policy file {policy_path}: {e}. "
+                "No policy is in effect: the gateway is running unrestricted."
+            )
+            return
+
+        try:
+            if not isinstance(data, dict):
+                raise ValueError(
+                    f"policy root must be an object, got {type(data).__name__}"
+                )
+            policy = GatewayPolicy.model_validate(data)
+        except Exception as e:
+            if fatal:
+                raise ValueError(
+                    f"Failed to load explicit policy {policy_path}: {e}"
+                ) from e
+            raise ValueError(
+                f"Invalid policy file {policy_path}: {e}. "
+                "Refusing to start rather than fall back to an unrestricted gateway."
+            ) from e
+
+        self._policy = policy
+        logger.info(f"Loaded policy from {policy_path}")
 
     def _compile_redaction_patterns(self) -> None:
         """Compile redaction regex patterns."""

--- a/src/pmcp/policy/policy.py
+++ b/src/pmcp/policy/policy.py
@@ -28,12 +28,32 @@ DEFAULT_REDACTION_PATTERNS = [
     r"\bgithub_pat_[A-Za-z0-9_]{10,}\b",
 ]
 
+# Search order for an auto-discovered policy. The project-local entries are kept
+# RELATIVE on purpose: they are resolved against `Path.cwd()` when a
+# `PolicyManager` is constructed, not when this module is imported. Storing them
+# pre-joined froze the working directory as of import, so a gateway that changed
+# directory before constructing its manager looked for a policy in the wrong
+# place and silently found none -- an unrestricted gateway with no warning at all
+# (Consiliency/pmcp#202).
+#
+# The list stays a module attribute so `monkeypatch.setattr` on
+# `pmcp.policy.policy.DEFAULT_POLICY_PATHS` remains a working test seam; absolute
+# entries pass through the resolver unchanged.
 DEFAULT_POLICY_PATHS = [
-    Path.cwd() / ".mcp-gateway-policy.yaml",
-    Path.cwd() / ".mcp-gateway-policy.json",
+    Path(".mcp-gateway-policy.yaml"),
+    Path(".mcp-gateway-policy.json"),
     Path.home() / ".claude" / "gateway-policy.yaml",
     Path.home() / ".claude" / "gateway-policy.json",
 ]
+
+
+def _default_policy_paths() -> list[Path]:
+    """Resolve `DEFAULT_POLICY_PATHS` against the *current* working directory.
+
+    Read the module attribute at call time so a monkeypatched list is honoured.
+    """
+    cwd = Path.cwd()
+    return [path if path.is_absolute() else cwd / path for path in DEFAULT_POLICY_PATHS]
 
 
 class PolicyManager:
@@ -49,7 +69,7 @@ class PolicyManager:
             self._load_policy(policy_path, fatal=True)
         else:
             # Try default locations
-            for default_path in DEFAULT_POLICY_PATHS:
+            for default_path in _default_policy_paths():
                 if default_path.exists():
                     self._load_policy(default_path, fatal=False)
                     break

--- a/tests/test_policy_fail_open.py
+++ b/tests/test_policy_fail_open.py
@@ -1,0 +1,268 @@
+"""An auto-discovered policy that parses must not fail open (Consiliency/pmcp#202).
+
+`PolicyManager` starts from `GatewayPolicy()`, and that default is **allow-all**:
+every field is a `default_factory`, so a discarded policy is not a partial policy
+-- it is no policy. Discarding a policy file therefore silently unrestricts the
+gateway.
+
+These tests pin the split the fix introduces, by *failure mode* rather than by
+file shape:
+
+* the file does not exist          -> no policy, silent (unchanged)
+* the parser **raises**            -> warn and continue (unchanged, deliberate;
+  `tests/test_scoped_advisor_audit.py` pins that case from the other side)
+* it **parses** but is not a valid policy -> refuse to start
+
+A list root, a scalar root and an empty YAML file are the third case, not the
+second: `yaml.safe_load` returns `list`, `str` and `None` for them *without
+raising*. They are the shapes an accidental policy file most often takes, and
+they are exactly what an earlier revision of the fix would have let through.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from pmcp.policy.policy import PolicyManager
+
+# A policy whose effect is observable: `deny-me` must actually be denied. Without
+# asserting enforcement, a change that refuses *everything* would pass this file.
+_VALID_POLICY = {
+    "servers": {"denylist": ["deny-me"]},
+    "limits": {"max_tools_per_server": 7},
+}
+
+
+def _discovery_paths(monkeypatch: pytest.MonkeyPatch, *paths: Path) -> None:
+    """Point auto-discovery at `paths` and nothing else."""
+    monkeypatch.setattr("pmcp.policy.policy.DEFAULT_POLICY_PATHS", list(paths))
+
+
+def _is_readable(path: Path) -> bool:
+    try:
+        path.read_text()
+    except OSError:
+        return False
+    return True
+
+
+# === parses, but is not a valid policy -> fatal ===
+
+
+def test_schema_invalid_discovered_policy_refuses_to_start(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The bug itself: valid JSON, invalid policy, previously -> allow-all."""
+    policy_file = tmp_path / ".mcp-gateway-policy.json"
+    policy_file.write_text(json.dumps({"gateway_tools": {"unknown": []}}))
+    _discovery_paths(monkeypatch, policy_file)
+
+    with pytest.raises(ValueError, match="Invalid policy file") as excinfo:
+        PolicyManager()
+
+    # The error must name the offending path, and must not be mistaken for the
+    # explicit-`--policy` failure, which is a different event with its own text.
+    assert str(policy_file) in str(excinfo.value)
+    assert "explicit policy" not in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("label", "content"),
+    [
+        # `yaml.safe_load` returns list / str / None for these -- no exception.
+        ("list root", "- gateway.health\n- gateway.invoke\n"),
+        ("scalar root", "gateway.health\n"),
+        ("empty file", ""),
+    ],
+)
+def test_non_mapping_discovered_policy_refuses_to_start(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, label: str, content: str
+) -> None:
+    policy_file = tmp_path / ".mcp-gateway-policy.yaml"
+    policy_file.write_text(content)
+    _discovery_paths(monkeypatch, policy_file)
+
+    with pytest.raises(ValueError, match="policy root must be an object") as excinfo:
+        PolicyManager()
+    assert str(policy_file) in str(excinfo.value), label
+
+
+def test_json_non_mapping_root_refuses_to_start(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`json.loads("[]")` parses; only the schema rejects it."""
+    policy_file = tmp_path / ".mcp-gateway-policy.json"
+    policy_file.write_text("[]")
+    _discovery_paths(monkeypatch, policy_file)
+
+    with pytest.raises(ValueError, match="policy root must be an object"):
+        PolicyManager()
+
+
+def test_higher_priority_invalid_policy_does_not_fall_through(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Discovery `break`s at the first *existing* path -- and stays that way.
+
+    An invalid file at the higher-priority path must fail closed rather than
+    silently hand control to a lower-priority policy.
+    """
+    first = tmp_path / ".mcp-gateway-policy.yaml"
+    first.write_text("servers:\n  denylist: not-a-list\n")
+    second = tmp_path / ".mcp-gateway-policy.json"
+    second.write_text(json.dumps(_VALID_POLICY))
+    _discovery_paths(monkeypatch, first, second)
+
+    with pytest.raises(ValueError, match="Invalid policy file") as excinfo:
+        PolicyManager()
+    assert str(first) in str(excinfo.value)
+
+
+# === the parser raises -> warn and continue (unchanged) ===
+
+
+def test_unparseable_discovered_policy_warns_and_continues(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    policy_file = tmp_path / ".mcp-gateway-policy.json"
+    policy_file.write_text("{")
+    _discovery_paths(monkeypatch, policy_file)
+
+    with caplog.at_level(logging.WARNING, logger="pmcp.policy.policy"):
+        manager = PolicyManager()
+
+    assert manager.is_gateway_tool_allowed("gateway.provision") is True
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any(str(policy_file) in message for message in warnings)
+    # Asserted on the emitted text, not on the level: a reader of the old line
+    # could not tell that the gateway had just become unrestricted.
+    assert any("No policy is in effect" in message for message in warnings)
+
+
+def test_unreadable_discovered_policy_warns_and_continues(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A permissions failure is a `read_text` raise, so it takes the warn path."""
+    policy_file = tmp_path / ".mcp-gateway-policy.yaml"
+    policy_file.write_text(json.dumps(_VALID_POLICY))
+    policy_file.chmod(0o000)
+    if _is_readable(policy_file):
+        policy_file.chmod(0o644)
+        pytest.skip("running as a user that ignores file permissions (e.g. root)")
+    _discovery_paths(monkeypatch, policy_file)
+
+    try:
+        with caplog.at_level(logging.WARNING, logger="pmcp.policy.policy"):
+            manager = PolicyManager()
+    finally:
+        policy_file.chmod(0o644)
+
+    assert manager.is_server_allowed("deny-me") is True
+    assert any(
+        "No policy is in effect" in r.getMessage()
+        for r in caplog.records
+        if r.levelno >= logging.WARNING
+    )
+
+
+# === a valid policy still loads AND enforces ===
+
+
+def test_valid_discovered_policy_loads_and_enforces(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The criterion that guards the opposite failure: refusing too much."""
+    policy_file = tmp_path / ".mcp-gateway-policy.yaml"
+    policy_file.write_text(json.dumps(_VALID_POLICY))  # JSON is valid YAML
+    _discovery_paths(monkeypatch, policy_file)
+
+    manager = PolicyManager()
+
+    assert manager.is_server_allowed("deny-me") is False
+    assert manager.is_server_allowed("allow-me") is True
+    assert manager.get_max_tools_per_server() == 7
+
+
+def test_no_policy_file_anywhere_is_silent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    _discovery_paths(
+        monkeypatch,
+        tmp_path / ".mcp-gateway-policy.yaml",
+        tmp_path / ".mcp-gateway-policy.json",
+    )
+
+    with caplog.at_level(logging.WARNING, logger="pmcp.policy.policy"):
+        manager = PolicyManager()
+
+    assert manager.is_gateway_tool_allowed("gateway.provision") is True
+    assert [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING] == []
+
+
+# === Path.cwd() is read at construction, not at import ===
+
+
+def test_default_paths_follow_the_cwd_at_construction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`DEFAULT_POLICY_PATHS` must not freeze `Path.cwd()` at import time.
+
+    Deliberately does **not** monkeypatch `DEFAULT_POLICY_PATHS`: patching in a
+    relative path would make this pass against `main` too, since `main`'s loop
+    would resolve that relative path against the post-`chdir` cwd. The module's
+    real state is the subject here. `pmcp.policy.policy` is imported at collection
+    time, long before this `chdir`.
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".mcp-gateway-policy.yaml").write_text(json.dumps(_VALID_POLICY))
+    monkeypatch.chdir(project)
+
+    manager = PolicyManager()
+
+    assert manager.is_server_allowed("deny-me") is False
+    assert manager.get_max_tools_per_server() == 7
+
+
+def test_default_policy_paths_stays_a_patchable_module_attribute(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The seam `tests/test_scoped_advisor_audit.py` relies on.
+
+    Absolute entries must pass through path resolution unchanged, so a patched
+    list is honoured verbatim regardless of the working directory.
+    """
+    policy_file = tmp_path / "elsewhere.yaml"
+    policy_file.write_text(json.dumps(_VALID_POLICY))
+    _discovery_paths(monkeypatch, policy_file)
+    monkeypatch.chdir(tmp_path)
+
+    assert PolicyManager().is_server_allowed("deny-me") is False
+
+
+# === explicit --policy is unchanged: all three modes remain fatal ===
+
+
+def test_explicit_policy_remains_fatal_for_every_mode(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.json"
+    with pytest.raises(ValueError, match="explicit policy"):
+        PolicyManager(missing)
+
+    unparseable = tmp_path / "unparseable.json"
+    unparseable.write_text("{")
+    with pytest.raises(ValueError, match="explicit policy"):
+        PolicyManager(unparseable)
+
+    schema_invalid = tmp_path / "schema-invalid.json"
+    schema_invalid.write_text(json.dumps({"gateway_tools": {"unknown": []}}))
+    with pytest.raises(ValueError, match="explicit policy"):
+        PolicyManager(schema_invalid)
+
+    non_mapping = tmp_path / "non-mapping.yaml"
+    non_mapping.write_text("- gateway.health\n")
+    with pytest.raises(ValueError, match="explicit policy"):
+        PolicyManager(non_mapping)

--- a/tests/test_policy_fail_open.py
+++ b/tests/test_policy_fail_open.py
@@ -200,7 +200,9 @@ def test_no_policy_file_anywhere_is_silent(
         manager = PolicyManager()
 
     assert manager.is_gateway_tool_allowed("gateway.provision") is True
-    assert [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING] == []
+    assert [
+        r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING
+    ] == []
 
 
 # === Path.cwd() is read at construction, not at import ===

--- a/tests/test_policy_fail_open.py
+++ b/tests/test_policy_fail_open.py
@@ -143,6 +143,33 @@ def test_unparseable_discovered_policy_warns_and_continues(
     assert any("No policy is in effect" in message for message in warnings)
 
 
+def test_empty_json_is_a_parse_failure_unlike_empty_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The split is drawn by the parser, so it lands differently per format.
+
+    `yaml.safe_load("")` returns `None` -- it parses, so it is fatal (covered by
+    `test_non_mapping_discovered_policy_refuses_to_start`). `json.loads("")`
+    *raises*, so an empty `.json` takes the warn path instead. README documents
+    this asymmetry; without this test that documented claim is unpinned, and a
+    reader who tests the fix with an empty `.json` and sees only a warning would
+    conclude it does not work.
+    """
+    policy_file = tmp_path / ".mcp-gateway-policy.json"
+    policy_file.write_text("")
+    _discovery_paths(monkeypatch, policy_file)
+
+    with caplog.at_level(logging.WARNING, logger="pmcp.policy.policy"):
+        manager = PolicyManager()
+
+    assert manager.is_server_allowed("deny-me") is True
+    assert any(
+        "No policy is in effect" in r.getMessage()
+        for r in caplog.records
+        if r.levelno >= logging.WARNING
+    )
+
+
 def test_unreadable_discovered_policy_warns_and_continues(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:

--- a/tests/test_scoped_advisor_audit.py
+++ b/tests/test_scoped_advisor_audit.py
@@ -84,9 +84,17 @@ def _make_ctx() -> ServerRequestContext[Any, Any]:
     )
 
 
-def test_explicit_policy_failures_are_fatal_but_default_discovery_is_best_effort(
+def test_explicit_policy_failures_are_fatal_but_an_unparseable_default_is_not(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """Best-effort discovery survives, but only for a file the parser *rejects*.
+
+    Renamed from ``..._but_default_discovery_is_best_effort``: since
+    Consiliency/pmcp#202 an auto-discovered file that *parses* but is not a valid
+    policy terminates startup, so the old name asserted something broader than
+    the code does. The unparseable case below is unchanged and still pins the
+    deliberate fallback; ``tests/test_policy_fail_open.py`` covers the other side.
+    """
     missing = tmp_path / "missing.json"
     with pytest.raises(ValueError, match="explicit policy"):
         PolicyManager(missing)


### PR DESCRIPTION
`PolicyManager` swallowed every load failure on the auto-discovery path and left
`self._policy` as the constructor's `GatewayPolicy()` — which is **allow-all**,
since every field is a `default_factory`. A discarded policy was therefore not a
partial policy, it was *no* policy: allow/deny lists, limits and redaction all
reverted to permissive behind one warning line that did not say so. A restrictive
policy sitting on disk stopped applying. See #202.

## The rule — split by failure mode, not by file shape

| the file… | before | after |
|---|---|---|
| does not exist | no policy, silent | unchanged — legitimately "no policy" |
| exists, the parser **raises** | warn, allow-all | unchanged — warn and continue |
| **parses** but is not a valid policy | warn, allow-all | **refuse to start** |

This is deliberately not "make everything fatal". The best-effort fallback for an
*unparseable* file is pinned by an existing test
(`test_scoped_advisor_audit.py`, added in 5ec4545) and its intent is preserved
exactly: a file the parser rejects could be a half-written file, an unrelated
`.json` dropped at the repo root, or a merge conflict. A file that parses as a
document but fails `GatewayPolicy` validation is unmistakably *a policy with a
mistake in it*, and that is the case where falling back to allow-all is
indefensible. That test is renamed to
`..._but_an_unparseable_default_is_not` — its assertions are untouched; only its
name, which would otherwise claim something broader than the code does.

**A list root, a scalar root and an empty YAML file are on the fatal side.**
`yaml.safe_load` returns `list`, `str` and `None` for them **without raising** —
they parse, and fail only the object schema. They are the shapes an accidental
policy file most often takes. (An earlier revision of the plan classified them as
parse failures, which would have left exactly that case still failing open; the
red-team seat caught it.)

## Second fix: `Path.cwd()` was frozen at import

`DEFAULT_POLICY_PATHS` pre-joined its two project-local entries with `Path.cwd()`
at module import. A gateway that changed directory before constructing its
`PolicyManager` looked for a policy elsewhere, found none, and ran unrestricted —
and by *that* road with no warning at all, since "no policy file" is legitimately
silent. Those entries are now stored relative and resolved by
`_default_policy_paths()` at construction. The module attribute stays a working
`monkeypatch` seam (`test_scoped_advisor_audit.py:104` relies on it); absolute
entries pass through unchanged, and there is a dedicated test for that seam.

`--policy` / `PMCP_POLICY` behaviour is untouched — it was already fatal for
every mode, and the discovery-fatal message is deliberately worded differently
(`Invalid policy file …` vs `Failed to load explicit policy …`) so the two are
not confused in a log. A test asserts the discovery error does **not** contain
"explicit policy".

## Evidence

**The cwd test shown RED against `main`** — a clean `git archive main` export with
`PYTHONPATH`, not by reasoning. The import really came from the export:

```
$ PYTHONPATH=$SP/main-export/src:$SP/main-export .venv/bin/python \
    -c "import pmcp.policy.policy as p; print('IMPORTED FROM:', p.__file__)"
IMPORTED FROM: .../scratchpad/main-export/src/pmcp/policy/policy.py

### RED against a clean git archive export of main ###
FAILED tests/test_policy_fail_open.py::test_default_paths_follow_the_cwd_at_construction
1 failed in 0.05s

### GREEN on the branch ###
1 passed in 0.03s
```

That test deliberately does **not** monkeypatch `DEFAULT_POLICY_PATHS`: patching
in a relative path would make it pass against `main` too, since `main`'s loop
would resolve a relative entry against the post-`chdir` cwd. A vacuous RED/GREEN
pair proves nothing.

The whole new file against the same `main` export — 9 failed, 4 passed. The 4 that
pass on `main` are the ones asserting behaviour this PR preserves (fallback for an
unparseable file at the gateway-tool level, no-file silence, explicit `--policy`).

```
$ .venv/bin/python -m pytest -q tests/test_policy_fail_open.py \
    tests/test_scoped_advisor_audit.py tests/test_policy.py
50 passed in 5.63s
```

**Lint and types** — `ruff check src/ tests/`: All checks passed.
`ruff format --check src/ tests/`: 119 files already formatted.
`mypy src/`: Success, no issues in 43 source files.

**Full suite: `3032 passed, 3 skipped, 107 failed, 106 errors`.** Not green on
this host — and **not green on `main` either**. The failing ID set is byte
identical between this branch's full run and a `main` export run of the four
affected files (213 vs 213, `diff` clean): `test_npm_resolver.py`,
`test_version_checker.py`, `test_tools.py`, `test_refresher.py`. Cause is the one
`tests/conftest.py` documents at the top of the file — a `/tmp/package.json` and
`/tmp/node_modules` on this development host set an npm local prefix, so the npm
identity resolver refuses rather than guesses (#195). Nothing policy-related, and
nothing this diff touches. CI is the arbiter for that criterion.

## Acceptance criteria

- [x] Schema-invalid file at a default path → `PolicyManager()` raises, error names the path. RED on `main`.
- [x] Unparseable file at a default path → still does not raise; the original test's own case, unmodified.
- [x] A list root, a scalar root and an empty file each raise. RED on `main`.
- [x] A valid file at a default path loads **and enforces** — asserted by a deny rule actually denying, plus a limit actually applying. A change that refuses everything fails this.
- [x] `Path.cwd()` read at construction, shown RED against `main`.
- [x] The warn-path message states "No policy is in effect", asserted on the emitted text via `caplog`, not on the level.
- [x] `pmcp.policy.policy.DEFAULT_POLICY_PATHS` remains monkeypatchable — the existing test's seam is untouched and has its own regression test.
- [x] Full suite green — **on CI**, not locally. `test (3.10)`, `test (3.11)`, `test (3.12)` all pass; `lint`, `typecheck`, `build`, `install-smoke`, `min-version-smoke`, `changelog`, `workflows`, `release-diff-ack` all pass. The local failures are host npm contamination identical to `main`, as detailed above.

No tag, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3sT5kftuVtAKVktekR1nS
