### PR TITLE
chore: v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-08-29
+
 ### Added
 - The truncation boundary at `max_tools_per_server` is now pinned by tests at
   `limit - 1`, `limit` and `limit + 1`. Mutating the guard from `>=` to `>` —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "2.6.0"
+version = "2.7.0"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "2.6.0"
+__version__ = "2.7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "2.6.0"
+version = "2.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts 2.7.0. Ships #193 (PR #203), #175 (PR #204) and #202 (PR #205).

## Why minor, not patch

Two behaviour changes are visible to operators:

- **A gateway that starts today can refuse to start.** An auto-discovered policy that *parses* but is not a valid policy now terminates startup. Previously it was discarded and the gateway fell back to allow-all — a restrictive policy present on disk silently stopped applying. A file the parser *rejects* still warns and continues, preserving intent an existing test pinned deliberately.
- **A downstream tool declaring no `inputSchema` is now skipped**, rather than being given a manufactured accept-anything schema.

Neither breaks an API, so minor rather than major.

## Contents

- **#202** — the policy fail-open, plus `DEFAULT_POLICY_PATHS` no longer freezing `Path.cwd()` at import time.
- **#175** — five catalog-indexing findings: the truncation boundary is now pinned by a test (the mutation that motivated the issue survived nine others), `adopt_process` clears indexes first, duplicate identities no longer overstate the count, and a zero limit stops blaming the server.
- **#193** — `--verify` no longer reports host-enumerated npm config types as drift. Maintainer tooling; no runtime effect.

## Known trade, stated rather than discovered later

The policy discovery loop breaks at the first path that *exists*, so a stray or stale `./.mcp-gateway-policy.yaml` can now stop the gateway booting even when a valid `~/.claude/gateway-policy.yaml` is present. That is fail-closed by choice, replacing a fail-open.

## CHANGELOG

`[Unreleased]` folded into `## [2.7.0]`; extraction verified to yield exactly one each of `### Added`, `### Changed`, `### Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T61zMNiPF4K29186r3uqc3

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790622939&installation_model_id=427051&pr_number=206&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F206&signature=6edfe1c47c2f51b3106e5290a9eb984f9942319959a268577d70434f90c2940d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->