### PR TITLE
fix(auth): classify IP literals correctly, including embedded and numeric forms (#210)

### DIFF
--- a/.consiliency/plans/detailed-public-host-check-20260830-1200.md
+++ b/.consiliency/plans/detailed-public-host-check-20260830-1200.md
@@ -1,5 +1,13 @@
 # Detailed plan: fix the IP-literal classification, and stop the docs overclaiming
 
+> **Revision 6 (2026-08-30).** The rev-4 board found a defect of a **different
+> class** than the five rounds before it: legacy numeric IPv4 forms
+> (`2852039166`, `0xA9FEA9FE`, `0177.0.0.1`) fail `ip_address()`, fall into the
+> "it's a DNS name" branch, and are **accepted** — while the resolver interprets
+> them directly as `169.254.169.254` and `127.0.0.1`. No DNS lookup is involved.
+> This is the most serious finding in the issue and it is **not** the deferred
+> #211 question.
+>
 > **Revision 5 (2026-08-30).** Rev 4's rule was still incomplete: I found two
 > more accepted bypasses by probing it — `::10.0.0.5` / `::127.0.0.1`
 > (IPv4-compatible IPv6) and `::0:5efe:a00:5` (ISATAP). **This is the fifth round
@@ -85,6 +93,30 @@ written to replace it.
   (ISATAP) still **accepted**. 6to4 (`2002::/16`) and Teredo (`2001::/32`) happen
   to be safe because both are already non-global — luck, not design, and worth a
   test so it stays true.
+
+### The numeric-form bypass — a second, distinct defect
+
+`_is_public_auth_host` treats *"`ip_address()` raised"* as *"this is a hostname,
+accept it"*. That conflates two very different things: a name whose target is
+unknowable without resolving (the #211 question), and **an IP address written in
+a form this code cannot parse**. Verified:
+
+```
+2852039166   ip_address() fails -> accepted   resolver -> 169.254.169.254
+0xA9FEA9FE   ip_address() fails -> accepted   resolver -> 169.254.169.254
+0177.0.0.1   ip_address() fails -> accepted   resolver -> 127.0.0.1
+167772161    ip_address() fails -> accepted   resolver -> 10.0.0.1
+10.0.0.1     ip_address() parses -> rejected
+```
+
+**Fix:** before deciding a host is a name, try to canonicalise it as a numeric
+address — decimal, hex, octal, and dotted variants — and if it resolves to one,
+classify it as a literal. A host that is *not* a name must not be granted a
+name's benefit of the doubt.
+
+**Do not fix this by resolving.** The correct rule is: if it can be read as a
+number, it is a literal, and literals go through the classifier. Only genuinely
+non-numeric hosts reach the accepted-unresolved path that #211 covers.
 
 ## Why this keeps happening
 
@@ -182,6 +214,12 @@ claim a green local suite that was not green.
       non-global — so the behaviour is pinned rather than incidental.
 - [ ] **The test matrix names each embedding format with its RFC.** The list must
       be readable as a specification, so a future format is a visible gap.
+- [ ] **Legacy numeric forms are rejected**: `2852039166`, `0xA9FEA9FE`,
+      `0177.0.0.1`, `167772161`, and the dotted-hex/octal variants. Each must
+      fail against `main`, where all are currently accepted. Two of them resolve
+      to the cloud-metadata address.
+- [ ] **A genuinely non-numeric host is still accepted** (`auth.example.com`), so
+      the canonicalisation does not swallow the DNS path that #211 covers.
 - [ ] **All five must-accept literals** still pass: `8.8.8.8`, `93.184.216.34`,
       `2001:4860:4860::8888`, `::ffff:8.8.8.8`, and `64:ff9b::808:808`. The last
       two are the over-rejection traps — a rule using `is_reserved` fails both.

--- a/.consiliency/plans/detailed-public-host-check-20260830-1200.md
+++ b/.consiliency/plans/detailed-public-host-check-20260830-1200.md
@@ -1,5 +1,12 @@
 # Detailed plan: fix the IP-literal classification, and stop the docs overclaiming
 
+> **Revision 5 (2026-08-30).** Rev 4's rule was still incomplete: I found two
+> more accepted bypasses by probing it — `::10.0.0.5` / `::127.0.0.1`
+> (IPv4-compatible IPv6) and `::0:5efe:a00:5` (ISATAP). **This is the fifth round
+> of "find another spelling", and that pattern is itself the finding** — see
+> "Why this keeps happening". Rev 5's rule is verified against 26 literals,
+> 0 mismatches.
+>
 > **Revision 4 (2026-08-30).** Rev 3 boarded 2 DISAGREE. Its prescribed recipe —
 > "prefer `is_global`" — **would have left `fec0::1` broken and regressed the
 > existing multicast test**. A rule I then drafted myself was wrong in both
@@ -51,13 +58,19 @@ written to replace it.
   The verified rule, 19 literals, 0 mismatches on Python 3.10:
 
   ```python
-  NAT64 = ip_network("64:ff9b::/96")
+  # Every IPv6 form that carries an IPv4 address in its low 32 bits.
+  _V4_EMBEDDING = [
+      ip_network("::ffff:0:0/96"),   # RFC 4291 IPv4-mapped
+      ip_network("::/96"),           # RFC 4291 IPv4-compatible (deprecated)
+      ip_network("64:ff9b::/96"),    # RFC 6052 NAT64 well-known prefix
+  ]
 
   def _unwrap(a):
       if isinstance(a, IPv6Address):
-          if a.ipv4_mapped is not None:
-              return a.ipv4_mapped
-          if a in NAT64:                      # embeds v4 in the low 32 bits
+          for net in _V4_EMBEDDING:
+              if a in net:
+                  return IPv4Address(int(a) & 0xFFFFFFFF)
+          if (int(a) >> 32) & 0xFFFF == 0x5EFE:   # RFC 5214 ISATAP
               return IPv4Address(int(a) & 0xFFFFFFFF)
       return a
 
@@ -66,6 +79,30 @@ written to replace it.
           and not getattr(addr, "is_site_local", False)
           and not addr.is_multicast)
   ```
+
+  **WAS WRONG (rev 4):** it unwrapped only `ipv4_mapped` and NAT64. Probing it
+  found `::10.0.0.5` and `::127.0.0.1` (IPv4-compatible) and `::0:5efe:a00:5`
+  (ISATAP) still **accepted**. 6to4 (`2002::/16`) and Teredo (`2001::/32`) happen
+  to be safe because both are already non-global — luck, not design, and worth a
+  test so it stays true.
+
+## Why this keeps happening
+
+Five rounds have each found another spelling of the same idea: *an IPv6 literal
+that carries an IPv4 address*. That is the identical failure mode as this repo's
+npm parser, which took five production fixes for the same reason — enumerating
+forms of a thing instead of modelling it.
+
+The difference, and the reason enumeration is defensible **here**: the set of
+IPv4-embedding IPv6 formats is closed and specified by RFCs (4291 mapped and
+compatible, 6052 NAT64, 3056 6to4, 4380 Teredo, 5214 ISATAP). It is a finite list
+with citations, not an open-ended vocabulary. The rule above covers all six —
+three by unwrapping, two because they are already non-global, one by pattern.
+
+What makes that safe to rely on is the **test**, not the code: the matrix must
+name every format and its RFC, so a seventh format added to the standards is a
+visible gap rather than a silent one. Do not let the list live only in the
+implementation.
 
   **WAS WRONG (rev 3):** "prefer `is_global`, falling back to an explicit check".
   `is_global` exists on every supported Python, so the fallback never runs — and
@@ -135,10 +172,16 @@ claim a green local suite that was not green.
 
 ## Acceptance criteria
 
-- [ ] **All five newly-rejected literals** fail against `main` and pass here:
+- [ ] **All eight newly-rejected literals** fail against `main` and pass here:
       `100.64.0.1`, `::ffff:100.64.0.1`, `fec0::1`, `64:ff9b::a00:5`,
-      `64:ff9b::7f00:1`. RED-on-main required for each — rev 3 named only the
-      first and third, and a fix satisfying rev 3 could still admit the other three.
+      `64:ff9b::7f00:1`, `::10.0.0.5`, `::127.0.0.1`, `::0:5efe:a00:5`.
+      RED-on-main required for each. Rev 3 named two of these and rev 4 named
+      five; a fix satisfying either could still admit the rest.
+- [ ] **6to4 and Teredo are asserted rejected** (`2002:0a00:0005::1`,
+      `2001:0:0:0:0:0:0a00:0005`) even though they pass today by being
+      non-global — so the behaviour is pinned rather than incidental.
+- [ ] **The test matrix names each embedding format with its RFC.** The list must
+      be readable as a specification, so a future format is a visible gap.
 - [ ] **All five must-accept literals** still pass: `8.8.8.8`, `93.184.216.34`,
       `2001:4860:4860::8888`, `::ffff:8.8.8.8`, and `64:ff9b::808:808`. The last
       two are the over-rejection traps — a rule using `is_reserved` fails both.

--- a/.consiliency/plans/detailed-public-host-check-20260830-1200.md
+++ b/.consiliency/plans/detailed-public-host-check-20260830-1200.md
@@ -1,0 +1,142 @@
+# Detailed plan: make the public-host check mean what it says
+
+## Task
+
+Close Consiliency/pmcp#210. `_is_public_auth_host` returns `True` — "public",
+therefore allowed — for **every hostname that is not an IP literal**, so a gate
+whose error reads *"Public auth URL host must be public"* admits
+`metadata.google.internal`.
+
+## Severity — corrected downward from the issue text
+
+The issue was filed from reading, and said severity "depends on whether an
+attacker can influence the auth URL, which I have not established". Established
+now, and it is **lower** than the issue implies. This is hardening and honesty,
+not a live vulnerability. Recording that plainly matters more than the fix: an
+overstated finding wastes the next reader's time and erodes trust in the ones
+that are real.
+
+Traced every call site:
+
+| site | input provenance | what happens to it |
+|---|---|---|
+| `transport/http.py:281` | operator config (`resource_server_jwks_url`) | validated, then **fetched** via `AsyncJWKS` |
+| `auth.py:205` | same JWKS URL | stored redacted for display; `_raw_url` fetched |
+| `auth.py:468` | **untrusted** — a remote server's `WWW-Authenticate` header | stored on `AuthChallengeInfo` |
+| `auth.py:519` | operator config / manifest / registry entries | surfaced in public metadata |
+| `auth.py:366`, `:639` | elicitation URLs | redacted for display |
+| `cli_commands/doctor.py:80` | operator config | printed |
+
+Two findings from that trace:
+
+- **The only fetched URL is operator-supplied.** An operator can already point
+  their own gateway anywhere; a private DNS name there is a configuration choice,
+  not an attack. `AsyncJWKS._fetch` also already sets `allow_redirects=False`,
+  which is evidence this class was thought about.
+- **The genuinely untrusted value is inert.** `AuthChallengeInfo.resource_metadata_url`
+  is parsed from a remote header, sanitised — and then **never referenced again
+  anywhere in `src/`**. Verified by grep. It is not fetched and not relayed.
+
+So there is **no verified attacker-controlled path to a fetch or a relay today.**
+
+What remains is real but narrower: a validation boundary that explicitly handles
+"untrusted authorization metadata" (`auth.py:519`'s own docstring) makes a
+promise it does not keep, and one input class — `protected_resource_metadata_url`
+carried on **registry entries** (`manifest/registry.py:355`) — is remote-sourced,
+so the boundary is doing untrusted-input work even where today's code does not
+reach a fetch. *(Reasoned, not verified: I did not trace whether a registry
+entry's value can reach a client-visible header.)*
+
+## Changes
+
+**The fix is to make the guarantee honest, not to resolve DNS.** Resolution at
+validation time buys little here — the only fetched URL is operator-supplied —
+while adding a TOCTOU gap, a DNS lookup on a caller-supplied string, and a new
+failure mode to define. That is a poor trade for a gate that is not currently
+load-bearing against an attacker.
+
+### `src/pmcp/auth.py` (modify)
+
+- `_is_public_auth_host` (`:127`) — modify — keep the behaviour, fix the
+  **contract**. Rename to something that states what it checks, e.g.
+  `_is_non_public_ip_literal` inverted, or keep the name and add a docstring that
+  says: this rejects IP literals that are private, loopback, link-local,
+  multicast or unspecified, and **accepts any DNS name without resolving it**.
+  A reader must be able to learn the limit from the function, not by testing it.
+- `sanitize_public_auth_url` (`:143`) — modify — the raised message currently
+  reads *"Public auth URL host must be public."* Narrow it to what was actually
+  checked, e.g. *"Public auth URL host must not be a private, loopback,
+  link-local or multicast IP address."* The current wording is what makes a
+  reader believe a name was vetted.
+- The module docstring or a comment near the gate — add — state the deliberate
+  decision **not** to resolve, and why (TOCTOU, DNS lookup on caller-supplied
+  input, and that the only fetched URL is operator-supplied). Without this, the
+  next reader re-derives the question or "fixes" it by adding resolution.
+
+### `tests/test_auth.py` (modify)
+
+- `test_sanitize_public_auth_url_rejects_invalid_and_non_public_urls` (`:738`) —
+  extend — add the **accepted** cases as explicit, named assertions:
+  `metadata.google.internal`, `internal.corp` and a plain
+  `example.com` all pass. Today that behaviour is real but unwritten, so a future
+  change to resolution would silently alter it with nothing going red.
+  A test that pins a *limitation* is how the limitation stays a decision.
+- Add the rejected IP-literal cases if not already covered: `10.0.0.5`,
+  `127.0.0.1`, `169.254.169.254`, `localhost`. Verified all four currently reject.
+
+## Documentation impact
+
+- `CHANGELOG.md` — add — `### Changed`, one line: the error message narrowed to
+  describe what is actually validated. No behaviour change, so not `### Fixed` —
+  claiming a fix would overstate it exactly as the issue did.
+- `README.md` — modify **only if** it documents the public-URL requirement for
+  auth metadata; check before editing.
+
+## Dependencies & order
+
+1. Tests first, pinning both current behaviours — accepted names and rejected
+   literals — **against unchanged code**. They must pass before anything changes;
+   that is what makes them a description of today rather than of the edit.
+2. Docstring, message, and comment.
+3. CHANGELOG.
+
+## Verification
+
+```bash
+uv run pytest -q tests/test_auth.py -k public_auth_url
+uv run pytest -q
+uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/
+```
+
+Note on this host: `/tmp/package.json` and `/tmp/node_modules` make the npm
+identity tests fail locally in a way that reproduces on a clean `main` export
+(`tests/conftest.py` documents it). Verify against `main` before attributing any
+failure to this diff, and do not claim a green local suite that was not green.
+
+## Acceptance criteria
+
+- [ ] `sanitize_public_auth_url` still **rejects** `10.0.0.5`, `127.0.0.1`,
+      `169.254.169.254` and `localhost`, and still **accepts**
+      `metadata.google.internal` and `example.com` — both directions asserted by
+      name, so the limitation is pinned rather than incidental.
+- [ ] The raised message no longer claims the host "must be public"; it names the
+      IP-literal classes actually rejected. Asserted on the message text.
+- [ ] `_is_public_auth_host`'s docstring states that a DNS name is accepted
+      unresolved, and the non-resolution decision is recorded with its reasons.
+- [ ] No behaviour change: the full test suite passes with no test modified other
+      than the additions above.
+
+## Non-goals
+
+- **Resolving hostnames.** Explicitly rejected above, with reasons. If a future
+  change makes an untrusted URL reachable by a fetch or a client-visible relay,
+  that decision should be revisited — and the recorded reasoning is what will
+  make that revisit possible.
+- Allowlisting auth hosts. Viable if the set is ever knowable; it is not today.
+- Auditing the `registry.py` provenance question named above. It is reasoned, not
+  verified, and deserves its own look rather than a guess folded in here.
+
+## Execution Policy
+
+- execute: effort=low, reason=a message, a docstring, and tests that pin existing
+  behaviour; the substance is in being accurate about what is and is not checked

--- a/.consiliency/plans/detailed-public-host-check-20260830-1200.md
+++ b/.consiliency/plans/detailed-public-host-check-20260830-1200.md
@@ -1,120 +1,86 @@
-# Detailed plan: make the public-host check mean what it says
+# Detailed plan: fix the IP-literal classification, and stop the docs overclaiming
 
-> **Revision 2 (2026-08-30).** Boarded **2 DISAGREE / 1 AGREE**. The DISAGREEs
-> disproved rev 1's central claim — that no attacker-influenced path reaches a
-> fetch or a relay. Rev 1's severity table also **mislabelled a fetch as
-> display**. Scope changed on the operator's instruction: reject non-public names
-> on the untrusted paths, rather than only documenting the gap.
+> **Revision 3 (2026-08-30).** Two board rounds. Rev 1 claimed no
+> attacker-influenced path reached a fetch or relay — disproved. Rev 2 proposed a
+> trust split — the board showed it would kill the elicitation feature and that
+> its own acceptance criterion would **freeze two live classification bugs**.
+> Scope narrowed on the operator's instruction: land the self-contained
+> IP-literal fix here; the trust split moves to **#211** with the evidence.
 
 ## Task
 
-Close Consiliency/pmcp#210. `_is_public_auth_host` returns `True` — "public",
-therefore allowed — for **every hostname that is not an IP literal**, so a gate
-whose error reads *"Public auth URL host must be public"* admits
-`metadata.google.internal`.
+Close Consiliency/pmcp#210's verifiable half. `_is_public_auth_host` classifies
+two non-public address ranges as public, and three user-facing sentences promise
+more than the code checks.
 
-## Severity — corrected, twice
+## What is actually broken — measured
 
-Rev 1 traced the call sites and concluded there was "no verified
-attacker-controlled path to a fetch or a relay today". **That was wrong**, and
-two seats showed why. Both corrections are verified here:
+```
+100.64.0.1      CGNAT / RFC 6598 shared      public=True   <-- wrong
+fec0::1         IPv6 site-local (RFC 3879)   public=True   <-- wrong
+169.254.169.254 link-local IMDS              public=False  correct
+::ffff:10.0.0.5 IPv4-mapped RFC1918          public=False  correct
+8.8.8.8         genuinely public             public=True   correct
+```
 
-**1. `auth.py:639` is a fetch, not display.** `fetch_json_metadata` calls
-`sanitize_public_auth_url(url, allow_loopback_http=True)` and then **`urlopen`s
-the result**. Rev 1's table listed it under "redacted for display". It is
-currently called only from `tests/test_auth.py`, so it is a *latent* fetch
-primitive rather than a live path — but the classification was simply wrong, and
-a latent fetch behind a gate that does not check names is exactly the thing that
-becomes live when someone wires it up.
+`_is_public_auth_host` tests `is_private or is_loopback or is_link_local or
+is_multicast or is_unspecified`. That misses **RFC 6598 shared address space**
+(`100.64.0.0/10`, used by carrier-grade NAT and by some cloud metadata paths) and
+**deprecated IPv6 site-local** (`fec0::/10`). Both are non-public and both pass.
 
-**2. The untrusted URL is relayed, not inert.** Rev 1 argued
-`AuthChallengeInfo.resource_metadata_url` was inert because grep found no
-internal consumers. Being unread inside `src/` is not the same as being inert: it
-is a field on a public dataclass, and the sibling elicitation path
-(`sanitize_url_elicitation_url` → `url_elicitations`) carries a **downstream
-server's URL to the operator**, having passed a check that reports it as public.
-pmcp is the vouching party. That is a confused-deputy relay, and it is the exact
-thing the "must be public" wording promises against.
+**A seat also claimed `::ffff:169.254.169.254` passes. It does not** — verified
+above; Python's `is_private` handles the IPv4-mapped form. Recorded so the next
+reader does not re-derive it.
 
-**3. The user-facing promise is broader than the code, in two files.**
-`README.md:168` and `SECURITY.md:39` both require the URL to be `https` **"on a
-public host"**. Rev 1 made the README conditional and did not mention
-`SECURITY.md` at all. Narrowing only the exception text would leave the same
-overstatement in the security policy.
-
-**The remaining true part of rev 1:** the only *fetched* URL reachable in
-production today (`resource_server_jwks_url` → `AsyncJWKS`) is operator-supplied,
-and that fetch already sets `allow_redirects=False`. So the operator path is not
-where the risk is — which is what makes a trust-split the right shape.
+**WAS WRONG (rev 2):** its acceptance criterion said "IP literals still behave as
+today", which would have **pinned both bugs as intended behaviour**. That is the
+same entrenching error the board caught in rev 1's criterion, in the criterion
+written to replace it.
 
 ## Changes
 
-**Split the gate by trust level.** The seam already exists and is currently
-pointed the wrong way: `sanitize_url_elicitation_url` (`auth.py:363`) is a named
-entry point for the untrusted elicitation path, and it delegates to
-`sanitize_public_auth_url(url, allow_loopback_http=True)` — *more* permissive
-than the operator path, not less.
-
-**No DNS resolution**, for the reasons rev 1 gave and the board upheld: TOCTOU,
-a lookup on caller-supplied input, and it is not real SSRF defence anyway
-(that needs connection-time IP pinning). The question is what a no-network rule
-can honestly assert.
-
 ### `src/pmcp/auth.py` (modify)
 
-- `_public_host_verdict(hostname)` — add — returns a three-way result rather than
-  a bool: `PRIVATE_LITERAL` (an IP literal in a private/loopback/link-local/
-  multicast/unspecified range, or `localhost`), `PUBLIC_LITERAL`, or
-  `UNVERIFIED_NAME` (any DNS name — because without resolving, that is the
-  strongest honest statement). Rev 1's bug was collapsing the third case into
-  "public".
-- `sanitize_public_auth_url` (`:143`) — modify — take a `trust` argument.
-  **Operator paths** accept `UNVERIFIED_NAME` (unchanged behaviour — an operator
-  can already point their gateway anywhere). **Untrusted paths reject it.**
-- `sanitize_url_elicitation_url` (`:363`) — modify — pass the untrusted trust
-  level, and **stop passing `allow_loopback_http=True`**. A downstream server
-  should not be able to hand the operator a loopback URL that pmcp presents as
-  validated.
-- The `WWW-Authenticate` parse (`:468`) — modify — same untrusted level.
-- Error messages — modify — say which rule rejected the input, and never claim a
-  name was verified public.
+- `_is_public_auth_host` (`:127`) — modify — **define public positively** rather
+  than by subtracting a list of bad ranges. A denylist of address properties has
+  now missed two ranges; the next added range will be missed the same way.
+  Prefer `is_global` where the stdlib offers it, falling back to an explicit
+  check that includes shared (`100.64.0.0/10`) and site-local (`fec0::/10`).
+  Whatever form, the rule must be stated so a reader can see what "public" means
+  without enumerating exclusions.
+- The docstring — modify — state plainly that **a DNS name is accepted without
+  resolution**. That limitation is real and stays; it is #211's subject, and it
+  must be visible here rather than implied.
+- `sanitize_public_auth_url`'s error message (`:143`) — modify — stop claiming
+  the host "must be public". Say what was checked: a non-public **IP literal**
+  was rejected. Do not imply a name was verified.
 
-**The honest limit, to be stated in the code and the CHANGELOG:** rejecting
-`UNVERIFIED_NAME` on untrusted paths means those paths accept **only IP literals
-in public ranges**. That is strict — it will reject legitimate public hostnames
-from well-behaved downstream servers. That is a real cost and the board should
-weigh it; the alternative is an operator allowlist for the untrusted paths, which
-is more work and more configuration. **Do not soften this into a suffix denylist**
-(`.internal`, `.local`, `.corp`): a denylist fails open on a custom internal TLD,
-which is the same fail-open shape this repo has now fixed five times.
+### `tests/test_auth.py` (modify)
+
+- Extend the existing public-URL test with the two fixed ranges and the
+  already-correct ones, each named: `100.64.0.1` and `fec0::1` **rejected**;
+  `169.254.169.254`, `::ffff:10.0.0.5`, `10.0.0.5`, `127.0.0.1`, `localhost`
+  rejected; `8.8.8.8` and a public DNS name accepted.
+- Add a test asserting the **name limitation** explicitly — that a DNS name is
+  accepted unresolved — with a comment pointing at #211. Pinning a limitation is
+  only right when it is *documented as a limitation*; rev 2's mistake was pinning
+  it as correctness.
 
 ## Documentation impact
 
-- `CHANGELOG.md` — add — `### Changed`. **Rev 2 is a behaviour change**, unlike
-  rev 1: a downstream server can no longer hand the operator a hostname-based URL
-  that pmcp presents as validated. State the cost explicitly — untrusted paths now
-  accept only public IP literals — so an operator seeing a legitimate server's URL
-  rejected can find out why.
-  **WAS WRONG (rev 1):** this bullet said "no behaviour change, so not
-  `### Fixed`". That reasoning was right for rev 1's scope and is wrong for this
-  one.
-- `README.md:168` — modify — **required**, not conditional. It says the URL must
-  be `https` "on a public host"; that is only true for IP literals.
-- `SECURITY.md:39` — modify — **required**. Same wording, in the security policy,
-  which is the worst place to overclaim. Rev 1 missed this file entirely.
+- `CHANGELOG.md` — add — `### Fixed`: two non-public IP ranges were accepted by
+  the auth-URL host check.
+- `README.md:168`, `README.md:173`, `SECURITY.md:39` — modify — all three promise
+  a "public host" or claim private/link-local/loopback/multicast hosts are
+  rejected. True only for IP literals. Qualify each. **`README:173` was found by a
+  seat and is absent from rev 2's list**; `SECURITY.md` was absent from rev 1's.
 
 ## Dependencies & order
 
-1. `_public_host_verdict` and its unit tests — the three-way verdict is the
-   primitive everything else reads.
-2. The `trust` split on `sanitize_public_auth_url`, then the two untrusted
-   callers (`sanitize_url_elicitation_url`, the `WWW-Authenticate` parse),
-   including dropping `allow_loopback_http=True` from the elicitation path.
-3. Operator-path tests **first among the integration tests** — the largest risk in
-   rev 2 is over-rejection breaking real deployments, so prove `auth.example.com`
-   still passes before proving the internal names fail.
-4. Messages, docstrings, README and SECURITY.md.
-5. CHANGELOG.
+1. The classification fix and its unit tests.
+2. The message and docstring.
+3. The three documentation sentences.
+4. CHANGELOG.
 
 ## Verification
 
@@ -124,45 +90,35 @@ uv run pytest -q
 uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/
 ```
 
-Note on this host: `/tmp/package.json` and `/tmp/node_modules` make the npm
-identity tests fail locally in a way that reproduces on a clean `main` export
-(`tests/conftest.py` documents it). Verify against `main` before attributing any
-failure to this diff, and do not claim a green local suite that was not green.
+This host's `/tmp/package.json` and `/tmp/node_modules` make the npm identity
+tests fail locally in a way that reproduces on a clean `main` export
+(`tests/conftest.py`). Verify against `main` before blaming this diff, and do not
+claim a green local suite that was not green.
 
 ## Acceptance criteria
 
-- [ ] On an **untrusted** path (`sanitize_url_elicitation_url`, and the
-      `WWW-Authenticate` parse), `https://metadata.google.internal/...` and
-      `https://internal.corp/...` are **rejected**.
-      **WAS WRONG (rev 1):** it required these to be *accepted*, which two seats
-      independently objected to — pinning them would have codified an
-      attacker-influenced relay as intended behaviour.
-- [ ] On an **operator** path (`resource_server_jwks_url`, doctor), a public DNS
-      name such as `auth.example.com` is still **accepted** — this must not
-      become a blanket rejection that breaks every real deployment.
-- [ ] IP literals still behave as today on both paths: `10.0.0.5`, `127.0.0.1`,
-      `169.254.169.254`, `localhost` rejected; a public literal accepted.
-- [ ] `sanitize_url_elicitation_url` no longer permits loopback HTTP — asserted
-      directly, since rev 1 did not notice it was passing `allow_loopback_http=True`.
-- [ ] No error message claims a hostname "must be public" or was verified public.
+- [ ] `100.64.0.1` and `fec0::1` are **rejected**, proven by a test that fails
+      against `main`. These are the defect; without a RED-on-main demonstration
+      the fix is unproven.
+- [ ] Every literal listed under "What is actually broken" keeps its correct
+      verdict — in particular `8.8.8.8` and `::ffff:10.0.0.5`, so the fix is not a
+      blanket rejection.
+- [ ] A public DNS name is still accepted, and a test says **in its name** that
+      this is a known limitation tracked by #211 — not a correctness assertion.
+- [ ] No error message claims a host "must be public" or was verified public.
       Asserted on message text.
-- [ ] `README.md:168` and `SECURITY.md:39` no longer promise a public host
-      without qualification.
-- [ ] Full suite green, and the existing `test_auth.py` public-URL tests still
-      pass or are updated with a stated reason per change.
+- [ ] `README.md:168`, `README.md:173` and `SECURITY.md:39` no longer promise
+      more than IP-literal filtering.
+- [ ] Full suite green.
 
 ## Non-goals
 
-- **Resolving hostnames.** Still rejected, for the reasons above, and the board
-  upheld that. Note rev 1 justified this partly by claiming no untrusted URL was
-  relayed — that justification is gone; the remaining ones (TOCTOU, a lookup on
-  caller-supplied input, and that resolution is not real SSRF defence without
-  connection-time pinning) stand on their own.
-- Allowlisting auth hosts. Viable if the set is ever knowable; it is not today.
-- Auditing the `registry.py` provenance question named above. It is reasoned, not
-  verified, and deserves its own look rather than a guess folded in here.
+- **The trust split, the fetch primitive, and the relay path** — all moved to
+  **#211**, which carries the board's evidence and the open design questions.
+- **DNS resolution**, and **suffix denylists**. Both rejected with reasons
+  recorded in #211.
 
 ## Execution Policy
 
-- execute: effort=low, reason=a message, a docstring, and tests that pin existing
-  behaviour; the substance is in being accurate about what is and is not checked
+- execute: effort=low, reason=a classification predicate, its tests, and three
+  documentation sentences; the subtlety is in not pinning the bugs as behaviour

--- a/.consiliency/plans/detailed-public-host-check-20260830-1200.md
+++ b/.consiliency/plans/detailed-public-host-check-20260830-1200.md
@@ -1,5 +1,11 @@
 # Detailed plan: fix the IP-literal classification, and stop the docs overclaiming
 
+> **Revision 4 (2026-08-30).** Rev 3 boarded 2 DISAGREE. Its prescribed recipe —
+> "prefer `is_global`" — **would have left `fec0::1` broken and regressed the
+> existing multicast test**. A rule I then drafted myself was wrong in both
+> directions too. Rev 4 carries a rule verified against 19 literals, 0
+> mismatches.
+>
 > **Revision 3 (2026-08-30).** Two board rounds. Rev 1 claimed no
 > attacker-influenced path reached a fetch or relay — disproved. Rev 2 proposed a
 > trust split — the board showed it would kill the elicitation feature and that
@@ -41,13 +47,45 @@ written to replace it.
 
 ### `src/pmcp/auth.py` (modify)
 
-- `_is_public_auth_host` (`:127`) — modify — **define public positively** rather
-  than by subtracting a list of bad ranges. A denylist of address properties has
-  now missed two ranges; the next added range will be missed the same way.
-  Prefer `is_global` where the stdlib offers it, falling back to an explicit
-  check that includes shared (`100.64.0.0/10`) and site-local (`fec0::/10`).
-  Whatever form, the rule must be stated so a reader can see what "public" means
-  without enumerating exclusions.
+- `_is_public_auth_host` (`:127`) — modify — **unwrap, then classify positively.**
+  The verified rule, 19 literals, 0 mismatches on Python 3.10:
+
+  ```python
+  NAT64 = ip_network("64:ff9b::/96")
+
+  def _unwrap(a):
+      if isinstance(a, IPv6Address):
+          if a.ipv4_mapped is not None:
+              return a.ipv4_mapped
+          if a in NAT64:                      # embeds v4 in the low 32 bits
+              return IPv4Address(int(a) & 0xFFFFFFFF)
+      return a
+
+  addr = _unwrap(ip_address(hostname))
+  return (addr.is_global
+          and not getattr(addr, "is_site_local", False)
+          and not addr.is_multicast)
+  ```
+
+  **WAS WRONG (rev 3):** "prefer `is_global`, falling back to an explicit check".
+  `is_global` exists on every supported Python, so the fallback never runs — and
+  `is_global` is **`True` for `fec0::1`**, leaving one of the two named defects in
+  place. Two seats caught it.
+
+  **Also wrong — a rule I drafted after rev 3**, recorded because it is the
+  instructive failure: `is_global and not is_site_local and not is_reserved`
+  **rejects `::ffff:8.8.8.8`** (every IPv4-mapped address is `is_reserved`) and
+  **accepts `224.0.0.1` and `ff02::1`** (multicast is `is_global` on 3.10),
+  which would have regressed the existing multicast test at
+  `tests/test_auth.py:751`. Getting it wrong in both directions is why the rule
+  above is stated as verified output rather than reasoning.
+
+  Three mapped/embedded forms drove the design, none of which the issue named:
+  `::ffff:100.64.0.1` (mapped CGNAT — `is_private` unwraps but CGNAT is not
+  IPv4-private, so it stayed public), and `64:ff9b::a00:5` / `64:ff9b::7f00:1`
+  (NAT64 embedding `10.0.0.5` and `127.0.0.1`). NAT64 wrapping a genuinely public
+  address — `64:ff9b::808:808` → `8.8.8.8` — must still be **accepted**, which is
+  what makes unwrapping the right move rather than rejecting the prefix wholesale.
 - The docstring — modify — state plainly that **a DNS name is accepted without
   resolution**. That limitation is real and stays; it is #211's subject, and it
   must be visible here rather than implied.
@@ -97,12 +135,17 @@ claim a green local suite that was not green.
 
 ## Acceptance criteria
 
-- [ ] `100.64.0.1` and `fec0::1` are **rejected**, proven by a test that fails
-      against `main`. These are the defect; without a RED-on-main demonstration
-      the fix is unproven.
-- [ ] Every literal listed under "What is actually broken" keeps its correct
-      verdict — in particular `8.8.8.8` and `::ffff:10.0.0.5`, so the fix is not a
-      blanket rejection.
+- [ ] **All five newly-rejected literals** fail against `main` and pass here:
+      `100.64.0.1`, `::ffff:100.64.0.1`, `fec0::1`, `64:ff9b::a00:5`,
+      `64:ff9b::7f00:1`. RED-on-main required for each — rev 3 named only the
+      first and third, and a fix satisfying rev 3 could still admit the other three.
+- [ ] **All five must-accept literals** still pass: `8.8.8.8`, `93.184.216.34`,
+      `2001:4860:4860::8888`, `::ffff:8.8.8.8`, and `64:ff9b::808:808`. The last
+      two are the over-rejection traps — a rule using `is_reserved` fails both.
+- [ ] **The existing multicast/link-local rejections still hold**: `224.0.0.1`,
+      `ff02::1`, `169.254.169.254`, `10.0.0.5`, `::ffff:10.0.0.5`, `127.0.0.1`,
+      `localhost`, `fc00::1`, `2001:db8::1`, `::`. A rule built on bare
+      `is_global` regresses the first two.
 - [ ] A public DNS name is still accepted, and a test says **in its name** that
       this is a known limitation tracked by #211 — not a correctness assertion.
 - [ ] No error message claims a host "must be public" or was verified public.

--- a/.consiliency/plans/detailed-public-host-check-20260830-1200.md
+++ b/.consiliency/plans/detailed-public-host-check-20260830-1200.md
@@ -1,5 +1,11 @@
 # Detailed plan: make the public-host check mean what it says
 
+> **Revision 2 (2026-08-30).** Boarded **2 DISAGREE / 1 AGREE**. The DISAGREEs
+> disproved rev 1's central claim — that no attacker-influenced path reaches a
+> fetch or a relay. Rev 1's severity table also **mislabelled a fetch as
+> display**. Scope changed on the operator's instruction: reject non-public names
+> on the untrusted paths, rather than only documenting the gap.
+
 ## Task
 
 Close Consiliency/pmcp#210. `_is_public_auth_host` returns `True` — "public",
@@ -7,90 +13,90 @@ therefore allowed — for **every hostname that is not an IP literal**, so a gat
 whose error reads *"Public auth URL host must be public"* admits
 `metadata.google.internal`.
 
-## Severity — corrected downward from the issue text
+## Severity — corrected, twice
 
-The issue was filed from reading, and said severity "depends on whether an
-attacker can influence the auth URL, which I have not established". Established
-now, and it is **lower** than the issue implies. This is hardening and honesty,
-not a live vulnerability. Recording that plainly matters more than the fix: an
-overstated finding wastes the next reader's time and erodes trust in the ones
-that are real.
+Rev 1 traced the call sites and concluded there was "no verified
+attacker-controlled path to a fetch or a relay today". **That was wrong**, and
+two seats showed why. Both corrections are verified here:
 
-Traced every call site:
+**1. `auth.py:639` is a fetch, not display.** `fetch_json_metadata` calls
+`sanitize_public_auth_url(url, allow_loopback_http=True)` and then **`urlopen`s
+the result**. Rev 1's table listed it under "redacted for display". It is
+currently called only from `tests/test_auth.py`, so it is a *latent* fetch
+primitive rather than a live path — but the classification was simply wrong, and
+a latent fetch behind a gate that does not check names is exactly the thing that
+becomes live when someone wires it up.
 
-| site | input provenance | what happens to it |
-|---|---|---|
-| `transport/http.py:281` | operator config (`resource_server_jwks_url`) | validated, then **fetched** via `AsyncJWKS` |
-| `auth.py:205` | same JWKS URL | stored redacted for display; `_raw_url` fetched |
-| `auth.py:468` | **untrusted** — a remote server's `WWW-Authenticate` header | stored on `AuthChallengeInfo` |
-| `auth.py:519` | operator config / manifest / registry entries | surfaced in public metadata |
-| `auth.py:366`, `:639` | elicitation URLs | redacted for display |
-| `cli_commands/doctor.py:80` | operator config | printed |
+**2. The untrusted URL is relayed, not inert.** Rev 1 argued
+`AuthChallengeInfo.resource_metadata_url` was inert because grep found no
+internal consumers. Being unread inside `src/` is not the same as being inert: it
+is a field on a public dataclass, and the sibling elicitation path
+(`sanitize_url_elicitation_url` → `url_elicitations`) carries a **downstream
+server's URL to the operator**, having passed a check that reports it as public.
+pmcp is the vouching party. That is a confused-deputy relay, and it is the exact
+thing the "must be public" wording promises against.
 
-Two findings from that trace:
+**3. The user-facing promise is broader than the code, in two files.**
+`README.md:168` and `SECURITY.md:39` both require the URL to be `https` **"on a
+public host"**. Rev 1 made the README conditional and did not mention
+`SECURITY.md` at all. Narrowing only the exception text would leave the same
+overstatement in the security policy.
 
-- **The only fetched URL is operator-supplied.** An operator can already point
-  their own gateway anywhere; a private DNS name there is a configuration choice,
-  not an attack. `AsyncJWKS._fetch` also already sets `allow_redirects=False`,
-  which is evidence this class was thought about.
-- **The genuinely untrusted value is inert.** `AuthChallengeInfo.resource_metadata_url`
-  is parsed from a remote header, sanitised — and then **never referenced again
-  anywhere in `src/`**. Verified by grep. It is not fetched and not relayed.
-
-So there is **no verified attacker-controlled path to a fetch or a relay today.**
-
-What remains is real but narrower: a validation boundary that explicitly handles
-"untrusted authorization metadata" (`auth.py:519`'s own docstring) makes a
-promise it does not keep, and one input class — `protected_resource_metadata_url`
-carried on **registry entries** (`manifest/registry.py:355`) — is remote-sourced,
-so the boundary is doing untrusted-input work even where today's code does not
-reach a fetch. *(Reasoned, not verified: I did not trace whether a registry
-entry's value can reach a client-visible header.)*
+**The remaining true part of rev 1:** the only *fetched* URL reachable in
+production today (`resource_server_jwks_url` → `AsyncJWKS`) is operator-supplied,
+and that fetch already sets `allow_redirects=False`. So the operator path is not
+where the risk is — which is what makes a trust-split the right shape.
 
 ## Changes
 
-**The fix is to make the guarantee honest, not to resolve DNS.** Resolution at
-validation time buys little here — the only fetched URL is operator-supplied —
-while adding a TOCTOU gap, a DNS lookup on a caller-supplied string, and a new
-failure mode to define. That is a poor trade for a gate that is not currently
-load-bearing against an attacker.
+**Split the gate by trust level.** The seam already exists and is currently
+pointed the wrong way: `sanitize_url_elicitation_url` (`auth.py:363`) is a named
+entry point for the untrusted elicitation path, and it delegates to
+`sanitize_public_auth_url(url, allow_loopback_http=True)` — *more* permissive
+than the operator path, not less.
+
+**No DNS resolution**, for the reasons rev 1 gave and the board upheld: TOCTOU,
+a lookup on caller-supplied input, and it is not real SSRF defence anyway
+(that needs connection-time IP pinning). The question is what a no-network rule
+can honestly assert.
 
 ### `src/pmcp/auth.py` (modify)
 
-- `_is_public_auth_host` (`:127`) — modify — keep the behaviour, fix the
-  **contract**. Rename to something that states what it checks, e.g.
-  `_is_non_public_ip_literal` inverted, or keep the name and add a docstring that
-  says: this rejects IP literals that are private, loopback, link-local,
-  multicast or unspecified, and **accepts any DNS name without resolving it**.
-  A reader must be able to learn the limit from the function, not by testing it.
-- `sanitize_public_auth_url` (`:143`) — modify — the raised message currently
-  reads *"Public auth URL host must be public."* Narrow it to what was actually
-  checked, e.g. *"Public auth URL host must not be a private, loopback,
-  link-local or multicast IP address."* The current wording is what makes a
-  reader believe a name was vetted.
-- The module docstring or a comment near the gate — add — state the deliberate
-  decision **not** to resolve, and why (TOCTOU, DNS lookup on caller-supplied
-  input, and that the only fetched URL is operator-supplied). Without this, the
-  next reader re-derives the question or "fixes" it by adding resolution.
+- `_public_host_verdict(hostname)` — add — returns a three-way result rather than
+  a bool: `PRIVATE_LITERAL` (an IP literal in a private/loopback/link-local/
+  multicast/unspecified range, or `localhost`), `PUBLIC_LITERAL`, or
+  `UNVERIFIED_NAME` (any DNS name — because without resolving, that is the
+  strongest honest statement). Rev 1's bug was collapsing the third case into
+  "public".
+- `sanitize_public_auth_url` (`:143`) — modify — take a `trust` argument.
+  **Operator paths** accept `UNVERIFIED_NAME` (unchanged behaviour — an operator
+  can already point their gateway anywhere). **Untrusted paths reject it.**
+- `sanitize_url_elicitation_url` (`:363`) — modify — pass the untrusted trust
+  level, and **stop passing `allow_loopback_http=True`**. A downstream server
+  should not be able to hand the operator a loopback URL that pmcp presents as
+  validated.
+- The `WWW-Authenticate` parse (`:468`) — modify — same untrusted level.
+- Error messages — modify — say which rule rejected the input, and never claim a
+  name was verified public.
 
-### `tests/test_auth.py` (modify)
-
-- `test_sanitize_public_auth_url_rejects_invalid_and_non_public_urls` (`:738`) —
-  extend — add the **accepted** cases as explicit, named assertions:
-  `metadata.google.internal`, `internal.corp` and a plain
-  `example.com` all pass. Today that behaviour is real but unwritten, so a future
-  change to resolution would silently alter it with nothing going red.
-  A test that pins a *limitation* is how the limitation stays a decision.
-- Add the rejected IP-literal cases if not already covered: `10.0.0.5`,
-  `127.0.0.1`, `169.254.169.254`, `localhost`. Verified all four currently reject.
+**The honest limit, to be stated in the code and the CHANGELOG:** rejecting
+`UNVERIFIED_NAME` on untrusted paths means those paths accept **only IP literals
+in public ranges**. That is strict — it will reject legitimate public hostnames
+from well-behaved downstream servers. That is a real cost and the board should
+weigh it; the alternative is an operator allowlist for the untrusted paths, which
+is more work and more configuration. **Do not soften this into a suffix denylist**
+(`.internal`, `.local`, `.corp`): a denylist fails open on a custom internal TLD,
+which is the same fail-open shape this repo has now fixed five times.
 
 ## Documentation impact
 
 - `CHANGELOG.md` — add — `### Changed`, one line: the error message narrowed to
   describe what is actually validated. No behaviour change, so not `### Fixed` —
   claiming a fix would overstate it exactly as the issue did.
-- `README.md` — modify **only if** it documents the public-URL requirement for
-  auth metadata; check before editing.
+- `README.md:168` — modify — **required**, not conditional. It says the URL must
+  be `https` "on a public host"; that is only true for IP literals.
+- `SECURITY.md:39` — modify — **required**. Same wording, in the security policy,
+  which is the worst place to overclaim. Rev 1 missed this file entirely.
 
 ## Dependencies & order
 
@@ -115,16 +121,25 @@ failure to this diff, and do not claim a green local suite that was not green.
 
 ## Acceptance criteria
 
-- [ ] `sanitize_public_auth_url` still **rejects** `10.0.0.5`, `127.0.0.1`,
-      `169.254.169.254` and `localhost`, and still **accepts**
-      `metadata.google.internal` and `example.com` — both directions asserted by
-      name, so the limitation is pinned rather than incidental.
-- [ ] The raised message no longer claims the host "must be public"; it names the
-      IP-literal classes actually rejected. Asserted on the message text.
-- [ ] `_is_public_auth_host`'s docstring states that a DNS name is accepted
-      unresolved, and the non-resolution decision is recorded with its reasons.
-- [ ] No behaviour change: the full test suite passes with no test modified other
-      than the additions above.
+- [ ] On an **untrusted** path (`sanitize_url_elicitation_url`, and the
+      `WWW-Authenticate` parse), `https://metadata.google.internal/...` and
+      `https://internal.corp/...` are **rejected**.
+      **WAS WRONG (rev 1):** it required these to be *accepted*, which two seats
+      independently objected to — pinning them would have codified an
+      attacker-influenced relay as intended behaviour.
+- [ ] On an **operator** path (`resource_server_jwks_url`, doctor), a public DNS
+      name such as `auth.example.com` is still **accepted** — this must not
+      become a blanket rejection that breaks every real deployment.
+- [ ] IP literals still behave as today on both paths: `10.0.0.5`, `127.0.0.1`,
+      `169.254.169.254`, `localhost` rejected; a public literal accepted.
+- [ ] `sanitize_url_elicitation_url` no longer permits loopback HTTP — asserted
+      directly, since rev 1 did not notice it was passing `allow_loopback_http=True`.
+- [ ] No error message claims a hostname "must be public" or was verified public.
+      Asserted on message text.
+- [ ] `README.md:168` and `SECURITY.md:39` no longer promise a public host
+      without qualification.
+- [ ] Full suite green, and the existing `test_auth.py` public-URL tests still
+      pass or are updated with a stated reason per change.
 
 ## Non-goals
 

--- a/.consiliency/plans/detailed-public-host-check-20260830-1200.md
+++ b/.consiliency/plans/detailed-public-host-check-20260830-1200.md
@@ -90,9 +90,14 @@ which is the same fail-open shape this repo has now fixed five times.
 
 ## Documentation impact
 
-- `CHANGELOG.md` — add — `### Changed`, one line: the error message narrowed to
-  describe what is actually validated. No behaviour change, so not `### Fixed` —
-  claiming a fix would overstate it exactly as the issue did.
+- `CHANGELOG.md` — add — `### Changed`. **Rev 2 is a behaviour change**, unlike
+  rev 1: a downstream server can no longer hand the operator a hostname-based URL
+  that pmcp presents as validated. State the cost explicitly — untrusted paths now
+  accept only public IP literals — so an operator seeing a legitimate server's URL
+  rejected can find out why.
+  **WAS WRONG (rev 1):** this bullet said "no behaviour change, so not
+  `### Fixed`". That reasoning was right for rev 1's scope and is wrong for this
+  one.
 - `README.md:168` — modify — **required**, not conditional. It says the URL must
   be `https` "on a public host"; that is only true for IP literals.
 - `SECURITY.md:39` — modify — **required**. Same wording, in the security policy,
@@ -100,11 +105,16 @@ which is the same fail-open shape this repo has now fixed five times.
 
 ## Dependencies & order
 
-1. Tests first, pinning both current behaviours — accepted names and rejected
-   literals — **against unchanged code**. They must pass before anything changes;
-   that is what makes them a description of today rather than of the edit.
-2. Docstring, message, and comment.
-3. CHANGELOG.
+1. `_public_host_verdict` and its unit tests — the three-way verdict is the
+   primitive everything else reads.
+2. The `trust` split on `sanitize_public_auth_url`, then the two untrusted
+   callers (`sanitize_url_elicitation_url`, the `WWW-Authenticate` parse),
+   including dropping `allow_loopback_http=True` from the elicitation path.
+3. Operator-path tests **first among the integration tests** — the largest risk in
+   rev 2 is over-rejection breaking real deployments, so prove `auth.example.com`
+   still passes before proving the internal names fail.
+4. Messages, docstrings, README and SECURITY.md.
+5. CHANGELOG.
 
 ## Verification
 
@@ -143,10 +153,11 @@ failure to this diff, and do not claim a green local suite that was not green.
 
 ## Non-goals
 
-- **Resolving hostnames.** Explicitly rejected above, with reasons. If a future
-  change makes an untrusted URL reachable by a fetch or a client-visible relay,
-  that decision should be revisited — and the recorded reasoning is what will
-  make that revisit possible.
+- **Resolving hostnames.** Still rejected, for the reasons above, and the board
+  upheld that. Note rev 1 justified this partly by claiming no untrusted URL was
+  relayed — that justification is gone; the remaining ones (TOCTOU, a lookup on
+  caller-supplied input, and that resolution is not real SSRF defence without
+  connection-time pinning) stand on their own.
 - Allowlisting auth hosts. Viable if the set is ever knowable; it is not today.
 - Auditing the `registry.py` provenance question named above. It is reasoned, not
   verified, and deserves its own look rather than a guess folded in here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The public auth-URL host check accepted several non-public hosts.** Two
+  distinct defects in `_is_public_auth_host`, both reachable through auth
+  metadata, elicitation, and `resource_server_jwks_url`:
+  - The classifier subtracted a list of bad properties (`is_private`,
+    `is_loopback`, `is_link_local`, `is_multicast`, `is_unspecified`), and that
+    list had holes. RFC 6598 CGNAT (`100.64.0.0/10`) and deprecated RFC 3879
+    IPv6 site-local (`fec0::/10`) were classified as public, as were IPv4
+    addresses embedded in IPv6 literals — `64:ff9b::7f00:1` (RFC 6052 NAT64
+    carrying `127.0.0.1`), `::10.0.0.5` (RFC 4291 IPv4-compatible) and
+    `::0:5efe:a00:5` (RFC 5214 ISATAP). The check now unwraps every
+    IPv4-embedding IPv6 format and then classifies positively.
+  - **Legacy numeric host forms bypassed the check entirely.** `ip_address()`
+    raises on them, and the code read "raised" as "this is a DNS name, accept
+    it" — while a stock resolver reads `2852039166` and `0xA9FEA9FE` as
+    `169.254.169.254` and `0177.0.0.1` as `127.0.0.1`, with no DNS lookup
+    involved. Such hosts are now canonicalised (not resolved) and classified as
+    the literals they are.
+
+  Genuinely public addresses are unaffected, including public addresses carried
+  inside an embedding format (`::ffff:8.8.8.8`, `64:ff9b::808:808`). A DNS name
+  is still accepted without being resolved; that limitation is now stated in the
+  docstring, `README.md` and `SECURITY.md` instead of being implied away, and is
+  tracked in #211. The error message no longer claims the host "must be public",
+  since only IP literals are ever checked. (#210)
+
 ## [2.7.1] - 2026-08-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     the literals they are.
 
   Genuinely public addresses are unaffected, including public addresses carried
-  inside an embedding format (`::ffff:8.8.8.8`, `64:ff9b::808:808`). A DNS name
-  is still accepted without being resolved; that limitation is now stated in the
-  docstring, `README.md` and `SECURITY.md` instead of being implied away, and is
-  tracked in #211. The error message no longer claims the host "must be public",
-  since only IP literals are ever checked. (#210)
+  inside an embedding format (`::ffff:8.8.8.8`, `64:ff9b::808:808`) and addresses
+  that merely resemble one: ISATAP is matched on its full RFC 5214 §6.1
+  interface identifier (`00-00-5E-FE`, or `02-00-5E-FE` with the u/g bit set),
+  not on the `5efe` hextet alone, so an ordinary global address such as
+  `2606:4700::1234:5efe:a00:5` is still accepted.
+
+  Two limitations remain, both name-shaped and both tracked in #211: a DNS name
+  is accepted **without being resolved**, and so is a trailing-dot IPv4 such as
+  `169.254.169.254.`, which POSIX `inet_aton` also rejects as an address. The
+  DNS-name limitation is now stated in the docstring, `README.md` and
+  `SECURITY.md` instead of being implied away. The error message no longer claims
+  the host "must be public", since only IP literals are ever checked. (#210)
 
 ## [2.7.1] - 2026-08-30
 

--- a/README.md
+++ b/README.md
@@ -165,13 +165,20 @@ audience is bound to the configured `resource_server_audience` (the server's
 canonical resource URI, per RFC 8707); it is never derived from the request
 Host header. `resource-server` mode fails closed at startup if the issuer,
 JWKS URL, or audience is missing, and `resource_server_jwks_url` must be an
-`https` URL on a public host. Token signatures are only accepted for the
+`https` URL whose host is not a non-public IP literal. Token signatures are
+only accepted for the
 operator-configured `resource_server_allowed_algorithms` allowlist (default
 `RS256`/`ES256`); the token's own `alg` header is never trusted. JWKS is fetched
 asynchronously and cached, so validation never blocks the event loop; an
 unreachable JWKS endpoint returns `503` while an invalid token returns `401`.
-It rejects private, link-local, loopback, multicast, and unspecified hosts in
-public auth metadata URLs. PMCP is still not an Authorization Server and does
+In public auth metadata URLs it rejects hosts written as non-public **IP
+literals** — private, CGNAT, link-local, loopback, multicast, site-local, and
+unspecified — including IPv4 addresses embedded in IPv6 literals and legacy
+numeric forms such as `2852039166`. This is a filter on literals only: a DNS
+name is accepted **without being resolved**, so a name that points at an
+internal address still passes (tracked in
+[#211](https://github.com/Consiliency/pmcp/issues/211)). PMCP is still not an
+Authorization Server and does
 not provide dynamic client registration, SSO, RBAC, billing, or a complete
 multi-tenant identity service.
 

--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ audience is bound to the configured `resource_server_audience` (the server's
 canonical resource URI, per RFC 8707); it is never derived from the request
 Host header. `resource-server` mode fails closed at startup if the issuer,
 JWKS URL, or audience is missing, and `resource_server_jwks_url` must be an
-`https` URL whose host is not a non-public IP literal. Token signatures are
-only accepted for the
-operator-configured `resource_server_allowed_algorithms` allowlist (default
-`RS256`/`ES256`); the token's own `alg` header is never trusted. JWKS is fetched
+`https` URL and is rejected when its host is a non-public IP literal. Token
+signatures are only accepted for the operator-configured
+`resource_server_allowed_algorithms` allowlist (default `RS256`/`ES256`); the
+token's own `alg` header is never trusted. JWKS is fetched
 asynchronously and cached, so validation never blocks the event loop; an
 unreachable JWKS endpoint returns `503` while an invalid token returns `401`.
 In public auth metadata URLs it rejects hosts written as non-public **IP
@@ -176,11 +176,10 @@ literals** — private, CGNAT, link-local, loopback, multicast, site-local, and
 unspecified — including IPv4 addresses embedded in IPv6 literals and legacy
 numeric forms such as `2852039166`. This is a filter on literals only: a DNS
 name is accepted **without being resolved**, so a name that points at an
-internal address still passes (tracked in
-[#211](https://github.com/Consiliency/pmcp/issues/211)). PMCP is still not an
-Authorization Server and does
-not provide dynamic client registration, SSO, RBAC, billing, or a complete
-multi-tenant identity service.
+internal address still passes
+([#211](https://github.com/Consiliency/pmcp/issues/211)). PMCP is still not an
+Authorization Server and does not provide dynamic client registration, SSO,
+RBAC, billing, or a complete multi-tenant identity service.
 
 Auth mode and OAuth resource-server parameters are configurable from the CLI or
 environment (CLI flags take precedence; env values are read only when the flag

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,7 +36,8 @@ PMCP is a local-first MCP gateway. Its default security posture assumes:
   are only accepted for the operator-configured algorithm allowlist (default
   `RS256`/`ES256`); the token's own `alg` header is never trusted. The mode
   fails closed at startup without an issuer, JWKS URL, and audience, and the
-  JWKS URL must be `https` on a public host. JWKS is fetched asynchronously and
+  JWKS URL must be `https` and is rejected when its host is a non-public IP
+  literal (see the DNS-name limitation below). JWKS is fetched asynchronously and
   cached so validation never blocks the event loop; an unreachable JWKS endpoint
   returns `503` while an invalid or wrong-audience token returns `401`.
 - Timing oracle attacks on token comparison (`hmac.compare_digest`)
@@ -64,6 +65,15 @@ PMCP is a local-first MCP gateway. Its default security posture assumes:
 
 ### Known limitations
 
+- **The auth-URL host check filters IP literals only**: a public auth metadata
+  or JWKS URL is rejected when its host is a non-public IP literal — private,
+  CGNAT, link-local, loopback, multicast, site-local or unspecified, including
+  IPv4 addresses embedded in IPv6 literals (RFC 4291 mapped and compatible,
+  RFC 6052 NAT64, RFC 3056 6to4, RFC 4380 Teredo, RFC 5214 ISATAP) and legacy
+  numeric forms such as `2852039166` or `0177.0.0.1`. **A DNS name is accepted
+  without being resolved**, so a name pointing at an internal address is not
+  caught. Tracked in
+  [#211](https://github.com/Consiliency/pmcp/issues/211).
 - **No mTLS**: clients are not authenticated by certificate; only Bearer token.
 - **No per-tool ACL on HTTP**: any valid token can invoke any tool. Tool-level policy is
   enforced at the MCP layer, not the HTTP layer.

--- a/src/pmcp/auth.py
+++ b/src/pmcp/auth.py
@@ -239,10 +239,15 @@ def _is_public_auth_host(hostname: str) -> bool:
     """
     if hostname.lower() == "localhost":
         return False
+    # Only the parse is guarded: a ValueError escaping the classifier would
+    # otherwise be misread as "not a literal" and fail open.
+    address: IPv4Address | IPv6Address | None
     try:
-        return _is_public_ip(ip_address(hostname))
+        address = ip_address(hostname)
     except ValueError:
-        pass
+        address = None
+    if address is not None:
+        return _is_public_ip(address)
     numeric = _legacy_numeric_addresses(hostname)
     if numeric:
         return all(_is_public_ip(address) for address in numeric)

--- a/src/pmcp/auth.py
+++ b/src/pmcp/auth.py
@@ -8,7 +8,8 @@ import time
 import asyncio
 from collections.abc import Mapping
 from dataclasses import dataclass
-from ipaddress import ip_address
+from ipaddress import IPv4Address, IPv6Address, ip_address, ip_network
+from itertools import product
 from typing import Any
 from urllib.error import HTTPError
 from urllib.parse import parse_qsl, quote, urlparse, urlunparse
@@ -124,20 +125,126 @@ def _is_loopback_host(hostname: str) -> bool:
         return False
 
 
+# Every IPv6 format that carries an IPv4 address in its low 32 bits. The set is
+# closed and RFC-specified, so enumerating it is defensible -- but the list must
+# not live only here. The matrix in tests/test_auth.py names each format with its
+# RFC so that a seventh format is a visible gap rather than a silent one.
+_V4_EMBEDDING_NETWORKS = (
+    ip_network("::ffff:0:0/96"),  # RFC 4291 IPv4-mapped
+    ip_network("::/96"),  # RFC 4291 IPv4-compatible (deprecated)
+    ip_network("64:ff9b::/96"),  # RFC 6052 NAT64 well-known prefix
+)
+# RFC 5214 ISATAP interface identifier; RFC 3056 6to4 (2002::/16) and RFC 4380
+# Teredo (2001::/32) need no unwrapping because neither prefix is global.
+_ISATAP_MARKER = 0x5EFE
+
+# inet_aton part grammar. A part is hex, octal, or decimal; a leading zero is
+# read as octal by glibc but as decimal by stricter resolvers, so both readings
+# are produced and the host is rejected if either one is non-public.
+_HEX_PART = re.compile(r"0[xX][0-9a-fA-F]+")
+_OCTAL_PART = re.compile(r"0[0-7]*")
+_DECIMAL_PART = re.compile(r"[0-9]+")
+
+
+def _unwrap_embedded_v4(address: IPv4Address | IPv6Address) -> IPv4Address | IPv6Address:
+    """Return the IPv4 address an IPv6 literal embeds, or the address unchanged."""
+    if isinstance(address, IPv6Address):
+        for network in _V4_EMBEDDING_NETWORKS:
+            if address in network:
+                return IPv4Address(int(address) & 0xFFFFFFFF)
+        if (int(address) >> 32) & 0xFFFF == _ISATAP_MARKER:
+            return IPv4Address(int(address) & 0xFFFFFFFF)
+    return address
+
+
+def _is_public_ip(address: IPv4Address | IPv6Address) -> bool:
+    """Classify an address positively, after unwrapping any embedded IPv4.
+
+    Classifying positively (what *is* public) rather than subtracting a list of
+    bad properties is deliberate: the subtractive form missed RFC 6598 CGNAT and
+    RFC 3879 site-local. `is_global` alone is not enough -- it is True for
+    ``fec0::1`` and, on Python 3.10, for multicast.
+    """
+    unwrapped = _unwrap_embedded_v4(address)
+    return bool(
+        unwrapped.is_global
+        and not getattr(unwrapped, "is_site_local", False)
+        and not unwrapped.is_multicast
+    )
+
+
+def _numeric_part_values(part: str) -> set[int]:
+    """Every integer a resolver could plausibly read one inet_aton part as."""
+    if _HEX_PART.fullmatch(part):
+        return {int(part, 16)}
+    values: set[int] = set()
+    if _DECIMAL_PART.fullmatch(part):
+        values.add(int(part, 10))
+    if _OCTAL_PART.fullmatch(part):
+        values.add(int(part, 8))
+    return values
+
+
+def _legacy_numeric_addresses(hostname: str) -> set[IPv4Address]:
+    """Read a host as a legacy numeric IPv4 literal, without resolving anything.
+
+    ``ip_address()`` rejects the inet_aton forms that every stock resolver still
+    accepts, so ``2852039166``, ``0xA9FEA9FE`` and ``0177.0.0.1`` reach
+    169.254.169.254 and 127.0.0.1 with no DNS lookup involved. Treating "did not
+    parse" as "must be a DNS name" therefore hands a literal the benefit of the
+    doubt owed only to a name.
+
+    Returns every reading; an empty set means the host is genuinely not numeric
+    and belongs on the name path.
+    """
+    parts = hostname.split(".")
+    if not 1 <= len(parts) <= 4:
+        return set()
+    readings: list[list[int]] = []
+    for part in parts:
+        values = _numeric_part_values(part)
+        if not values:
+            return set()
+        readings.append(sorted(values))
+
+    addresses: set[IPv4Address] = set()
+    for combination in product(*readings):
+        # inet_aton: every leading part is one byte and the final part fills the
+        # remaining low bytes, so `169.254.43518` and `5` are addresses too.
+        *head, tail = combination
+        if any(value > 0xFF for value in head):
+            continue
+        if tail >= 1 << (8 * (4 - len(head))):
+            continue
+        packed = tail
+        for index, value in enumerate(head):
+            packed |= value << (8 * (3 - index))
+        addresses.add(IPv4Address(packed))
+    return addresses
+
+
 def _is_public_auth_host(hostname: str) -> bool:
+    """Report whether an auth URL's host is a public IP literal or a DNS name.
+
+    Only IP literals are actually classified. **A DNS name is accepted without
+    being resolved**, so this function cannot tell that ``metadata.example.com``
+    points at 169.254.169.254. That limitation is real and tracked by #211; it is
+    stated here rather than implied because the caller's error message used to
+    claim more than this check performs.
+
+    Legacy numeric forms are *not* names: anything readable as a number is
+    canonicalised and classified as the literal it is.
+    """
     if hostname.lower() == "localhost":
         return False
     try:
-        address = ip_address(hostname)
+        return _is_public_ip(ip_address(hostname))
     except ValueError:
-        return True
-    return not (
-        address.is_private
-        or address.is_loopback
-        or address.is_link_local
-        or address.is_multicast
-        or address.is_unspecified
-    )
+        pass
+    numeric = _legacy_numeric_addresses(hostname)
+    if numeric:
+        return all(_is_public_ip(address) for address in numeric)
+    return True
 
 
 def sanitize_public_auth_url(url: str, *, allow_loopback_http: bool = False) -> str:
@@ -160,7 +267,9 @@ def sanitize_public_auth_url(url: str, *, allow_loopback_http: bool = False) -> 
         allow_loopback_http and parsed.scheme == "http" and _is_loopback_host(hostname)
     ):
         if not _is_public_auth_host(hostname):
-            raise ValueError("Public auth URL host must be public.")
+            raise ValueError(
+                "Public auth URL host is a non-public IP literal or loopback name."
+            )
 
     return redact_auth_url(url)
 

--- a/src/pmcp/auth.py
+++ b/src/pmcp/auth.py
@@ -146,7 +146,9 @@ _OCTAL_PART = re.compile(r"0[0-7]*")
 _DECIMAL_PART = re.compile(r"[0-9]+")
 
 
-def _unwrap_embedded_v4(address: IPv4Address | IPv6Address) -> IPv4Address | IPv6Address:
+def _unwrap_embedded_v4(
+    address: IPv4Address | IPv6Address,
+) -> IPv4Address | IPv6Address:
     """Return the IPv4 address an IPv6 literal embeds, or the address unchanged."""
     if isinstance(address, IPv6Address):
         for network in _V4_EMBEDDING_NETWORKS:

--- a/src/pmcp/auth.py
+++ b/src/pmcp/auth.py
@@ -134,9 +134,15 @@ _V4_EMBEDDING_NETWORKS = (
     ip_network("::/96"),  # RFC 4291 IPv4-compatible (deprecated)
     ip_network("64:ff9b::/96"),  # RFC 6052 NAT64 well-known prefix
 )
-# RFC 5214 ISATAP interface identifier; RFC 3056 6to4 (2002::/16) and RFC 4380
-# Teredo (2001::/32) need no unwrapping because neither prefix is global.
-_ISATAP_MARKER = 0x5EFE
+# RFC 5214 §6.1: an ISATAP interface identifier is the full 32 bits
+# `00-00-5E-FE` -- or `02-00-5E-FE` with the u/g bit set -- immediately followed
+# by the IPv4 address in the low 32 bits. Matching only the `5efe` hextet is not
+# enough to identify ISATAP: `2606:4700::1234:5efe:a00:5` is an ordinary global
+# address that merely happens to carry `5efe` there, and unwrapping it would
+# reject a genuinely public host.
+# RFC 3056 6to4 (2002::/16) and RFC 4380 Teredo (2001::/32) need no unwrapping
+# because neither prefix is global.
+_ISATAP_INTERFACE_IDS = (0x00005EFE, 0x02005EFE)
 
 # inet_aton part grammar. A part is hex, octal, or decimal; a leading zero is
 # read as octal by glibc but as decimal by stricter resolvers, so both readings
@@ -154,7 +160,7 @@ def _unwrap_embedded_v4(
         for network in _V4_EMBEDDING_NETWORKS:
             if address in network:
                 return IPv4Address(int(address) & 0xFFFFFFFF)
-        if (int(address) >> 32) & 0xFFFF == _ISATAP_MARKER:
+        if ((int(address) >> 32) & 0xFFFFFFFF) in _ISATAP_INTERFACE_IDS:
             return IPv4Address(int(address) & 0xFFFFFFFF)
     return address
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -756,11 +756,170 @@ def test_sanitize_public_auth_url_rejects_invalid_and_non_public_urls() -> None:
         "https://169.254.169.254/meta",
         "https://224.0.0.1/meta",
         "https://0.0.0.0/meta",
+        # #210: the two ranges the subtractive classifier let through.
+        "https://100.64.0.1/meta",
+        "https://[fec0::1]/meta",
         "ftp://auth.example/meta",
         "http://auth.example/meta",
     ]:
         with pytest.raises(ValueError):
             sanitize_public_auth_url(url)
+
+
+# --------------------------------------------------------------------------- #
+# Public-host classification matrix (#210)
+#
+# `_is_public_auth_host` classifies IP *literals* only. What follows is the
+# specification for that classification, not a sample of it.
+#
+# Every IPv6 format that can carry an IPv4 address in its low 32 bits is named
+# here with its RFC. The list is closed and standards-defined, which is what
+# makes enumerating it defensible -- but it must not live only in the
+# implementation. If a seventh embedding format is standardised, its absence
+# from this matrix is the visible gap that catches it. Do not shorten or
+# de-duplicate these labels.
+#
+#   RFC 4291  IPv4-mapped         ::ffff:0:0/96    unwrapped
+#   RFC 4291  IPv4-compatible     ::/96            unwrapped (deprecated form)
+#   RFC 6052  NAT64 well-known    64:ff9b::/96     unwrapped
+#   RFC 5214  ISATAP              ..:5efe:a.b.c.d  unwrapped by marker
+#   RFC 3056  6to4                2002::/16        already non-global
+#   RFC 4380  Teredo              2001::/32        already non-global
+#
+# The last two pass today only because neither prefix is global -- luck, not
+# design. They are pinned below so that stays true.
+# --------------------------------------------------------------------------- #
+
+_MUST_ACCEPT_HOSTS = [
+    ("8.8.8.8", "public IPv4"),
+    ("93.184.216.34", "public IPv4"),
+    ("2001:4860:4860::8888", "public IPv6"),
+    # Over-rejection traps: a rule adding `not is_reserved` fails both, because
+    # every IPv4-mapped address is is_reserved.
+    ("::ffff:8.8.8.8", "RFC 4291 IPv4-mapped, wrapping a public address"),
+    ("64:ff9b::808:808", "RFC 6052 NAT64, wrapping a public address"),
+]
+
+_MUST_REJECT_HOSTS = [
+    # --- Fixed by #210: ranges the subtractive classifier missed -------------
+    ("100.64.0.1", "RFC 6598 CGNAT shared address space"),
+    ("::ffff:100.64.0.1", "RFC 4291 IPv4-mapped, wrapping RFC 6598 CGNAT"),
+    ("fec0::1", "RFC 3879 deprecated IPv6 site-local"),
+    # --- Fixed by #210: IPv4 embedded in an IPv6 literal --------------------
+    ("64:ff9b::a00:5", "RFC 6052 NAT64, embedding 10.0.0.5"),
+    ("64:ff9b::7f00:1", "RFC 6052 NAT64, embedding 127.0.0.1"),
+    ("::10.0.0.5", "RFC 4291 IPv4-compatible, embedding 10.0.0.5"),
+    ("::127.0.0.1", "RFC 4291 IPv4-compatible, embedding 127.0.0.1"),
+    ("::0:5efe:a00:5", "RFC 5214 ISATAP, embedding 10.0.0.5"),
+    # --- Pinned, not fixed: these are already non-global ---------------------
+    ("2002:0a00:0005::1", "RFC 3056 6to4, embedding 10.0.0.5"),
+    ("2001:0:0:0:0:0:0a00:0005", "RFC 4380 Teredo"),
+    # --- Fixed by #210: legacy numeric forms, which ip_address() cannot parse
+    # and which the resolver reads directly -- no DNS lookup is involved.
+    ("2852039166", "legacy decimal -> 169.254.169.254 (cloud metadata)"),
+    ("0xA9FEA9FE", "legacy hex -> 169.254.169.254 (cloud metadata)"),
+    ("0xa9fea9fe", "legacy hex, lowercased by urlparse"),
+    ("0177.0.0.1", "legacy octal -> 127.0.0.1"),
+    ("167772161", "legacy decimal -> 10.0.0.1"),
+    ("2130706433", "legacy decimal -> 127.0.0.1"),
+    ("0xa9.0xfe.0xa9.0xfe", "dotted hex -> 169.254.169.254"),
+    ("0251.0376.0251.0376", "dotted octal -> 169.254.169.254"),
+    ("169.254.43518", "3-part inet_aton -> 169.254.169.254"),
+    ("169.16689662", "2-part inet_aton -> 169.254.169.254"),
+    ("0x7f.1", "2-part dotted hex -> 127.0.0.1"),
+    # glibc reads a leading zero as octal (8.0.0.1) but stricter resolvers read
+    # it as decimal (10.0.0.1). Ambiguous means rejected: over-rejection is the
+    # safe direction, and no must-accept host has a leading zero.
+    ("010.0.0.1", "ambiguous leading zero; the decimal reading is 10.0.0.1"),
+    ("5", "bare integer -> 0.0.0.5"),
+    # --- Already rejected before #210; must not regress ----------------------
+    ("224.0.0.1", "IPv4 multicast -- a bare is_global rule regresses this"),
+    ("ff02::1", "IPv6 multicast -- a bare is_global rule regresses this"),
+    ("169.254.169.254", "IPv4 link-local cloud metadata"),
+    ("10.0.0.5", "RFC 1918 private"),
+    ("::ffff:10.0.0.5", "RFC 4291 IPv4-mapped, wrapping RFC 1918"),
+    ("127.0.0.1", "loopback"),
+    ("localhost", "loopback name"),
+    ("fc00::1", "RFC 4193 unique local"),
+    ("2001:db8::1", "RFC 3849 documentation range"),
+    ("::", "unspecified"),
+]
+
+
+def _auth_url(host: str) -> str:
+    # An IPv6 literal must be bracketed, or urlparse reads the ':' as a port
+    # separator and the URL is rejected for a reason that has nothing to do
+    # with host classification.
+    return f"https://{f'[{host}]' if ':' in host else host}/meta"
+
+
+@pytest.mark.parametrize(
+    "host,rationale", _MUST_ACCEPT_HOSTS, ids=[h for h, _ in _MUST_ACCEPT_HOSTS]
+)
+def test_public_auth_url_accepts_public_ip_literals(host: str, rationale: str) -> None:
+    assert sanitize_public_auth_url(_auth_url(host)) == _auth_url(host), rationale
+
+
+@pytest.mark.parametrize(
+    "host,rationale", _MUST_REJECT_HOSTS, ids=[h for h, _ in _MUST_REJECT_HOSTS]
+)
+def test_public_auth_url_rejects_non_public_ip_literals(
+    host: str, rationale: str
+) -> None:
+    with pytest.raises(ValueError) as excinfo:
+        sanitize_public_auth_url(_auth_url(host))
+    # Guard against passing for the wrong reason -- a malformed URL raises the
+    # same exception type from a different branch.
+    assert "non-public IP literal" in str(excinfo.value), rationale
+
+
+def test_public_auth_url_error_message_does_not_claim_the_host_was_verified() -> None:
+    """The old message promised far more than the check performs (#210)."""
+    with pytest.raises(ValueError) as excinfo:
+        sanitize_public_auth_url("https://10.0.0.5/meta")
+    message = str(excinfo.value)
+    assert "must be public" not in message
+    assert "verified" not in message
+    assert "non-public IP literal" in message
+
+
+def test_public_auth_url_accepts_dns_names_unresolved_known_limitation_of_211() -> None:
+    """KNOWN LIMITATION, tracked by #211 -- not an assertion of correctness.
+
+    A DNS name is accepted without being resolved, so a name pointing at
+    169.254.169.254 passes this check. This test pins the limitation so that
+    closing #211 has to change it deliberately; #210 deliberately does not fix
+    it, because resolving here would introduce a TOCTOU gap of its own.
+    """
+    assert (
+        sanitize_public_auth_url("https://auth.example.com/meta")
+        == "https://auth.example.com/meta"
+    )
+
+
+def test_public_auth_url_still_accepts_non_numeric_hosts_after_canonicalisation() -> (
+    None
+):
+    """Canonicalising numeric hosts must not swallow the DNS path (#210)."""
+    for host in [
+        "auth.example.com",
+        "metadata.google.internal",
+        "1.example.com",  # a numeric label, but the host is not a number
+        "999.999.999.999",  # numeric-looking, but no valid reading exists
+        "0xdeadbeefcafe",  # exceeds 32 bits, so it is not an address
+        "1.2.3.4.5",  # too many parts for inet_aton
+    ]:
+        assert sanitize_public_auth_url(_auth_url(host)) == _auth_url(host)
+
+
+def test_public_auth_host_canonicalisation_rejects_python_int_quirks() -> None:
+    """`int()` accepts separators, signs, and non-ASCII digits; hosts must not.
+
+    Parsing with a bare `int(part)` would canonicalise these into literals and
+    reject them, or worse, mis-read them. They are hostnames, not addresses.
+    """
+    for host in ["1_0", "١٢٧", "+2852039166"]:
+        assert sanitize_public_auth_url(_auth_url(host)) == _auth_url(host)
 
 
 def test_normalize_auth_metadata_omits_invalid_urls_with_safe_diagnostics() -> None:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -912,11 +912,13 @@ def test_public_auth_url_still_accepts_non_numeric_hosts_after_canonicalisation(
         assert sanitize_public_auth_url(_auth_url(host)) == _auth_url(host)
 
 
-def test_public_auth_host_canonicalisation_rejects_python_int_quirks() -> None:
-    """`int()` accepts separators, signs, and non-ASCII digits; hosts must not.
+def test_public_auth_host_does_not_read_python_int_quirks_as_addresses() -> None:
+    """`int()` accepts separators, signs, and non-ASCII digits; the parser must not.
 
-    Parsing with a bare `int(part)` would canonicalise these into literals and
-    reject them, or worse, mis-read them. They are hostnames, not addresses.
+    `int("1_0")` is 10 and `int("١٢٧")` is 127, so canonicalising with a bare
+    `int(part)` would turn these hostnames into addresses. No resolver reads them
+    that way, so they stay on the name path. The parser matches ASCII character
+    classes before converting, which is what keeps that true.
     """
     for host in ["1_0", "١٢٧", "+2852039166"]:
         assert sanitize_public_auth_url(_auth_url(host)) == _auth_url(host)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -782,7 +782,11 @@ def test_sanitize_public_auth_url_rejects_invalid_and_non_public_urls() -> None:
 #   RFC 4291  IPv4-mapped         ::ffff:0:0/96    unwrapped
 #   RFC 4291  IPv4-compatible     ::/96            unwrapped (deprecated form)
 #   RFC 6052  NAT64 well-known    64:ff9b::/96     unwrapped
-#   RFC 5214  ISATAP              ..:5efe:a.b.c.d  unwrapped by marker
+#   RFC 5214  ISATAP              ..:0:5efe:a.b.c.d unwrapped by interface id
+#             -- the interface id is the full 32 bits 00-00-5E-FE, or
+#             02-00-5E-FE with the u/g bit set (RFC 5214 section 6.1). The
+#             `5efe` hextet alone does NOT identify ISATAP; see the
+#             over-rejection trap in _MUST_ACCEPT_HOSTS.
 #   RFC 3056  6to4                2002::/16        already non-global
 #   RFC 4380  Teredo              2001::/32        already non-global
 #
@@ -798,6 +802,15 @@ _MUST_ACCEPT_HOSTS = [
     # every IPv4-mapped address is is_reserved.
     ("::ffff:8.8.8.8", "RFC 4291 IPv4-mapped, wrapping a public address"),
     ("64:ff9b::808:808", "RFC 6052 NAT64, wrapping a public address"),
+    # Over-rejection trap for ISATAP: an ordinary global address that merely
+    # carries `5efe` in that hextet. Matching the marker alone rather than the
+    # full RFC 5214 interface identifier unwraps this to 10.0.0.5 and rejects a
+    # genuinely public host. No other must-accept host carries an incidental
+    # `5efe`, which is why the whole suite stayed green through that bug.
+    (
+        "2606:4700::1234:5efe:a00:5",
+        "global address with an incidental 5efe hextet -- NOT RFC 5214 ISATAP",
+    ),
 ]
 
 _MUST_REJECT_HOSTS = [
@@ -810,7 +823,9 @@ _MUST_REJECT_HOSTS = [
     ("64:ff9b::7f00:1", "RFC 6052 NAT64, embedding 127.0.0.1"),
     ("::10.0.0.5", "RFC 4291 IPv4-compatible, embedding 10.0.0.5"),
     ("::127.0.0.1", "RFC 4291 IPv4-compatible, embedding 127.0.0.1"),
-    ("::0:5efe:a00:5", "RFC 5214 ISATAP, embedding 10.0.0.5"),
+    ("::0:5efe:a00:5", "RFC 5214 ISATAP (00-00-5E-FE), embedding 10.0.0.5"),
+    ("::0:5efe:7f00:1", "RFC 5214 ISATAP (00-00-5E-FE), embedding 127.0.0.1"),
+    ("::200:5efe:a00:5", "RFC 5214 ISATAP with the u/g bit set (02-00-5E-FE)"),
     # --- Pinned, not fixed: these are already non-global ---------------------
     ("2002:0a00:0005::1", "RFC 3056 6to4, embedding 10.0.0.5"),
     ("2001:0:0:0:0:0:0a00:0005", "RFC 4380 Teredo"),


### PR DESCRIPTION
`_is_public_auth_host` decides whether an auth-metadata URL's host is public, and
`sanitize_public_auth_url` rejected non-public hosts with *"Public auth URL host must be
public."* The check was far weaker than that message claimed. See #210.

## Two distinct defects

**1. The IP classifier missed whole ranges.** It subtracted a list of bad properties
(`is_private or is_loopback or is_link_local or is_multicast or is_unspecified`), and that
list had holes. RFC 6598 CGNAT (`100.64.0.0/10`), deprecated RFC 3879 site-local
(`fec0::/10`), and every IPv6 format carrying an IPv4 address in its low 32 bits passed as
public. Replaced with a rule that **unwraps, then classifies positively**.

Bare `is_global` is not a substitute: it is `True` for `fec0::1` and, on Python 3.10, for
multicast — it would leave a named defect and regress the existing multicast test. Adding
`not is_reserved` is also wrong: it rejects `::ffff:8.8.8.8`. Both were tried in earlier
plan revisions and failed.

**2. Legacy numeric forms bypassed the check entirely.** `ip_address()` raises on them, and
the code read *"raised"* as *"this is a DNS name, accept it"*. A stock resolver reads them
directly, with **no DNS lookup involved**:

```
2852039166   ip_address() fails -> accepted   getaddrinfo -> 169.254.169.254
0xA9FEA9FE   ip_address() fails -> accepted   getaddrinfo -> 169.254.169.254
0177.0.0.1   ip_address() fails -> accepted   getaddrinfo -> 127.0.0.1
167772161    ip_address() fails -> accepted   getaddrinfo -> 10.0.0.1
10.0.0.1     ip_address() parses -> rejected
```

Fixed by **canonicalising, not resolving**: a host readable as an `inet_aton` number is a
literal and goes through the classifier. Only genuinely non-numeric hosts reach the
accepted-unresolved path.

A part with a leading zero is ambiguous — glibc reads `010` as octal (8), stricter
resolvers as decimal (10) — so both readings are classified and the host is rejected if
either is non-public. Over-rejection is the safe direction and no must-accept host has a
leading zero.

## The defect surface differs by Python version

Worth stating, because it is not in the issue. The embedded-IPv6 forms are **already
rejected on Python 3.13+** (`ipaddress` changed `is_private`/`is_global` in 3.12.4+), but
are **live on the entire CI matrix (3.10, 3.11, 3.12)**. Verifying only on a modern
interpreter would have hidden eight of them. The new rule was verified to give identical
results on **3.10, 3.11, 3.12, 3.13 and 3.14** — 24 literals, 0 mismatches on each — so the
fix also normalises behaviour across versions.

## RED-on-main demonstration

Run against a clean `git archive origin/main` export, not by reasoning. All 22 literals the
fix newly rejects are **ACCEPTED on main**, identically on 3.10 and 3.12:

```
### Must be newly REJECTED by the fix  (expected: REJECTED)   [SOURCE: git archive origin/main]
  MISMATCH 100.64.0.1                   ACCEPTED   RFC 6598 CGNAT shared address space
  MISMATCH ::ffff:100.64.0.1            ACCEPTED   RFC 4291 IPv4-mapped, wrapping RFC 6598 CGNAT
  MISMATCH fec0::1                      ACCEPTED   RFC 3879 deprecated IPv6 site-local
  MISMATCH 64:ff9b::a00:5               ACCEPTED   RFC 6052 NAT64, embedding 10.0.0.5
  MISMATCH 64:ff9b::7f00:1              ACCEPTED   RFC 6052 NAT64, embedding 127.0.0.1
  MISMATCH ::10.0.0.5                   ACCEPTED   RFC 4291 IPv4-compatible, embedding 10.0.0.5
  MISMATCH ::127.0.0.1                  ACCEPTED   RFC 4291 IPv4-compatible, embedding 127.0.0.1
  MISMATCH ::0:5efe:a00:5               ACCEPTED   RFC 5214 ISATAP (00-00-5E-FE), embedding 10.0.0.5
  MISMATCH ::0:5efe:7f00:1              ACCEPTED   RFC 5214 ISATAP (00-00-5E-FE), embedding 127.0.0.1
  MISMATCH ::200:5efe:a00:5             ACCEPTED   RFC 5214 ISATAP with u/g bit set (02-00-5E-FE)
  MISMATCH 2852039166                   ACCEPTED   legacy decimal -> 169.254.169.254 (IMDS)
  MISMATCH 0xA9FEA9FE                   ACCEPTED   legacy hex -> 169.254.169.254 (IMDS)
  MISMATCH 0177.0.0.1                   ACCEPTED   legacy octal -> 127.0.0.1
  MISMATCH 167772161                    ACCEPTED   legacy decimal -> 10.0.0.1
  MISMATCH 2130706433                   ACCEPTED   legacy decimal -> 127.0.0.1
  MISMATCH 0xa9.0xfe.0xa9.0xfe          ACCEPTED   dotted hex -> 169.254.169.254 (IMDS)
  MISMATCH 0251.0376.0251.0376          ACCEPTED   dotted octal -> 169.254.169.254 (IMDS)
  MISMATCH 169.254.43518                ACCEPTED   3-part inet_aton -> 169.254.169.254 (IMDS)
  MISMATCH 169.16689662                 ACCEPTED   2-part inet_aton -> 169.254.169.254 (IMDS)
  MISMATCH 0x7f.1                       ACCEPTED   2-part dotted hex -> 127.0.0.1
  MISMATCH 010.0.0.1                    ACCEPTED   ambiguous leading zero; decimal reading is 10.0.0.1
  MISMATCH 5                            ACCEPTED   bare integer -> 0.0.0.5
```

On the fixed tree, the same 38-host matrix is clean on both interpreters — and critically,
**a rule that rejects everything does not pass it**: 7 must-accept hosts, including three
over-rejection traps and a DNS name, are asserted accepted.

```
######## FIXED tree @ Python 3.10 ########
41 hosts; newly-rejected group mismatches=0, must-accept mismatches=0, must-stay-rejected mismatches=0
######## FIXED tree @ Python 3.12 ########
41 hosts; newly-rejected group mismatches=0, must-accept mismatches=0, must-stay-rejected mismatches=0
```

Must-accept (unchanged): `8.8.8.8`, `93.184.216.34`, `2001:4860:4860::8888`,
`::ffff:8.8.8.8`, `64:ff9b::808:808`, `2606:4700::1234:5efe:a00:5`, `auth.example.com`.

## The test matrix is the deliverable

`tests/test_auth.py` names **every** IPv6 embedding format with its RFC, so a seventh format
added to the standards is a visible gap rather than a silent one. The list deliberately does
not live only in the implementation.

| RFC | Format | Prefix | Handling |
| --- | --- | --- | --- |
| 4291 | IPv4-mapped | `::ffff:0:0/96` | unwrapped |
| 4291 | IPv4-compatible (deprecated) | `::/96` | unwrapped |
| 6052 | NAT64 well-known | `64:ff9b::/96` | unwrapped |
| 5214 | ISATAP | `..:0:5efe:a.b.c.d` | unwrapped by full interface id |
| 3056 | 6to4 | `2002::/16` | already non-global |
| 4380 | Teredo | `2001::/32` | already non-global |

6to4 and Teredo pass today only because neither prefix is global — luck, not design. They are
pinned so that stays true.

### Board fix: ISATAP was matched on the marker hextet alone

Review caught an **over-rejection** originating in the plan's rule, not in the implementation
of it. The predicate tested `(int(a) >> 32) & 0xFFFF == 0x5EFE`, but RFC 5214 §6.1 defines the
interface identifier as the full 32 bits `00-00-5E-FE` — or `02-00-5E-FE` with the u/g bit set
— immediately followed by the IPv4 address. The marker alone is not sufficient:

```
host                          want    OLD(marker)  NEW(full iid)
2606:4700::1234:5efe:a00:5    ACCEPT  reject FAIL  accept ok
::0:5efe:a00:5                REJECT  reject ok    reject ok
::0:5efe:7f00:1               REJECT  reject ok    reject ok
::200:5efe:a00:5              REJECT  reject ok    reject ok
2606:4700:4700::1111          ACCEPT  accept ok    accept ok
```

`2606:4700::1234:5efe:a00:5` is an ordinary global address that merely carries `5efe` in that
hextet; the old predicate unwrapped it to `10.0.0.5` and rejected a genuinely public host. CI
stayed green through it because **no must-accept host in the matrix carried an incidental
`5efe`** — so that host is now a must-accept row, and the u/g variant `::200:5efe:a00:5` (a
real ISATAP form the matrix did not cover) is now a reject row.

**Known limitation, not fixed here:** a trailing-dot IPv4 such as `169.254.169.254.` takes the
name path — `split(".")` yields five labels, and POSIX `inet_aton` rejects that form as an
address too. It is name-shaped, so it belongs with #211; recorded in the CHANGELOG.

## Deliberately not in scope

**A DNS name is still accepted without resolution.** That is tracked in #211 along with the
trust split, `fetch_json_metadata`, and the relay path. A test pins the behaviour and says
**in its name** that it is a known limitation of #211 — pinning it *as a limitation* is
right where an earlier revision's pinning it *as correctness* would have frozen the bugs.

## Docs

`README.md` (two sentences) and `SECURITY.md` no longer promise a "public host". Each now
says what is actually checked, and `SECURITY.md` gains a *Known limitations* entry naming the
DNS-name gap and the embedding formats covered. The error message no longer claims the host
"must be public"; a test asserts on the message text.

No tag, no version bump — the CHANGELOG entry is under `[Unreleased]`.

## Verification

**CI (`e9236df`): all 12 checks pass**, including `test (3.10)`, `test (3.11)` and
`test (3.12)` — the three interpreters on which the embedded-IPv6 defects were live.

Locally, the suite is **not** green on this host and is not claimed to be. `/tmp/package.json`
and `/tmp/node_modules` are present, which `tests/conftest.py` documents as flipping every
`monkeypatch.chdir(tmp_path)` npm-identity test from resolving to refusing. The claim made
here is **failure parity**, measured against a clean `git archive origin/main` export run
with the same interpreter and the same host condition:

```
branch (final tree, e9236df):            107 failed, 3082 passed, 3 skipped, 106 errors
main-export (git archive origin/main):   119 failed, 3002 passed, 3 skipped, 129 errors

=== FAILS ON BRANCH BUT NOT ON MAIN  (would be regressions from this diff) ===
--- (empty above means zero new failures) ---
```

The branch's failing set is a strict subset of main's, so this diff introduces **zero new
failures**. The 35 main-export-only failures are export-environment artifacts — the archive
is not a git repository or an installed package:

```
      7 ERROR  tests/runtime/test_get_retired.py
      8 ERROR  tests/runtime/test_wire_handshake_era.py
      8 ERROR  tests/runtime/test_wire_modern_era.py
      9 FAILED tests/runtime/test_harness.py
      1 FAILED tests/runtime/test_subscriptions_e2e.py
      2 FAILED tests/test_workflow_guards.py
```

`tests/test_auth.py` has **zero** failures on either side: 97 collected, 97 passed, of which
45 are new (41 parametrized matrix rows plus 4 standalone tests). `ruff check`, `ruff format --check` and `mypy src/` are all clean.
