### PR TITLE
chore: v2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.2] - 2026-08-30
+
 ### Fixed
 - **The public auth-URL host check accepted several non-public hosts.** Two
   distinct defects in `_is_public_auth_host`, both reachable through auth

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "2.7.1"
+version = "2.7.2"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "2.7.1"
+__version__ = "2.7.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "2.7.1"
+version = "2.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts 2.7.2. Ships #210 (PR #212).

## What changes for users

**22 IP literals move from accepted to rejected** by `sanitize_public_auth_url`. Two of them — `0xA9FEA9FE` and `2852039166` — resolve to the cloud metadata endpoint `169.254.169.254` and were previously accepted.

Patch rather than minor, on the same reasoning as 2.7.1: no API change, and the inputs whose treatment changes were never legitimate. A validator whose error says *"host must be public"* should always have rejected them.

## The two defects

- **The classifier subtracted a list of bad properties and had holes** — RFC 6598 shared space (`100.64.0.0/10`), IPv6 site-local (`fec0::/10`), and every IPv6 form carrying an IPv4 address in its low 32 bits. Now unwraps RFC 4291 mapped/compatible, RFC 6052 NAT64 and RFC 5214 ISATAP, then classifies positively.
- **Legacy numeric forms bypassed it entirely** — `ip_address()` raising was treated as "this is a DNS name, accept it". Fixed by canonicalising through the `inet_aton` grammar, not by resolving. A host is rejected if *any* valid reading is non-public.

## Verified

All 22 demonstrated RED against a clean `origin/main` export at Python 3.10 and 3.12. Must-accept hosts unaffected, including the over-rejection traps `::ffff:8.8.8.8`, `64:ff9b::808:808` and `2606:4700::1234:5efe:a00:5` (a global address carrying an incidental `5efe`).

## Still open, stated in the docs

A DNS name is accepted without resolution, and a trailing-dot IPv4 takes the name path. Both are name-shaped and tracked in #211. `README.md` and `SECURITY.md` no longer promise a verified public host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T61zMNiPF4K29186r3uqc3

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790705060&installation_model_id=427051&pr_number=213&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F213&signature=f7e8b033b3fa37aa45f731305f9e162c2aafa0f017ab6d250ee5111f9dae4de2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->