### PR TITLE
chore: v2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.1] - 2026-08-30
+
 ### Changed
 - **A policy file setting `max_tools_per_server: 0` is now rejected, and via
   #202 that terminates startup.** `LimitsPolicy.max_tools_per_server` is bounded

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "2.7.0"
+version = "2.7.1"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "2.7.0"
+__version__ = "2.7.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "2.7.0"
+version = "2.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts 2.7.1. Ships #207 (PR #208).

## Why its own release

`max_tools_per_server` is now bounded at `ge=1`. That is a behaviour change: a discovered policy carrying `max_tools_per_server: 0` fails validation, and via #202 that **terminates startup**.

Patch rather than minor — no API change, and `0` produces a gateway that indexes no tools at all, so the affected population is plausibly zero. But "plausibly zero" is not "none", and an operator whose gateway stops booting needs to be able to search the release notes for the exact value. Folding this into a later, larger release would bury it.

## Why the bound could ship now

#175 proposed it and withdrew it as a security regression: policy validation errors were swallowed and the gateway fell back to an allow-all default, so rejecting `0` would have silently discarded an operator's entire policy file. #202 made a discovered policy that parses-but-fails-validation terminate startup, removing that hazard.

## Unchanged

`ClientManager(max_tools_per_server=0)` still constructs, its `< 1` guard remains, and the accurate zero-limit log is still reachable that way. Only the policy/schema surface is bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T61zMNiPF4K29186r3uqc3

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/209"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790642132&installation_model_id=427051&pr_number=209&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F209&signature=64cb201f6666ae9ae9002e0381bfc3e078384488f38f317f520d945f1319dd1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->