### PR TITLE
fix(policy): bound max_tools_per_server now that #202 makes validation fatal (#207)

### DIFF
--- a/.consiliency/plans/detailed-limit-bound-20260829-1500.md
+++ b/.consiliency/plans/detailed-limit-bound-20260829-1500.md
@@ -33,7 +33,7 @@ describes `max_tools_per_server`'s default of 100 as a *legitimate catalog size*
 `_parse_tool_entries`; the citation does not, and is removed rather than
 reworded.
 
-**Two independent axes.** `LimitsPolicy.max_tools_per_server` (`types.py:960`) is
+**Two independent axes.** `LimitsPolicy.max_tools_per_server` (`types.py:973`) is
 the policy/schema surface. `ClientManager.__init__`'s `max_tools_per_server: int = 100`
 (`manager.py:936`) is a separate constructor parameter, and
 `manager.py:2169` guards `< 1` — so it already handles zero *and negatives*
@@ -124,7 +124,8 @@ a gateway that indexes no tools at all, but "plausibly zero" is not "none".
 ## Dependencies & order
 
 1. The `ge=1` bound and the inverted schema test.
-2. The three comment corrections.
+2. The four comment corrections — `types.py` docstring, `manager.py:2174-2177`,
+   `manager.py:683-687`, and the `TestZeroLimitLogsAccurately` docstring.
 3. The end-to-end discovered-policy test.
 4. CHANGELOG.
 

--- a/.consiliency/plans/detailed-limit-bound-20260829-1500.md
+++ b/.consiliency/plans/detailed-limit-bound-20260829-1500.md
@@ -1,0 +1,154 @@
+# Detailed plan: bound `max_tools_per_server`, and stop the code arguing against it
+
+## Task
+
+Close Consiliency/pmcp#207. Add `Field(ge=1)` to
+`LimitsPolicy.max_tools_per_server`, and correct three comments that state the
+reason it was omitted — a reason #202 removed.
+
+## Research summary
+
+Verified in this worktree.
+
+**Why the bound was blocked, and why it no longer is.** #175 proposed it, then
+dropped it: `PolicyManager._load_policy(..., fatal=False)` swallowed validation
+errors and fell back to an **allow-all** default, so making `0` schema-invalid
+would have silently discarded an operator's whole policy file. #202 made a
+discovered policy that *parses but fails validation* terminate startup, so a
+schema bound can no longer silently unrestrict anything.
+
+**`0` is not a meaningful setting.** `manager.py:107` states the limit "is a
+runaway guard, not a catalog-size limit". At `0`, `_parse_tool_entries` empties
+its result before examining a single entry. There is no supported "disable tool
+indexing" semantic that `0` expresses — it is a mistake, which is what makes it
+boundable.
+
+**Two independent axes.** `LimitsPolicy.max_tools_per_server` (`types.py:960`) is
+the policy/schema surface. `ClientManager.__init__`'s `max_tools_per_server: int = 100`
+(`manager.py:936`) is a separate constructor parameter, and
+`manager.py:2169` guards `< 1` — so it already handles zero *and negatives*
+defensively. #207 is about the schema axis; the constructor axis is deliberately
+left alone (see Non-goals).
+
+**What currently pins `0` as valid.** `tests/test_client_manager.py:6110`
+asserts `LimitsPolicy(max_tools_per_server=0).max_tools_per_server == 0`, and
+`:6116` constructs `ClientManager(max_tools_per_server=0)`. The first must
+invert; the second must **stay**, because it exercises the constructor axis and
+the log behaviour, both of which survive this change.
+
+## The migration consequence, stated plainly
+
+**This change plus #202 converts a working configuration into a hard boot
+failure.** An operator whose discovered policy contains `max_tools_per_server: 0`
+starts fine today (with a now-accurate log saying nothing was indexed); after
+this, that file fails validation and #202 terminates startup.
+
+That is the intended direction — a nonsensical value should be rejected loudly
+rather than silently indexing nothing — but it is a real behaviour change for
+anyone holding that value, and it must be in the CHANGELOG under `### Changed`,
+not buried as a fix. The affected population is plausibly zero, since `0` yields
+a gateway that indexes no tools at all, but "plausibly zero" is not "none".
+
+## Changes
+
+### `src/pmcp/types.py` (modify)
+
+- `LimitsPolicy.max_tools_per_server` (`:960`) — modify — `Field(default=100, ge=1)`.
+- `LimitsPolicy` docstring (`:957-970`) — modify — it currently says the field
+  **deliberately carries no `Field(ge=1)`** and explains why, citing the
+  swallow-and-fall-back-to-allow-all behaviour. That reason is now false. Replace
+  it with a short record that the bound was blocked until #202 made discovered
+  policy validation fatal. Keeping the history matters: without it, the next
+  person to consider a schema bound has no way to know the hazard existed or that
+  it was removed.
+
+### `src/pmcp/client/manager.py` (modify)
+
+- The comment at `:2174-2177` — modify — same correction. It currently justifies
+  the missing bound by the fail-open.
+- `:2169`'s `< 1` guard and the "so none were indexed" log at `:690` —
+  **unchanged**. They remain reachable through the constructor axis, and the log
+  fix from #175 is correct independently of whether the schema accepts `0`.
+
+### `tests/test_client_manager.py` (modify)
+
+- `:6110` — modify — invert: `LimitsPolicy(max_tools_per_server=0)` must now
+  raise `ValidationError`. Also assert `-1` raises, since `ge=1` covers it and
+  the old bound covered neither.
+- `:6116` and the rest of `TestZeroLimitLogsAccurately` — **keep**. They drive
+  `ClientManager(max_tools_per_server=0)` directly, which is still legal, and
+  they pin the accurate-log behaviour. Deleting them because "0 is now invalid"
+  would remove coverage of a path that still exists.
+- The class docstring at `:6066-6075` — modify — it explains the log fix by
+  reference to a policy file setting `0`, which is no longer possible. Reframe to
+  the constructor axis so the test's stated reason matches its actual mechanism.
+
+### `tests/test_policy_fail_open.py` or a sibling (modify/create)
+
+- Add the end-to-end consequence: a **discovered policy file** containing
+  `max_tools_per_server: 0` now makes `PolicyManager()` raise. This is the
+  interaction between #207 and #202, and neither issue's tests cover it alone —
+  #207's tests are schema-level and #202's use a different invalid key.
+
+## Documentation impact
+
+- `CHANGELOG.md` — add — under `### Changed`, not `### Fixed`: a policy file with
+  `max_tools_per_server: 0` is now rejected, and via #202 that terminates
+  startup. Name the value explicitly so an affected operator can search for it.
+- `README.md` — modify **only if** it documents `max_tools_per_server` or shows a
+  policy example carrying it; check both before editing.
+
+## Dependencies & order
+
+1. The `ge=1` bound and the inverted schema test.
+2. The three comment corrections.
+3. The end-to-end discovered-policy test.
+4. CHANGELOG.
+
+## Verification
+
+```bash
+uv run pytest -q tests/test_client_manager.py -k "ZeroLimit or Limits"
+uv run pytest -q tests/test_policy_fail_open.py
+uv run pytest -q
+uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/
+
+# The zero-limit log path must still be reachable and still accurate:
+#   construct ClientManager(max_tools_per_server=0) directly and assert the
+#   message names the limit and does not say "unparseable".
+```
+
+Edge cases: `max_tools_per_server: -1` in a policy file; the value absent
+(default 100 still applies); an explicit `--policy` carrying `0` (already fatal
+via `fatal=True`, but assert it, since that path's message differs); a policy
+with `limits: {}`.
+
+## Acceptance criteria
+
+- [ ] `LimitsPolicy(max_tools_per_server=0)` and `(-1)` both raise
+      `ValidationError`; the default of 100 still applies when the field is absent.
+- [ ] A **discovered policy file** containing `max_tools_per_server: 0` makes
+      `PolicyManager()` raise — the #207 × #202 interaction, proven end-to-end
+      rather than inferred from the schema test.
+- [ ] `ClientManager(max_tools_per_server=0)` **still works** and still logs the
+      accurate zero-limit message. A change that removes this path because the
+      schema now rejects `0` must not pass — the constructor axis is untouched by
+      this issue.
+- [ ] None of the three corrected comments still asserts that auto-discovery
+      swallows validation errors — grep for `swallow` and `fatal=False` across
+      `src/` and `tests/` returns nothing describing current behaviour.
+- [ ] Full suite green.
+
+## Non-goals
+
+- **Bounding `ClientManager.__init__`'s parameter.** It is a programmatic API, its
+  `< 1` guard already handles the value defensively, and #175's own review noted
+  it is not required to close the finding. Mirroring `ge=1` there is defensible
+  but is a separate decision about how strict a Python constructor should be.
+- Any further policy-schema tightening. This is the first bound added after #202
+  removed the hazard; adding one at a time keeps the blast radius legible.
+
+## Execution Policy
+
+- execute: effort=low, reason=a one-field schema bound plus comment corrections;
+  the only subtlety is which existing tests invert and which must survive

--- a/.consiliency/plans/detailed-limit-bound-20260829-1500.md
+++ b/.consiliency/plans/detailed-limit-bound-20260829-1500.md
@@ -1,5 +1,9 @@
 # Detailed plan: bound `max_tools_per_server`, and stop the code arguing against it
 
+> **Revision 2 (2026-08-29).** Boarded 3 AGREE, no blocking defects. Three
+> corrections applied, one of them a **misattributed citation of mine** that
+> argued the opposite of what the source says.
+
 ## Task
 
 Close Consiliency/pmcp#207. Add `Field(ge=1)` to
@@ -17,11 +21,17 @@ would have silently discarded an operator's whole policy file. #202 made a
 discovered policy that *parses but fails validation* terminate startup, so a
 schema bound can no longer silently unrestrict anything.
 
-**`0` is not a meaningful setting.** `manager.py:107` states the limit "is a
-runaway guard, not a catalog-size limit". At `0`, `_parse_tool_entries` empties
-its result before examining a single entry. There is no supported "disable tool
-indexing" semantic that `0` expresses — it is a mistake, which is what makes it
-boundable.
+**`0` is not a meaningful setting.** At `0`, `_parse_tool_entries` empties its
+result before examining a single entry, and no documented semantic assigns `0` a
+"disable tool indexing" meaning.
+
+**WAS WRONG (rev 1):** it supported this by citing `manager.py:107` — "the cap is
+a runaway guard, not a catalog-size limit". That sentence is about
+`_MAX_LISTING_PAGES = 500`, **not** `max_tools_per_server`, and the same passage
+describes `max_tools_per_server`'s default of 100 as a *legitimate catalog size*
+— the opposite of the point it was quoted for. The conclusion survives on
+`_parse_tool_entries`; the citation does not, and is removed rather than
+reworded.
 
 **Two independent axes.** `LimitsPolicy.max_tools_per_server` (`types.py:960`) is
 the policy/schema surface. `ClientManager.__init__`'s `max_tools_per_server: int = 100`
@@ -53,7 +63,8 @@ a gateway that indexes no tools at all, but "plausibly zero" is not "none".
 
 ### `src/pmcp/types.py` (modify)
 
-- `LimitsPolicy.max_tools_per_server` (`:960`) — modify — `Field(default=100, ge=1)`.
+- `LimitsPolicy.max_tools_per_server` (`:973` — rev 1 said `:960`, which is the
+  docstring) — modify — `Field(default=100, ge=1)`.
 - `LimitsPolicy` docstring (`:957-970`) — modify — it currently says the field
   **deliberately carries no `Field(ge=1)`** and explains why, citing the
   swallow-and-fall-back-to-allow-all behaviour. That reason is now false. Replace
@@ -66,6 +77,9 @@ a gateway that indexes no tools at all, but "plausibly zero" is not "none".
 
 - The comment at `:2174-2177` — modify — same correction. It currently justifies
   the missing bound by the fail-open.
+- The comment at `:683-687` — modify — it tells the operator to "fix their policy
+  file", which after the bound is unreachable via a policy file; that path is
+  constructor-only.
 - `:2169`'s `< 1` guard and the "so none were indexed" log at `:690` —
   **unchanged**. They remain reachable through the constructor axis, and the log
   fix from #175 is correct independently of whether the schema accepts `0`.
@@ -86,13 +100,22 @@ a gateway that indexes no tools at all, but "plausibly zero" is not "none".
 ### `tests/test_policy_fail_open.py` or a sibling (modify/create)
 
 - Add the end-to-end consequence: a **discovered policy file** containing
-  `max_tools_per_server: 0` now makes `PolicyManager()` raise. This is the
+  `max_tools_per_server: 0` now makes `PolicyManager()` raise **`ValueError`** —
+  `PolicyManager` wraps pydantic errors, so this test must follow
+  `test_policy_fail_open.py`'s existing `ValueError` / `Invalid policy file`
+  pattern and its `_discovery_paths` helper. Only the schema-level test in
+  `test_client_manager.py` sees a raw `ValidationError`, and it needs the pydantic
+  import. This is the
   interaction between #207 and #202, and neither issue's tests cover it alone —
   #207's tests are schema-level and #202's use a different invalid key.
 
 ## Documentation impact
 
-- `CHANGELOG.md` — add — under `### Changed`, not `### Fixed`: a policy file with
+- `CHANGELOG.md` — add — in a **fresh `[Unreleased]`** section. **2.7.0 is now
+  cut**, so #175's and #202's entries — including the sentence saying
+  `LimitsPolicy` still accepts `0` and that the bound is left to a follow-up —
+  sit under `## [2.7.0]` as shipped history. Leave them; they were true of that
+  release. Under `### Changed`, not `### Fixed`: a policy file with
   `max_tools_per_server: 0` is now rejected, and via #202 that terminates
   startup. Name the value explicitly so an affected operator can search for it.
 - `README.md` — modify **only if** it documents `max_tools_per_server` or shows a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **A policy file setting `max_tools_per_server: 0` is now rejected, and via
+  #202 that terminates startup.** `LimitsPolicy.max_tools_per_server` is bounded
+  at `ge=1`; `0` — and any negative value — no longer validates. **This can stop
+  a gateway that starts today.** If your policy file (`.mcp-gateway-policy.yaml`
+  / `.json`, or `~/.claude/gateway-policy.yaml` / `.json`) contains the literal
+  line `max_tools_per_server: 0`, the gateway will refuse to start with
+  `Invalid policy file ...`; remove the line to take the default of `100`, or
+  set the number of tools you actually want indexed. Such a gateway indexed no
+  tools at all before, so the value is unlikely to be in deliberate use — but
+  the failure is a hard one and worth searching for. 2.7.0 shipped the log fix
+  for this value and deliberately left the bound out: at that time a discovered
+  policy that failed validation was discarded in favour of the allow-all
+  default, so rejecting one value would have silently discarded the operator's
+  entire policy file. #202, in the same release, made that case fatal, which is
+  what makes the bound safe to add. `ClientManager`'s `max_tools_per_server`
+  constructor parameter is a separate, programmatic axis and is unchanged — it
+  still accepts `0` and still logs that nothing was indexed. (#207)
+
 ## [2.7.0] - 2026-08-29
 
 ### Added

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -682,9 +682,13 @@ def _parse_tool_entries(
             if limit < 1:
                 # "has more than 0 tools, truncating" is true and useless: it
                 # reads as a server that overran a bound, when what happened is
-                # that the bound admits nothing. Name the limit instead -- the
-                # operator's next move is to fix their policy file, and the log
-                # should point at it. (#175 item 3.)
+                # that the bound admits nothing. Name the limit instead, so the
+                # reader can see the gateway made this decision. (#175 item 3.)
+                #
+                # Since #207 a policy file cannot produce this: `LimitsPolicy`
+                # bounds the field at `ge=1`. The caller here is
+                # `ClientManager`'s constructor parameter, which is deliberately
+                # unbounded, so this stays reachable programmatically.
                 logger.warning(
                     f"Server {name} offered {len(tools)} tools but "
                     f"max_tools_per_server is {limit}, so none were indexed"
@@ -2170,11 +2174,13 @@ class ClientManager:
                     # #175 item 3. A zero limit empties the parse result before
                     # a single entry is looked at, so the generic message below
                     # would accuse the downstream of sending garbage for a
-                    # decision this gateway's own policy made. Deliberately no
-                    # `Field(ge=1)` on the schema instead: `_load_policy(...,
-                    # fatal=False)` swallows validation errors and falls back to
-                    # the allow-all default, so rejecting the value would
-                    # silently discard the operator's entire policy file (#202).
+                    # decision this gateway made itself.
+                    #
+                    # `LimitsPolicy` now bounds the field at `ge=1` (#207), so a
+                    # policy file can no longer reach here -- #202 made such a
+                    # file terminate startup. `self._max_tools_per_server` comes
+                    # from the constructor parameter, which is deliberately left
+                    # unbounded, so this branch still guards a live path.
                     logger.warning(
                         f"[{name}] max_tools_per_server is "
                         f"{self._max_tools_per_server}, so none of the "

--- a/src/pmcp/types.py
+++ b/src/pmcp/types.py
@@ -957,20 +957,26 @@ class PromptPolicy(BaseModel):
 class LimitsPolicy(BaseModel):
     """Resource limits policy.
 
-    **`max_tools_per_server` deliberately carries no `Field(ge=1)`.** A zero
-    limit indexes no tools, which #175 item 3 first proposed to reject at the
-    schema. It must not be: `PolicyManager._load_policy(..., fatal=False)` --
-    the auto-discovery path -- swallows any validation exception and leaves the
-    default allow-all `GatewayPolicy` in place, so a bound here would make a
-    policy file containing `max_tools_per_server: 0` schema-invalid and silently
-    discard **the whole file** -- allowlist, denylist, limits and redaction all
-    reverting to permissive. A cosmetic log fix is not worth a fail-open. The
-    misleading log was fixed in `_reconcile_once` instead; the underlying
-    fail-open is #202, and any future tightening of this schema carries the same
-    risk until it is resolved.
+    **`max_tools_per_server` is bounded at `ge=1`, and could not be until
+    #202.** A zero limit indexes no tools, and #175 item 3 first proposed
+    rejecting it here -- then withdrew the proposal as a security regression.
+    At the time `PolicyManager._load_policy(..., fatal=False)` -- the
+    auto-discovery path -- discarded any validation failure and left the default
+    allow-all `GatewayPolicy` in place, so a bound here would have made a policy
+    file containing `max_tools_per_server: 0` schema-invalid and silently thrown
+    away **the whole file** -- allowlist, denylist, limits and redaction all
+    reverting to permissive. #202 made a discovered policy that parses but fails
+    validation terminate startup, so a bound can no longer quietly unrestrict
+    anything, and #207 added this one.
+
+    That history is kept because the hazard is not obvious from the code: any
+    future tightening of this schema is safe only for as long as #202's
+    fail-closed behaviour holds. Note also that `ClientManager.__init__`'s
+    `max_tools_per_server` parameter is a separate, deliberately unbounded axis
+    -- see its `< 1` guard in `pmcp.client.manager`.
     """
 
-    max_tools_per_server: int = 100
+    max_tools_per_server: int = Field(default=100, ge=1)
     max_output_bytes: int = 50000  # 50KB
     max_output_tokens: int = 4000
 

--- a/tests/test_client_manager.py
+++ b/tests/test_client_manager.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx2
 import pytest
+from pydantic import ValidationError
 
 from pmcp.client.manager import (
     _MAX_LISTING_PAGES,
@@ -6063,24 +6064,23 @@ class TestDuplicateIdentitiesAreNotDoubleCounted:
 
 
 class TestZeroLimitLogsAccurately:
-    """#175 item 3: `max_tools_per_server: 0` must not be reported as a
+    """#175 item 3: a zero `max_tools_per_server` must not be reported as a
     downstream that sent garbage.
 
     A zero limit empties `_parse_tool_entries`' result before a single entry is
     examined, so `_reconcile_once`'s offered-but-none-parseable branch fired
     and announced "Every tools entry in the listing was unparseable" -- an
-    accusation aimed at the server for a decision this gateway's own policy
-    file made. The operator's next move is to fix the policy, and the log has
-    to point there.
+    accusation aimed at the server for a decision this gateway made itself. The
+    log has to name the limit instead.
 
-    Deliberately fixed in the *log* and not in the schema. `LimitsPolicy` gets
-    no `Field(ge=1)`: `PolicyManager._load_policy(..., fatal=False)` -- the
-    auto-discovery path -- swallows any validation exception and leaves the
-    default allow-all `GatewayPolicy` in place, so making `0` schema-invalid
-    would silently discard the operator's *entire* policy file, allow and deny
-    lists and redaction included. That fail-open is #202 and is not this
-    change's to fix; the test below pins that `0` still validates, so a future
-    tightening cannot land here unnoticed.
+    **The reachable path is the constructor, not a policy file.** #207 added
+    `Field(ge=1)` to `LimitsPolicy.max_tools_per_server`, so a policy file can
+    no longer carry `0` -- via #202 such a file terminates startup. But
+    `ClientManager.__init__`'s `max_tools_per_server` parameter is a separate
+    axis and is deliberately left unbounded (a programmatic API, guarded
+    defensively at the use site), so every case below is still reachable and the
+    log wording still has to be right. The schema test that follows pins the
+    bound from the other side.
     """
 
     @staticmethod
@@ -6104,10 +6104,22 @@ class TestZeroLimitLogsAccurately:
 
         manager._send_request = fake_send  # type: ignore[method-assign]
 
-    def test_a_zero_limit_still_validates_on_the_policy_schema(self) -> None:
-        """Rejecting it is what triggers #202's fail-open, so it must not be
-        rejected."""
-        assert LimitsPolicy(max_tools_per_server=0).max_tools_per_server == 0
+    def test_a_zero_limit_is_rejected_by_the_policy_schema(self) -> None:
+        """#207: `0` indexes nothing, so the schema refuses it.
+
+        Only safe since #202 -- before it, auto-discovery discarded a policy
+        that failed validation and fell back to allow-all, so this bound would
+        have silently unrestricted the gateway instead of rejecting one value.
+        `-1` is covered too: the old field accepted it as well.
+        """
+        with pytest.raises(ValidationError):
+            LimitsPolicy(max_tools_per_server=0)
+        with pytest.raises(ValidationError):
+            LimitsPolicy(max_tools_per_server=-1)
+
+        # The bound must not disturb the default or ordinary values.
+        assert LimitsPolicy().max_tools_per_server == 100
+        assert LimitsPolicy(max_tools_per_server=1).max_tools_per_server == 1
 
     @pytest.mark.asyncio
     async def test_zero_limit_names_the_limit_and_blames_no_one(

--- a/tests/test_policy_fail_open.py
+++ b/tests/test_policy_fail_open.py
@@ -70,6 +70,71 @@ def test_schema_invalid_discovered_policy_refuses_to_start(
     assert "explicit policy" not in str(excinfo.value)
 
 
+@pytest.mark.parametrize("limit", [0, -1])
+def test_discovered_policy_with_an_unusable_tool_limit_refuses_to_start(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, limit: int
+) -> None:
+    """The #207 x #202 interaction, end to end.
+
+    #207 bounded `LimitsPolicy.max_tools_per_server` at `ge=1`. On its own that
+    is a schema fact; what makes it a *behaviour* change is #202, which turned a
+    discovered policy that parses-but-fails-validation into a startup refusal.
+    Neither issue's own tests cover the pair -- #207's are schema-level and
+    #202's use a different invalid key -- so a regression in either half (the
+    bound reverted, or discovered-policy validation made non-fatal again) would
+    show up here and nowhere else.
+
+    `PolicyManager` wraps the pydantic error in `ValueError`, so this is the
+    `Invalid policy file` path, not a raw `ValidationError`.
+    """
+    policy_file = tmp_path / ".mcp-gateway-policy.json"
+    policy_file.write_text(json.dumps({"limits": {"max_tools_per_server": limit}}))
+    _discovery_paths(monkeypatch, policy_file)
+
+    with pytest.raises(ValueError, match="Invalid policy file") as excinfo:
+        PolicyManager()
+
+    assert str(policy_file) in str(excinfo.value)
+    assert "max_tools_per_server" in str(excinfo.value)
+    assert "explicit policy" not in str(excinfo.value)
+
+
+def test_discovered_policy_with_empty_limits_still_loads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The bound must reject only the stated values, not an absent field.
+
+    `limits: {}` is the shape most likely to be caught by an over-broad bound:
+    it names the section without setting anything, and must keep the default.
+    """
+    policy_file = tmp_path / ".mcp-gateway-policy.yaml"
+    policy_file.write_text("servers:\n  denylist:\n    - deny-me\nlimits: {}\n")
+    _discovery_paths(monkeypatch, policy_file)
+
+    manager = PolicyManager()
+
+    assert manager.get_max_tools_per_server() == 100
+    assert manager.is_server_allowed("deny-me") is False
+
+
+def test_explicit_policy_with_an_unusable_tool_limit_is_fatal_too(
+    tmp_path: Path,
+) -> None:
+    """Same value, different path, different message.
+
+    An explicit `--policy` was already fatal for every failure mode, but it
+    reports as `explicit policy` rather than `Invalid policy file`, so an
+    operator grepping for one string would not find the other.
+    """
+    policy_file = tmp_path / "explicit.json"
+    policy_file.write_text(json.dumps({"limits": {"max_tools_per_server": 0}}))
+
+    with pytest.raises(ValueError, match="explicit policy") as excinfo:
+        PolicyManager(policy_file)
+
+    assert "max_tools_per_server" in str(excinfo.value)
+
+
 @pytest.mark.parametrize(
     ("label", "content"),
     [


### PR DESCRIPTION
See #207.

`LimitsPolicy.max_tools_per_server` accepted `0`, a value at which nothing
indexes. #175 proposed `Field(ge=1)` and **withdrew it as a security
regression**: `PolicyManager._load_policy(..., fatal=False)` discarded a
discovered policy that failed validation and fell back to an allow-all
`GatewayPolicy`, so rejecting `0` would have silently thrown away the
operator's entire policy file — allowlist, denylist, limits, redaction — rather
than one value. #202 made a discovered policy that parses-but-fails-validation
terminate startup, which removed that hazard. This adds the bound and corrects
the comments that still state the old reason.

## Migration consequence

**This can stop a gateway that starts today.** A discovered policy containing
the literal `max_tools_per_server: 0` now fails validation, and via #202 that
terminates startup with `Invalid policy file ...`. Remove the line to take the
default of `100`, or set the number you actually want. Such a gateway indexed
no tools at all before, so the affected population is plausibly zero — but
"plausibly zero" is not "none", so it is in the CHANGELOG under `### Changed`
with the value named literally, not softened into a `### Fixed` bullet.

## Two independent axes

Only the policy/schema surface is bounded. `ClientManager.__init__`'s
`max_tools_per_server` parameter is a separate, deliberately unbounded
programmatic API; its `< 1` guard and the accurate zero-limit log from #175
remain reachable and are still tested — `TestZeroLimitLogsAccurately` keeps its
`ClientManager(max_tools_per_server=0)` construction. Deleting those tests
because "0 is now invalid" would drop coverage of a path that still exists.

## Changes

- `src/pmcp/types.py` — `Field(default=100, ge=1)`; docstring rewritten to
  record *why* the bound was blocked and what unblocked it. The history is kept
  deliberately: the hazard is not visible from the code, and any future
  tightening of this schema is safe only while #202's behaviour holds.
- `src/pmcp/client/manager.py` — two comments corrected. Both justified the
  missing bound by the fail-open; one also told the operator to "fix their
  policy file", a route the bound closes. The log strings are byte-identical.
- `tests/test_client_manager.py` — the schema assertion inverts (`0` and `-1`
  both raise `ValidationError`; default still `100`); the class docstring is
  reframed to the constructor axis so the tests' stated reason matches their
  actual mechanism.
- `tests/test_policy_fail_open.py` — the #207 × #202 interaction end-to-end,
  which neither issue's tests cover alone: a discovered policy carrying `0` or
  `-1` makes `PolicyManager()` raise `ValueError`/`Invalid policy file`. Plus
  `limits: {}` still loading with the default, and the explicit-`--policy` path,
  whose message differs.

## Verification

```
uv run pytest -q                              107 failed, 3037 passed, 3 skipped, 106 errors
uv run ruff check src/ tests/                 All checks passed!
uv run ruff format --check src/ tests/        119 files already formatted
uv run mypy src/                              Success: no issues found in 43 source files
```

The 107 failures are host contamination, not this diff: `/tmp/package.json` and
`/tmp/node_modules` on the development host flip every `chdir(tmp_path)`
npm-identity test, as documented at the top of `tests/conftest.py`. A clean
`origin/main` export on the same host produces **the identical 107 failed / 106
errors** across the same four files (`test_npm_resolver`, `test_version_checker`,
`test_tools`, `test_refresher`). CI, which has no such `/tmp`, is the real
signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3sT5kftuVtAKVktekR1nS

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790624760&installation_model_id=427051&pr_number=208&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F208&signature=eda2e9edad55efbde997c4fc37ea6f860c045c0f0164785844478274185df868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->