### PR TITLE
fix(auth): stop vouching for URLs a downstream server supplied (#211)

### DIFF
--- a/.consiliency/plans/detailed-auth-trust-split-20260830-1600.md
+++ b/.consiliency/plans/detailed-auth-trust-split-20260830-1600.md
@@ -1,0 +1,137 @@
+# Detailed plan: stop vouching for URLs a downstream server supplied
+
+## Task
+
+Close Consiliency/pmcp#211. `sanitize_public_auth_url` applies one permissiveness
+to inputs of very different provenance, and pmcp presents the result as
+validated. A downstream server can hand back a URL on an internal host and have
+pmcp show it to the operator as though pmcp checked it.
+
+## What #210 already closed — measured today, post-merge
+
+#211 was filed before #210 landed. Re-checking the untrusted elicitation path
+now:
+
+```
+https://0xA9FEA9FE/x              rejected     <- #210 closed this
+https://metadata.google.internal/x  ACCEPTED   <- remains
+http://127.0.0.1/cb                 ACCEPTED   <- remains
+https://auth.vendor.com/x           ACCEPTED   <- legitimate, must stay
+```
+
+So the numeric-form relay is gone. **What is left is names, and loopback HTTP.**
+That is a materially smaller issue than filed, and the plan is scoped to it.
+
+Two other open questions from the issue, now answered:
+
+- **The JWKS URL is purely operator-supplied.** It reaches
+  `transport/http.py:281` only from `cli.py:2295`'s `--oauth-jwks-url`. It does
+  **not** arrive from a manifest or registry entry. The issue speculated it
+  might; it does not.
+- **`fetch_json_metadata` still has no production caller** — only its own
+  definition at `auth.py:756`.
+
+## The shape of the fix
+
+**Do not reject names on the untrusted paths.** A board round established that
+rejecting unverifiable names there would refuse
+`https://auth.vendor.com/...` from a well-behaved server — killing the feature
+the check exists to protect. Rejecting is right for a *fetch* and wrong for a
+*relay*.
+
+The harm is not that pmcp accepts the URL. It is that pmcp **presents it as
+validated**. So:
+
+- **Fail closed on fetches.** Anything pmcp will retrieve must be verifiably
+  public.
+- **Stop vouching on relays.** Keep passing the URL through, but stop implying
+  pmcp checked where it points.
+
+### `src/pmcp/auth.py` (modify)
+
+- `fetch_json_metadata` (`:756`) — **delete it**, or give it an explicit
+  fetch-trust gate. It is a live `urlopen` primitive with no production caller.
+  Deleting is preferred: a loaded gun with no user is a liability, and it can be
+  restored from git with its trust decision made deliberately. **If it is kept**,
+  it must reject anything that is not a verifiably-public literal, since it
+  fetches.
+- `sanitize_url_elicitation_url` (`:485`) — modify — **stop passing
+  `allow_loopback_http=True`.** Verified: a downstream server can currently hand
+  back `http://127.0.0.1/cb` and have it accepted. A local-OAuth callback is the
+  *operator's* flow, not something a remote server should be able to induce.
+  If a legitimate local flow depends on this, that flow should pass an explicit
+  operator-side flag rather than inheriting the permission from an untrusted
+  payload — say so if the tests prove otherwise.
+- A `verified` signal on the returned value — add — the untrusted sanitisers
+  should return, alongside the URL, whether the host was verified as a public
+  literal or merely accepted as an unresolved name. Without this the callers
+  cannot present it honestly, which is the whole finding.
+
+### Presentation (modify)
+
+- `cli.py` — where `url_elicitations` are shown to the operator — must mark an
+  unverified host plainly: this URL came from the server and its destination was
+  not checked. Today the operator is told to open it, with no such distinction.
+- `AuthChallengeInfo.resource_metadata_url` and `AuthMetadataInfo` — carry the
+  same signal, so any consumer of the public dataclasses can tell the difference.
+
+## Documentation impact
+
+- `CHANGELOG.md` — `### Changed`: pmcp no longer implies it verified where a
+  server-supplied auth URL points, and no longer accepts a loopback HTTP URL from
+  a downstream server.
+- `README.md` / `SECURITY.md` — the #210 wording already says the check filters
+  IP literals. Extend to state that a server-supplied URL is relayed unverified
+  and is presented as such.
+
+## Dependencies & order
+
+1. The `verified` signal, with unit tests — everything else reads it.
+2. The `allow_loopback_http` removal and its tests.
+3. `fetch_json_metadata` — delete or gate.
+4. Presentation changes.
+5. Docs.
+
+## Verification
+
+```bash
+uv run pytest -q tests/test_auth.py
+uv run pytest -q
+uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/ && uv run mypy src/
+```
+
+`/tmp/package.json` and `/tmp/node_modules` on this host make ~107 npm-identity
+tests fail locally in a way that reproduces on a clean `main` export
+(`tests/conftest.py`). Verify against `main` before blaming this diff.
+
+## Acceptance criteria
+
+- [ ] A downstream elicitation payload carrying `http://127.0.0.1/cb` is
+      **rejected** — proven by a test failing against `main`, where it is
+      currently accepted.
+- [ ] `https://auth.vendor.com/...` from a downstream server is **still
+      accepted** — the feature must survive. A change that rejects names must not
+      pass.
+- [ ] A relayed URL whose host is an unresolved name is marked **unverified**,
+      and the operator-facing output says so. Asserted on the emitted text, not
+      on a field's presence.
+- [ ] A relayed URL whose host is a verified public literal is **not** marked
+      unverified — so the signal distinguishes, rather than labelling everything.
+- [ ] `fetch_json_metadata` is either gone, or rejects a non-public literal.
+      Asserted either way, so "we left it alone" cannot pass.
+- [ ] Full suite green.
+
+## Non-goals
+
+- **Resolving hostnames.** Rejected across three board rounds: TOCTOU, a lookup
+  on caller-supplied input, and it is not SSRF defence without connection-time IP
+  pinning.
+- **The trailing-dot IPv4 form** (`169.254.169.254.`), which takes the name path.
+  It is name-shaped; if the `verified` signal is right, it is relayed unverified
+  like any other name.
+- Re-opening #210's literal classification. It is closed and pinned by 22 tests.
+
+## Execution Policy
+
+- execute: effort=medium, reason=small diff, but it changes what pmcp claims to
+  an operator, and the risk is over-rejecting a legitimate auth flow

--- a/.consiliency/plans/detailed-auth-trust-split-20260830-1600.md
+++ b/.consiliency/plans/detailed-auth-trust-split-20260830-1600.md
@@ -1,5 +1,8 @@
 # Detailed plan: stop vouching for URLs a downstream server supplied
 
+> **Revision 2 (2026-08-30).** Boarded 2 DISAGREE. Rev 1 named the wrong types
+> and would have broken a frozen operator contract. Both verified below.
+
 ## Task
 
 Close Consiliency/pmcp#211. `sanitize_public_auth_url` applies one permissiveness
@@ -55,25 +58,36 @@ validated**. So:
   restored from git with its trust decision made deliberately. **If it is kept**,
   it must reject anything that is not a verifiably-public literal, since it
   fetches.
-- `sanitize_url_elicitation_url` (`:485`) — modify — **stop passing
-  `allow_loopback_http=True`.** Verified: a downstream server can currently hand
-  back `http://127.0.0.1/cb` and have it accepted. A local-OAuth callback is the
-  *operator's* flow, not something a remote server should be able to induce.
-  If a legitimate local flow depends on this, that flow should pass an explicit
-  operator-side flag rather than inheriting the permission from an untrusted
-  payload — say so if the tests prove otherwise.
-- A `verified` signal on the returned value — add — the untrusted sanitisers
-  should return, alongside the URL, whether the host was verified as a public
-  literal or merely accepted as an unresolved name. Without this the callers
-  cannot present it honestly, which is the whole finding.
+- `sanitize_url_elicitation_url` (`:485`) — modify — **split it by provenance.**
+  **WAS WRONG (rev 1):** it said "stop passing `allow_loopback_http=True`",
+  full stop. Verified: this helper is **shared** between the downstream-payload
+  path (`auth.py:736`) and the **operator-supplied** acknowledgement path
+  (`handlers.py:4592`, `parsed.elicitation_url`). Removing loopback globally
+  would break the operator's local-OAuth flow, which `plans/phase-plan-v4-elicit.md`
+  records as a frozen contract. The remote path must lose loopback HTTP; the
+  operator path must keep it. Two policies, two call sites, regression tests for
+  both.
+- A `verified` signal on the returned value — add — whether the host was
+  verified as a public literal or merely accepted as an unresolved name. It must
+  **default to unverified**: a default of "verified" reintroduces vouching at any
+  call site the change misses.
 
 ### Presentation (modify)
 
-- `cli.py` — where `url_elicitations` are shown to the operator — must mark an
-  unverified host plainly: this URL came from the server and its destination was
-  not checked. Today the operator is told to open it, with no such distinction.
-- `AuthChallengeInfo.resource_metadata_url` and `AuthMetadataInfo` — carry the
-  same signal, so any consumer of the public dataclasses can tell the difference.
+- **`UrlElicitationInfo` (`types.py:163`) is the primary relay surface and rev 1
+  omitted it entirely.** Its docstring reads *"URL-mode elicitation details **safe
+  to display to users**"* — the type asserts precisely the claim this issue
+  disproves. It carries `url`, `message`, `next_step` and no verification field,
+  and `handlers.py:4610` constructs it with an unconditional open-the-URL
+  instruction. Add the signal here first; without it AC 3 cannot be met on the
+  surface that actually reaches an operator. Correct the docstring too.
+- `cli.py` — where `url_elicitations` are shown — must state that an unverified
+  URL came from the server and its destination was not checked, in **both** the
+  human text and `--json`.
+- **`AuthMetadataInfo` needs a PER-URL signal, not one object-level bool.** It
+  carries five independent URL fields; a single flag cannot be honest when one is
+  a public literal and another is a name. Rev 1 specified one signal per object.
+- `AuthChallengeInfo.resource_metadata_url` — same per-URL treatment.
 
 ## Documentation impact
 
@@ -106,15 +120,23 @@ tests fail locally in a way that reproduces on a clean `main` export
 
 ## Acceptance criteria
 
-- [ ] A downstream elicitation payload carrying `http://127.0.0.1/cb` is
-      **rejected** — proven by a test failing against `main`, where it is
-      currently accepted.
+- [ ] A **downstream** elicitation payload carrying `http://127.0.0.1/cb` is
+      **rejected**, proven by a test failing against `main`. **And the operator
+      path at `handlers.py:4592` still accepts it** — both directions, or the
+      change breaks a frozen contract. `test_sanitize_url_elicitation_url_allows_loopback_http`
+      inverts for the remote path only.
 - [ ] `https://auth.vendor.com/...` from a downstream server is **still
       accepted** — the feature must survive. A change that rejects names must not
       pass.
-- [ ] A relayed URL whose host is an unresolved name is marked **unverified**,
-      and the operator-facing output says so. Asserted on the emitted text, not
-      on a field's presence.
+- [ ] A relayed URL whose host is an unresolved name is marked **unverified** on
+      `UrlElicitationInfo`, and the gateway output, the CLI human text **and**
+      `--json` all say so. Asserted on emitted text, not on a field's presence.
+      Rev 1's criteria exercised only elicitation and CLI, which would let the
+      challenge and metadata surfaces stay misleading while every test passed.
+- [ ] `AuthMetadataInfo` with a **mix** — one public literal, one name — reports
+      them differently. A single object-level flag cannot pass this.
+- [ ] The signal defaults to **unverified** — proven by constructing the type
+      without it and asserting the unverified presentation.
 - [ ] A relayed URL whose host is a verified public literal is **not** marked
       unverified — so the signal distinguishes, rather than labelling everything.
 - [ ] `fetch_json_metadata` is either gone, or rejects a non-public literal.

--- a/.consiliency/plans/detailed-auth-trust-split-20260830-1600.md
+++ b/.consiliency/plans/detailed-auth-trust-split-20260830-1600.md
@@ -1,5 +1,10 @@
 # Detailed plan: stop vouching for URLs a downstream server supplied
 
+> **Revision 3 (2026-08-30).** Rev 2 boarded 1 DISAGREE / 1 PARTIALLY AGREE /
+> 1 AGREE. Its `fetch_json_metadata` criterion was **already satisfied by
+> unchanged `main`**, it proposed deleting a **frozen interface**, and it left
+> the string agents actually follow unqualified. All three verified.
+>
 > **Revision 2 (2026-08-30).** Boarded 2 DISAGREE. Rev 1 named the wrong types
 > and would have broken a frozen operator contract. Both verified below.
 
@@ -52,12 +57,17 @@ validated**. So:
 
 ### `src/pmcp/auth.py` (modify)
 
-- `fetch_json_metadata` (`:756`) — **delete it**, or give it an explicit
-  fetch-trust gate. It is a live `urlopen` primitive with no production caller.
-  Deleting is preferred: a loaded gun with no user is a liability, and it can be
-  restored from git with its trust decision made deliberately. **If it is kept**,
-  it must reject anything that is not a verifiably-public literal, since it
-  fetches.
+- `fetch_json_metadata` (`:756`) — **gate it. Do not delete it.**
+  **WAS WRONG (rev 2):** it said deleting is preferred. Verified — this function
+  is a **frozen interface**: `plans/phase-plan-v4-safeurl.md:48` lists it under
+  *Interfaces provided*, and **IF-0-SAFEURL-4** names it by contract. Deleting it
+  breaks that freeze; gating preserves compatibility.
+
+  It fetches, so it is the fail-closed side: it must reject anything that is not
+  a **verifiably public literal** — names included, and loopback HTTP included.
+  Verified on `main` today: `https://10.0.0.1/x` is already rejected, but
+  `http://127.0.0.1/x` and `https://metadata.google.internal/x` both **reach
+  `urlopen`**.
 - `sanitize_url_elicitation_url` (`:485`) — modify — **split it by provenance.**
   **WAS WRONG (rev 1):** it said "stop passing `allow_loopback_http=True`",
   full stop. Verified: this helper is **shared** between the downstream-payload
@@ -82,11 +92,21 @@ validated**. So:
   instruction. Add the signal here first; without it AC 3 cannot be met on the
   surface that actually reaches an operator. Correct the docstring too.
 - `cli.py` — where `url_elicitations` are shown — must state that an unverified
-  URL came from the server and its destination was not checked, in **both** the
-  human text and `--json`.
+  URL's destination was not checked, in **both** the human text and `--json`.
+  Note the copy must not say "came from the server" on the acknowledge path
+  (`cli.py:2603-2605`), which echoes an **operator-supplied** URL.
+- `cli_commands/doctor.py:90-95` reports sanitize success as
+  `[OK] … configured at {url}` for a name — operator config rather than a
+  downstream payload, but another vouch. Qualify it or state why it is exempt.
 - **`AuthMetadataInfo` needs a PER-URL signal, not one object-level bool.** It
   carries five independent URL fields; a single flag cannot be honest when one is
   a public literal and another is a name. Rev 1 specified one signal per object.
+  **Keep the URL fields `str | None`** — `transport/http.py:373` interpolates
+  `protected_resource_metadata_url` straight into a `WWW-Authenticate` header, so
+  wrapping them is a silent contract break. Use companion flags or a side map.
+- **Keep `sanitize_url_elicitation_url` returning `str`** (frozen as
+  IF-0-ELICIT-1). Carry `verified` on a small result object or a parallel
+  predicate, so every string-equality test does not have to move.
 - `AuthChallengeInfo.resource_metadata_url` — same per-URL treatment.
 
 ## Documentation impact
@@ -137,12 +157,30 @@ tests fail locally in a way that reproduces on a clean `main` export
       challenge and metadata surfaces stay misleading while every test passed.
 - [ ] `AuthMetadataInfo` with a **mix** — one public literal, one name — reports
       them differently. A single object-level flag cannot pass this.
+- [ ] **`AuthChallengeInfo.resource_metadata_url`** is covered by the same four
+      assertions: unresolved name marked unverified, public literal not marked,
+      default unverified, and the serialized output carries it. Rev 2 required
+      per-URL treatment for this surface in *Changes* but wrote **no criterion**
+      for it — so leaving `parse_www_authenticate` untouched would have satisfied
+      every listed criterion while it still relays
+      `https://metadata.google.internal/meta` unmarked.
+- [ ] **The `next_step` text is qualified.** The open-the-URL instruction is
+      copied to `handlers.py:2133`, `:2786`, `:4215`, `:4349`, `:4436` and printed
+      by `cli.py:2519-2521`. That string is what an agent follows. A JSON
+      `verified: false` plus a CLI sidebar, with `next_step` still saying "open
+      the URL" unqualified, must **not** pass.
 - [ ] The signal defaults to **unverified** — proven by constructing the type
       without it and asserting the unverified presentation.
 - [ ] A relayed URL whose host is a verified public literal is **not** marked
       unverified — so the signal distinguishes, rather than labelling everything.
-- [ ] `fetch_json_metadata` is either gone, or rejects a non-public literal.
-      Asserted either way, so "we left it alone" cannot pass.
+- [ ] `fetch_json_metadata` rejects **`http://127.0.0.1/x`** and **an unresolved
+      hostname**, each **without invoking the opener** — asserted by patching the
+      opener and proving it was never called.
+      **WAS WRONG (rev 2):** the criterion was "rejects a non-public literal",
+      which unchanged `main` **already satisfies** for `https://10.0.0.1/x`. It
+      could be passed by doing nothing, while the two forms that actually reach
+      `urlopen` stayed open. This is the fourth vacuous criterion in this
+      project; it was caught because a seat ran it rather than read it.
 - [ ] Full suite green.
 
 ## Non-goals

--- a/.consiliency/plans/detailed-auth-trust-split-20260830-1600.md
+++ b/.consiliency/plans/detailed-auth-trust-split-20260830-1600.md
@@ -100,8 +100,10 @@ validated**. So:
 
 ## Dependencies & order
 
-1. The `verified` signal, with unit tests — everything else reads it.
-2. The `allow_loopback_http` removal and its tests.
+1. The `verified` signal on `UrlElicitationInfo` first, defaulting to
+   unverified, with unit tests — it is the surface that reaches an operator.
+2. The provenance split on `sanitize_url_elicitation_url` — remote loses
+   loopback HTTP, operator keeps it — with regression tests both ways.
 3. `fetch_json_metadata` — delete or gate.
 4. Presentation changes.
 5. Docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **PMCP no longer implies it verified where a server-supplied auth URL
+  points.** It never did: `_is_public_auth_host` classifies IP literals and
+  accepts a DNS name **without resolving it**, so
+  `https://metadata.google.internal/...` in an elicitation payload or a
+  `WWW-Authenticate` header was relayed to the operator — and to an agent —
+  looking like something PMCP had checked. Names are still relayed, because
+  refusing unresolvable ones would refuse a well-behaved server's
+  `https://auth.vendor.com/...` too; what changed is what PMCP claims about
+  them. `UrlElicitationInfo.url_verified`, `AuthMetadataInfo.verified_urls`
+  (per URL field, since those five URLs are independent) and
+  `AuthChallengeInfo.resource_metadata_url_verified` report whether PMCP itself
+  classified the host as a public literal, and all three default to
+  **unverified**. The qualification is threaded into the `next_step` string an
+  agent actually follows, and into `pmcp auth connect` / `pmcp auth acknowledge`
+  output in both human text and `--json`. `pmcp doctor` no longer reports a bare
+  `[OK] ... configured at <name>` for a host it did not verify
+  ([#211](https://github.com/Consiliency/pmcp/issues/211)).
+- **A downstream server can no longer hand back a loopback `http://` URL.**
+  `sanitize_url_elicitation_url` now splits by provenance: a URL parsed out of a
+  server's error payload loses loopback HTTP, while one the operator types into
+  `gateway.auth_connect` keeps it, because local OAuth redirects to
+  `http://127.0.0.1`. The default is the strict remote policy, so a call site
+  missed by a future change fails closed (#211).
+- **`fetch_json_metadata` now fails closed.** PMCP retrieves that URL itself, so
+  "accepted but unresolved" is not good enough there: the host must be one PMCP
+  verified as a public IP literal, and a refused URL is rejected before the
+  opener is reached rather than fetched and judged afterwards. `http://127.0.0.1/x`
+  and unresolved names previously both reached `urlopen` (#211).
+
 ## [2.7.2] - 2026-08-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -176,7 +176,13 @@ literals** — private, CGNAT, link-local, loopback, multicast, site-local, and
 unspecified — including IPv4 addresses embedded in IPv6 literals and legacy
 numeric forms such as `2852039166`. This is a filter on literals only: a DNS
 name is accepted **without being resolved**, so a name that points at an
-internal address still passes
+internal address still passes. PMCP therefore no longer presents such a URL as
+one it checked: a server-supplied URL is **relayed unverified and presented as
+such** — `UrlElicitationInfo.url_verified`, `AuthMetadataInfo.verified_urls`,
+and `AuthChallengeInfo.resource_metadata_url_verified` all default to
+unverified, and the caveat is carried in the `next_step` an agent follows and in
+CLI output. Where PMCP *fetches* a URL itself it fails closed instead, requiring
+a verified public literal
 ([#211](https://github.com/Consiliency/pmcp/issues/211)). PMCP is still not an
 Authorization Server and does not provide dynamic client registration, SSO,
 RBAC, billing, or a complete multi-tenant identity service.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,8 +72,17 @@ PMCP is a local-first MCP gateway. Its default security posture assumes:
   RFC 6052 NAT64, RFC 3056 6to4, RFC 4380 Teredo, RFC 5214 ISATAP) and legacy
   numeric forms such as `2852039166` or `0177.0.0.1`. **A DNS name is accepted
   without being resolved**, so a name pointing at an internal address is not
-  caught. Tracked in
-  [#211](https://github.com/Consiliency/pmcp/issues/211).
+  caught. PMCP does not resolve names deliberately: a lookup is
+  TOCTOU-vulnerable and is not SSRF defence without connection-time IP pinning.
+  What it does instead is stop claiming otherwise — **a server-supplied URL is
+  relayed unverified and presented as such**, via
+  `UrlElicitationInfo.url_verified`, `AuthMetadataInfo.verified_urls` (one entry
+  per URL field), and `AuthChallengeInfo.resource_metadata_url_verified`, all
+  defaulting to unverified, with the caveat carried in the `next_step` string an
+  agent follows and in `pmcp auth` output. Paths where PMCP fetches the URL
+  itself fail closed and require a verified public literal, and a URL from a
+  downstream server's payload may not be loopback `http://`
+  ([#211](https://github.com/Consiliency/pmcp/issues/211)).
 - **No mTLS**: clients are not authenticated by certificate; only Bearer token.
 - **No per-tool ACL on HTTP**: any valid token can invoke any tool. Tool-level policy is
   enforced at the MCP layer, not the HTTP layer.

--- a/src/pmcp/auth.py
+++ b/src/pmcp/auth.py
@@ -10,7 +10,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from ipaddress import IPv4Address, IPv6Address, ip_address, ip_network
 from itertools import product
-from typing import Any
+from typing import Any, Literal
 from urllib.error import HTTPError
 from urllib.parse import parse_qsl, quote, urlparse, urlunparse
 from urllib.request import HTTPRedirectHandler, Request, build_opener
@@ -260,6 +260,66 @@ def _is_public_auth_host(hostname: str) -> bool:
     return True
 
 
+def _is_verified_public_auth_host(hostname: str) -> bool:
+    """Report whether PMCP itself classified this host as a public literal.
+
+    This is the honest half of :func:`_is_public_auth_host`. That function
+    returns True for a DNS name, because rejecting unresolvable names would
+    refuse every legitimate ``auth.vendor.com``. But "not rejected" is not
+    "checked", and presenting the two identically is the vouch #211 reports.
+
+    A name therefore returns **False** here: PMCP does not resolve names -- a
+    deliberate non-goal, since a lookup is TOCTOU-vulnerable and is not SSRF
+    defence without connection-time IP pinning -- so it does not know where one
+    points and must not imply that it does.
+    """
+    if hostname.lower() == "localhost":
+        return False
+    address: IPv4Address | IPv6Address | None
+    try:
+        address = ip_address(hostname)
+    except ValueError:
+        address = None
+    if address is not None:
+        return _is_public_ip(address)
+    numeric = _legacy_numeric_addresses(hostname)
+    if numeric:
+        return all(_is_public_ip(candidate) for candidate in numeric)
+    return False
+
+
+def is_verified_public_auth_url(url: str) -> bool:
+    """Report whether PMCP verified where an auth URL points.
+
+    True only for an absolute ``https://`` URL whose host PMCP classified as a
+    public IP literal. False for every DNS name, every non-public literal, and
+    every ``http://`` URL -- a cleartext hop's destination is not authenticated
+    even when the address is public.
+
+    Callers use this to decide what to *claim*, not what to accept: a relay path
+    keeps passing an unverified URL through, it just stops vouching for it.
+    """
+    try:
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+        _ = parsed.port
+    except ValueError:
+        return False
+    if parsed.scheme != "https" or not parsed.netloc or not hostname:
+        return False
+    return _is_verified_public_auth_host(hostname)
+
+
+# One provenance-neutral sentence, used on both the downstream relay path and
+# the operator acknowledgement path. The acknowledge path echoes a URL the
+# operator typed, so the copy must not attribute it to "the server".
+UNVERIFIED_URL_CAVEAT = (
+    "PMCP has not verified where this URL points -- it checks the URL's form "
+    "and rejects private address literals, but it does not resolve host names. "
+    "Confirm the destination yourself before opening it."
+)
+
+
 def sanitize_public_auth_url(url: str, *, allow_loopback_http: bool = False) -> str:
     """Validate and redact a public absolute auth metadata or elicitation URL."""
     try:
@@ -482,10 +542,33 @@ def validate_resource_server_token(
     )
 
 
-def sanitize_url_elicitation_url(url: str) -> str:
-    """Validate and redact a URL-mode elicitation URL."""
+def sanitize_url_elicitation_url(
+    url: str, *, provenance: Literal["remote", "operator"] = "remote"
+) -> str:
+    """Validate and redact a URL-mode elicitation URL.
+
+    This helper is shared by two call sites whose inputs have very different
+    provenance, and one permissiveness cannot be right for both (#211):
+
+    ``remote`` (the default)
+        The URL came out of a downstream server's error payload. A loopback
+        ``http://`` URL from there is an attempt to steer the operator at
+        something on the operator's own machine, so it is refused.
+
+    ``operator``
+        The URL was typed by the operator into ``gateway.auth_connect``. Local
+        OAuth redirects back to ``http://127.0.0.1``, and refusing that would
+        break the frozen local-consent flow, so loopback HTTP stays allowed.
+
+    The default is the strict side deliberately: a call site this change misses
+    should lose loopback, not silently keep it. Returns ``str`` -- the frozen
+    IF-0-ELICIT-1 shape. Ask :func:`is_verified_public_auth_url` separately for
+    whether PMCP actually verified the destination.
+    """
     try:
-        return sanitize_public_auth_url(url, allow_loopback_http=True)
+        return sanitize_public_auth_url(
+            url, allow_loopback_http=provenance == "operator"
+        )
     except ValueError as exc:
         raise ValueError("Invalid URL-mode elicitation URL.") from exc
 
@@ -585,6 +668,7 @@ def parse_www_authenticate(header: str) -> AuthChallengeInfo | None:
     missing = params.get("missing_scope") or scope or ""
     missing_scopes = [part for part in missing.split() if part]
     resource_metadata_url = None
+    resource_metadata_url_verified = False
     if params.get("resource_metadata"):
         try:
             resource_metadata_url = sanitize_public_auth_url(
@@ -592,10 +676,15 @@ def parse_www_authenticate(header: str) -> AuthChallengeInfo | None:
             )
         except ValueError:
             resource_metadata_url = None
+        else:
+            resource_metadata_url_verified = is_verified_public_auth_url(
+                params["resource_metadata"]
+            )
 
     return AuthChallengeInfo(
         scheme=scheme,
         resource_metadata_url=resource_metadata_url,
+        resource_metadata_url_verified=resource_metadata_url_verified,
         scope=scope,
         missing_scopes=missing_scopes,
         error=params.get("error"),
@@ -633,18 +722,29 @@ def normalize_auth_metadata(
 ) -> AuthMetadataInfo:
     """Normalize untrusted authorization metadata into PMCP's public shape."""
     normalized_diagnostics = [sanitize_auth_diagnostic(d) for d in (diagnostics or [])]
+    # Per-field, not per-object: these five URLs are independent, so one flag
+    # cannot be honest about a mix of a literal and a name (#211).
+    verified_urls: list[str] = []
 
     def public_url(raw_url: str | None, field_name: str) -> str | None:
         if not raw_url:
             return None
         try:
-            return sanitize_public_auth_url(raw_url)
+            safe_url = sanitize_public_auth_url(raw_url)
         except ValueError as exc:
             normalized_diagnostics.append(
                 f"{field_name} ignored: {sanitize_auth_diagnostic(exc)} "
                 f"({redact_auth_url(raw_url)})"
             )
             return None
+        if is_verified_public_auth_url(raw_url):
+            verified_urls.append(field_name)
+        else:
+            normalized_diagnostics.append(
+                f"{field_name} is relayed unverified: PMCP did not resolve "
+                f"{safe_url} and cannot confirm where it points."
+            )
+        return safe_url
 
     metadata = metadata or {}
     scopes_supported = metadata.get("scopes_supported")
@@ -691,6 +791,7 @@ def normalize_auth_metadata(
         granted_scopes=granted_scopes or [],
         missing_scopes=missing_scopes or [],
         diagnostics=normalized_diagnostics,
+        verified_urls=verified_urls,
     )
 
 
@@ -733,20 +834,30 @@ def parse_url_elicitation_error(payload: object) -> list[UrlElicitationInfo]:
         if not isinstance(elicitation_id, str) or not isinstance(url, str):
             continue
         try:
-            safe_url = sanitize_url_elicitation_url(url)
+            safe_url = sanitize_url_elicitation_url(url, provenance="remote")
         except ValueError:
             continue
         message = entry.get("message")
+        verified = is_verified_public_auth_url(url)
+        # `next_step` is the string an agent actually follows, so the caveat has
+        # to live inside it. A `url_verified: false` field alongside an
+        # unqualified "Open the URL" instruction still gets the URL opened.
+        follow_up = (
+            "open the URL out of band, complete consent, then call "
+            f"gateway.auth_connect(auth_mode='url_elicitation', "
+            f"server_name='<server>', elicitation_id='{elicitation_id}', "
+            "consent_acknowledged=true)."
+        )
         parsed_entries.append(
             UrlElicitationInfo(
                 elicitation_id=elicitation_id,
                 url=safe_url,
+                url_verified=verified,
                 message=message if isinstance(message, str) else None,
                 next_step=(
-                    "Open the URL out of band, complete consent, then call "
-                    f"gateway.auth_connect(auth_mode='url_elicitation', "
-                    f"server_name='<server>', elicitation_id='{elicitation_id}', "
-                    "consent_acknowledged=true)."
+                    f"{follow_up[0].upper()}{follow_up[1:]}"
+                    if verified
+                    else f"{UNVERIFIED_URL_CAVEAT} Once confirmed, {follow_up}"
                 ),
             )
         )
@@ -756,11 +867,28 @@ def parse_url_elicitation_error(payload: object) -> list[UrlElicitationInfo]:
 def fetch_json_metadata(
     url: str, *, timeout: float = 5.0
 ) -> tuple[dict[str, object] | None, str | None]:
-    """Fetch public auth metadata without forwarding credentials."""
+    """Fetch public auth metadata without forwarding credentials.
+
+    This is the fail-closed side of #211. PMCP *retrieves* this URL itself, so
+    "accepted but unverified" is not good enough here the way it is on a relay
+    path: the host must be one PMCP classified as a public IP literal. Loopback
+    HTTP and unresolved names are both refused, and refused **before** the
+    opener is reached, so a rejected URL is never requested.
+
+    This gates the interface rather than removing it: ``fetch_json_metadata`` is
+    frozen by IF-0-SAFEURL-4 (``plans/phase-plan-v4-safeurl.md``), so deleting
+    it would break that freeze even though it has no production caller today.
+    """
     try:
-        safe_url = sanitize_public_auth_url(url, allow_loopback_http=True)
+        safe_url = sanitize_public_auth_url(url)
     except ValueError as exc:
         return None, sanitize_auth_diagnostic(exc)
+    if not is_verified_public_auth_url(url):
+        return None, (
+            f"{safe_url}: refused before fetching -- PMCP retrieves only URLs "
+            "whose host it verified as a public IP literal, and it does not "
+            "resolve host names."
+        )
     try:
         request = Request(safe_url, headers={"Accept": "application/json"})
         with urlopen(request, timeout=timeout) as response:

--- a/src/pmcp/cli.py
+++ b/src/pmcp/cli.py
@@ -962,6 +962,20 @@ def _sanitize_cli_payload(value: Any) -> Any:
     return value
 
 
+def _url_verification_suffix(elicitation: dict[str, Any]) -> str:
+    """Qualify a displayed elicitation URL that PMCP did not verify.
+
+    Deliberately provenance-neutral: this is printed both for a URL relayed by a
+    downstream server and, on the acknowledge path, for one the operator typed,
+    so it must not claim the URL "came from the server". Absent or false
+    ``url_verified`` both mean unverified -- an older gateway that does not send
+    the field must not be read as a clean bill of health (#211).
+    """
+    if elicitation.get("url_verified") is True:
+        return ""
+    return " (destination not verified by pmcp)"
+
+
 def _format_auth_evidence(
     payload: dict[str, Any],
     *,
@@ -997,6 +1011,11 @@ def _format_auth_evidence(
         ]
         if ids:
             parts.append("elicitations=" + ",".join(ids))
+        if any(
+            isinstance(item, dict) and item.get("url_verified") is not True
+            for item in url_elicitations
+        ):
+            parts.append("url_destination=unverified")
 
     next_step = payload.get("next_step")
     if not next_step and semantics:
@@ -2513,7 +2532,10 @@ async def run_auth_connect(args: argparse.Namespace) -> None:
             else:
                 print(first.get("message", "URL-mode elicitation required."))
                 if elicitation.get("url"):
-                    print(f"URL: {_redact_url_credentials(str(elicitation['url']))}")
+                    print(
+                        f"URL: {_redact_url_credentials(str(elicitation['url']))}"
+                        + _url_verification_suffix(elicitation)
+                    )
                 if elicitation.get("elicitation_id"):
                     print(f"Elicitation ID: {elicitation['elicitation_id']}")
                 next_step = elicitation.get("next_step") or first.get("next_step")
@@ -2602,7 +2624,10 @@ async def run_auth_acknowledge(args: argparse.Namespace) -> None:
             print(auth_result.get("message", "URL-mode elicitation acknowledged."))
             url_elicitation = auth_result.get("url_elicitation")
             if isinstance(url_elicitation, dict) and url_elicitation.get("url"):
-                print(f"URL: {_redact_url_credentials(str(url_elicitation['url']))}")
+                print(
+                    f"URL: {_redact_url_credentials(str(url_elicitation['url']))}"
+                    + _url_verification_suffix(url_elicitation)
+                )
             if auth_result.get("next_step"):
                 print(f"Next step: {auth_result['next_step']}")
     finally:

--- a/src/pmcp/cli_commands/doctor.py
+++ b/src/pmcp/cli_commands/doctor.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from pmcp.auth import (
+    is_verified_public_auth_url,
     redact_auth_url,
     sanitize_auth_diagnostic,
     sanitize_public_auth_url,
@@ -87,11 +88,21 @@ def collect_remote_header_diagnostics(
                     )
                 )
             else:
+                # `sanitize_public_auth_url` succeeding means the URL's form is
+                # valid and its host is not a private address literal -- not
+                # that pmcp knows where it points. Reporting a bare `[OK] ...
+                # configured at <name>` claimed the latter (#211).
+                qualifier = (
+                    ""
+                    if is_verified_public_auth_url(metadata_url)
+                    else " (host not verified; pmcp does not resolve names)"
+                )
                 checks.append(
                     (
                         "remote",
                         "ok",
-                        f"{server_name}: {metadata_key} configured at {safe_metadata_url}.",
+                        f"{server_name}: {metadata_key} configured at "
+                        f"{safe_metadata_url}{qualifier}.",
                     )
                 )
 

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -22,6 +22,8 @@ from dotenv import load_dotenv
 from mcp.types import Tool
 from pmcp import __version__ as PMCP_VERSION
 from pmcp.auth import (
+    UNVERIFIED_URL_CAVEAT,
+    is_verified_public_auth_url,
     normalize_auth_metadata,
     parse_url_elicitation_error,
     parse_www_authenticate,
@@ -4589,7 +4591,13 @@ class GatewayTools:
             url_elicitation = None
             if parsed.elicitation_url:
                 try:
-                    safe_url = sanitize_url_elicitation_url(parsed.elicitation_url)
+                    # Operator provenance: this URL was typed into
+                    # gateway.auth_connect, not relayed from a server. Local
+                    # OAuth redirects to http://127.0.0.1, so loopback HTTP
+                    # stays allowed here and only here (#211).
+                    safe_url = sanitize_url_elicitation_url(
+                        parsed.elicitation_url, provenance="operator"
+                    )
                 except ValueError as e:
                     self._audit(
                         method="gateway.auth_connect",
@@ -4607,10 +4615,15 @@ class GatewayTools:
                         message=str(e),
                         auth_state="elicitation_required",
                     )
+                retry_step = f"Retry gateway.provision(server_name='{server_name}') or gateway.invoke."
+                url_verified = is_verified_public_auth_url(parsed.elicitation_url)
                 url_elicitation = UrlElicitationInfo(
                     elicitation_id=parsed.elicitation_id,
                     url=safe_url,
-                    next_step=f"Retry gateway.provision(server_name='{server_name}') or gateway.invoke.",
+                    url_verified=url_verified,
+                    next_step=retry_step
+                    if url_verified
+                    else f"{UNVERIFIED_URL_CAVEAT} {retry_step}",
                 )
             self._audit(
                 method="gateway.auth_connect",

--- a/src/pmcp/types.py
+++ b/src/pmcp/types.py
@@ -136,7 +136,20 @@ class GatewayDiagnosticsInfo(BaseModel):
 
 
 class AuthMetadataInfo(BaseModel):
-    """Non-secret authorization metadata and discovery hints."""
+    """Non-secret authorization metadata and discovery hints.
+
+    The URL fields stay ``str | None``. ``transport/http.py`` interpolates
+    ``protected_resource_metadata_url`` straight into a ``WWW-Authenticate``
+    header, so wrapping them in a richer type would be a silent contract break.
+
+    ``verified_urls`` names the fields whose host PMCP verified as a public IP
+    literal. It is a per-field list rather than one object-level flag because
+    these five URLs are independent: a single bool cannot be honest when
+    ``oidc_issuer_url`` is a literal PMCP classified and
+    ``protected_resource_metadata_url`` is a name it never resolved (#211).
+    A field absent from the list is **unverified**, so the empty default
+    under-claims for every URL rather than vouching for any.
+    """
 
     protected_resource_metadata_url: str | None = None
     authorization_server_metadata_url: str | None = None
@@ -147,13 +160,25 @@ class AuthMetadataInfo(BaseModel):
     granted_scopes: list[str] = Field(default_factory=list)
     missing_scopes: list[str] = Field(default_factory=list)
     diagnostics: list[str] = Field(default_factory=list)
+    verified_urls: list[str] = Field(default_factory=list)
+
+    def url_verified(self, field_name: str) -> bool:
+        """Report whether PMCP verified where ``field_name``'s URL points."""
+        return field_name in self.verified_urls
 
 
 class AuthChallengeInfo(BaseModel):
-    """Parsed non-secret details from an authorization challenge."""
+    """Parsed non-secret details from an authorization challenge.
+
+    ``resource_metadata_url`` is relayed from a downstream server's
+    ``WWW-Authenticate`` header. ``resource_metadata_url_verified`` reports
+    whether PMCP verified its host as a public IP literal; it defaults to False
+    because PMCP does not resolve names and must not imply otherwise (#211).
+    """
 
     scheme: str | None = None
     resource_metadata_url: str | None = None
+    resource_metadata_url_verified: bool = False
     scope: str | None = None
     missing_scopes: list[str] = Field(default_factory=list)
     error: str | None = None
@@ -161,10 +186,22 @@ class AuthChallengeInfo(BaseModel):
 
 
 class UrlElicitationInfo(BaseModel):
-    """URL-mode elicitation details safe to display to users."""
+    """URL-mode elicitation details, carrying how far PMCP checked the URL.
+
+    This used to say the details were "safe to display to users", which claimed
+    more than PMCP performs. PMCP validates the URL's form and refuses private,
+    loopback, and legacy-numeric address literals — but it does **not** resolve
+    host names, so it cannot tell that ``metadata.example.com`` points at a link
+    local address (#211).
+
+    ``url_verified`` distinguishes the two cases: True only when PMCP itself
+    classified the host as a public IP literal. It defaults to False so that a
+    construction which forgets it under-claims rather than vouches.
+    """
 
     elicitation_id: str
     url: str
+    url_verified: bool = False
     message: str | None = None
     next_step: str | None = None
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -17,6 +17,7 @@ from pmcp.auth import (
     ResourceServerAuthError,
     ResourceServerJWKSUnavailable,
     fetch_json_metadata,
+    is_verified_public_auth_url,
     normalize_auth_metadata,
     parse_url_elicitation_error,
     parse_www_authenticate,
@@ -36,12 +37,15 @@ from pmcp.remote_auth import (
 )
 from pmcp.types import (
     DEFAULT_AUTH_STATE_SEMANTICS,
+    AuthChallengeInfo,
     AuthConnectInput,
+    AuthMetadataInfo,
     GatewayAuditEvent,
     GatewayDiagnosticsInfo,
     InvokeOutput,
     ProvisionOutput,
     ServerHealthInfo,
+    UrlElicitationInfo,
 )
 from pmcp.types import AuthState
 
@@ -524,19 +528,59 @@ def test_sanitize_url_elicitation_url_accepts_https_and_redacts_query_secrets() 
     assert "refresh-secret" not in url
 
 
-def test_sanitize_url_elicitation_url_allows_loopback_http() -> None:
+def test_sanitize_url_elicitation_url_allows_loopback_http_for_operator() -> None:
+    """Operator provenance keeps loopback HTTP -- local OAuth needs it.
+
+    This is the surviving half of the original
+    `test_sanitize_url_elicitation_url_allows_loopback_http`. Removing loopback
+    globally to close #211 would have broken the frozen local-consent flow at
+    `gateway.auth_connect`, where the operator types the redirect URL.
+    """
     assert (
-        sanitize_url_elicitation_url("http://localhost:3000/cb?code=secret")
+        sanitize_url_elicitation_url(
+            "http://localhost:3000/cb?code=secret", provenance="operator"
+        )
         == "http://localhost:3000/cb?code=%5BREDACTED%5D"
     )
     assert (
-        sanitize_url_elicitation_url("http://127.0.0.1/cb?token=secret")
+        sanitize_url_elicitation_url(
+            "http://127.0.0.1/cb?token=secret", provenance="operator"
+        )
         == "http://127.0.0.1/cb?token=%5BREDACTED%5D"
     )
     assert (
-        sanitize_url_elicitation_url("http://[::1]/cb?refresh_token=secret")
+        sanitize_url_elicitation_url(
+            "http://[::1]/cb?refresh_token=secret", provenance="operator"
+        )
         == "http://[::1]/cb?refresh_token=%5BREDACTED%5D"
     )
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost:3000/cb?code=secret",
+        "http://127.0.0.1/cb?token=secret",
+        "http://[::1]/cb?refresh_token=secret",
+    ],
+)
+def test_sanitize_url_elicitation_url_refuses_loopback_http_from_remote(
+    url: str,
+) -> None:
+    """#211: the same URL is refused when a downstream server supplied it.
+
+    A loopback `http://` URL in a server's error payload is an attempt to point
+    the operator at something on the operator's own machine. The inverse of the
+    operator case above -- the provenance is the whole difference.
+    """
+    with pytest.raises(ValueError):
+        sanitize_url_elicitation_url(url, provenance="remote")
+
+
+def test_sanitize_url_elicitation_url_defaults_to_the_strict_remote_policy() -> None:
+    """A caller that forgets `provenance` must lose loopback, not keep it."""
+    with pytest.raises(ValueError):
+        sanitize_url_elicitation_url("http://127.0.0.1/cb")
 
 
 @pytest.mark.parametrize(
@@ -983,11 +1027,13 @@ def test_fetch_json_metadata_uses_safe_request_headers(
 
     monkeypatch.setattr("pmcp.auth.urlopen", fake_urlopen)
 
-    data, error = fetch_json_metadata("https://auth.example/meta?token=secret")
+    # A verified public literal -- since #211 this is the only shape that gets
+    # fetched at all, so the happy path has to use one.
+    data, error = fetch_json_metadata("https://93.184.216.34/meta?token=secret")
 
     assert data == {"issuer": "https://issuer.example"}
     assert error is None
-    assert seen["url"] == "https://auth.example/meta?token=%5BREDACTED%5D"
+    assert seen["url"] == "https://93.184.216.34/meta?token=%5BREDACTED%5D"
     assert seen["accept"] == "application/json"
     assert seen["authorization"] is None
     assert seen["cookie"] is None
@@ -999,6 +1045,46 @@ def test_fetch_json_metadata_rejects_non_public_urls() -> None:
     assert data is None
     assert error is not None
     assert "secret" not in error
+
+
+@pytest.mark.parametrize(
+    ("url", "why"),
+    [
+        ("http://127.0.0.1/x", "loopback HTTP -- reached urlopen before #211"),
+        ("http://localhost/x", "loopback by name"),
+        (
+            "https://metadata.google.internal/x",
+            "unresolved hostname -- reached urlopen before #211",
+        ),
+        ("https://auth.vendor.com/.well-known/x", "an ordinary unresolved name"),
+        ("https://10.0.0.1/x", "private literal -- already rejected on main"),
+    ],
+)
+def test_fetch_json_metadata_refuses_unverified_hosts_without_opening_them(
+    monkeypatch: pytest.MonkeyPatch, url: str, why: str
+) -> None:
+    """#211: a refused fetch must never reach the network.
+
+    `fetch_json_metadata` is the fail-closed side: pmcp retrieves this URL
+    itself, so "accepted but unresolved" is not good enough the way it is on a
+    relay path. Asserting on the return value alone is not sufficient -- an
+    implementation that fetched first and judged afterwards would still return
+    an error while the request had already left. So the opener is patched with
+    one that fails the test if it is called at all.
+    """
+    calls: list[object] = []
+
+    def forbidden_urlopen(request: object, timeout: float) -> object:
+        calls.append(request)
+        raise AssertionError(f"fetch_json_metadata opened a refused URL: {url}")
+
+    monkeypatch.setattr("pmcp.auth.urlopen", forbidden_urlopen)
+
+    data, error = fetch_json_metadata(url)
+
+    assert calls == [], why
+    assert data is None
+    assert error is not None
 
 
 def test_parse_www_authenticate_handles_quoted_edges_and_safe_metadata() -> None:
@@ -1073,3 +1159,181 @@ def test_env_store_rejects_injection_before_write(tmp_path: Path) -> None:
         write_env_file(env_path, {"GOOD=bad": "secret"})
 
     assert not env_path.exists()
+
+
+# --- #211: pmcp must not present a relayed URL as one it verified ----------
+#
+# The fix is deliberately *not* "reject unverifiable names". Two board rounds
+# established that doing so would refuse a well-behaved server's
+# `https://auth.vendor.com/...` and kill URL-mode elicitation outright.
+# Rejecting is right for a fetch and wrong for a relay. So these tests pin the
+# other half: the URL still goes through, pmcp just stops vouching for it.
+
+
+def _elicitation_payload(url: str) -> dict[str, object]:
+    return {
+        "error": {
+            "code": -32042,
+            "data": {"elicitationId": "el-1", "url": url, "message": "consent"},
+        }
+    }
+
+
+def test_downstream_elicitation_relays_a_vendor_name_and_marks_it_unverified() -> None:
+    """The feature survives: a name is relayed, but not vouched for."""
+    parsed = parse_url_elicitation_error(
+        _elicitation_payload("https://auth.vendor.com/consent")
+    )
+
+    assert len(parsed) == 1
+    assert parsed[0].url == "https://auth.vendor.com/consent"
+    assert parsed[0].url_verified is False
+
+
+def test_downstream_elicitation_marks_a_public_literal_verified() -> None:
+    """The signal has to distinguish, not label everything unverified."""
+    parsed = parse_url_elicitation_error(
+        _elicitation_payload("https://93.184.216.34/consent")
+    )
+
+    assert len(parsed) == 1
+    assert parsed[0].url_verified is True
+
+
+def test_downstream_elicitation_rejects_loopback_http() -> None:
+    """#211: this payload was accepted and shown to the operator before."""
+    assert (
+        parse_url_elicitation_error(_elicitation_payload("http://127.0.0.1/cb")) == []
+    )
+
+
+def test_url_elicitation_next_step_carries_the_caveat_for_a_name() -> None:
+    """`next_step` is the string an agent follows, so the caveat lives there.
+
+    A JSON `url_verified: false` beside an unqualified "Open the URL" is not a
+    fix: the agent reads the instruction. This asserts on the emitted text.
+    """
+    parsed = parse_url_elicitation_error(
+        _elicitation_payload("https://metadata.google.internal/consent")
+    )
+
+    next_step = parsed[0].next_step
+    assert next_step is not None
+    assert "not verified where this URL points" in next_step
+    assert "does not resolve host names" in next_step
+    # The actionable instruction must survive the qualification.
+    assert "gateway.auth_connect" in next_step
+    assert "consent_acknowledged=true" in next_step
+
+
+def test_url_elicitation_next_step_is_unqualified_for_a_verified_literal() -> None:
+    parsed = parse_url_elicitation_error(
+        _elicitation_payload("https://93.184.216.34/consent")
+    )
+
+    next_step = parsed[0].next_step
+    assert next_step is not None
+    assert "not verified" not in next_step
+    assert next_step.startswith("Open the URL out of band")
+
+
+def test_url_elicitation_info_defaults_to_unverified() -> None:
+    """Constructed without the signal, the type must under-claim.
+
+    A default of "verified" would reintroduce the vouch at every call site this
+    change missed.
+    """
+    info = UrlElicitationInfo(elicitation_id="el-1", url="https://auth.vendor.com/x")
+
+    assert info.url_verified is False
+
+
+def test_auth_challenge_marks_an_unresolved_name_unverified() -> None:
+    """`parse_www_authenticate` relays a header field from a remote server."""
+    parsed = parse_www_authenticate(
+        'Bearer resource_metadata="https://metadata.google.internal/meta"'
+    )
+
+    assert parsed is not None
+    assert parsed.resource_metadata_url == "https://metadata.google.internal/meta"
+    assert parsed.resource_metadata_url_verified is False
+    assert '"resource_metadata_url_verified":false' in parsed.model_dump_json()
+
+
+def test_auth_challenge_marks_a_public_literal_verified() -> None:
+    parsed = parse_www_authenticate(
+        'Bearer resource_metadata="https://93.184.216.34/meta"'
+    )
+
+    assert parsed is not None
+    assert parsed.resource_metadata_url_verified is True
+
+
+def test_auth_challenge_info_defaults_to_unverified() -> None:
+    assert AuthChallengeInfo(scheme="Bearer").resource_metadata_url_verified is False
+
+
+def test_auth_metadata_reports_a_literal_and_a_name_differently() -> None:
+    """A single object-level flag cannot pass this.
+
+    `AuthMetadataInfo` carries five independent URLs. One bool would have to
+    describe a public literal and an unresolved name at once, and would be a
+    lie about one of them whichever way it fell.
+    """
+    metadata = normalize_auth_metadata(
+        protected_resource_metadata_url="https://93.184.216.34/pr",
+        authorization_server_metadata_url="https://auth.vendor.com/as",
+    )
+
+    assert metadata.protected_resource_metadata_url == "https://93.184.216.34/pr"
+    assert metadata.authorization_server_metadata_url == "https://auth.vendor.com/as"
+    assert metadata.url_verified("protected_resource_metadata_url") is True
+    assert metadata.url_verified("authorization_server_metadata_url") is False
+    assert metadata.verified_urls == ["protected_resource_metadata_url"]
+    assert any(
+        "authorization_server_metadata_url is relayed unverified" in diagnostic
+        for diagnostic in metadata.diagnostics
+    )
+
+
+def test_auth_metadata_url_fields_stay_plain_strings() -> None:
+    """transport/http.py interpolates one of these into a WWW-Authenticate
+    header, so wrapping them would be a silent contract break."""
+    metadata = normalize_auth_metadata(
+        protected_resource_metadata_url="https://auth.vendor.com/pr"
+    )
+
+    assert isinstance(metadata.protected_resource_metadata_url, str)
+    assert f'resource_metadata="{metadata.protected_resource_metadata_url}"' == (
+        'resource_metadata="https://auth.vendor.com/pr"'
+    )
+
+
+def test_auth_metadata_defaults_to_no_verified_urls() -> None:
+    assert AuthMetadataInfo().verified_urls == []
+    assert AuthMetadataInfo().url_verified("protected_resource_metadata_url") is False
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://93.184.216.34/x", True),
+        ("https://[2606:4700::1111]/x", True),
+        ("https://auth.vendor.com/x", False),
+        ("https://metadata.google.internal/x", False),
+        # Name-shaped but numeric: #210 classifies it as the literal it is.
+        ("https://0xA9FEA9FE/x", False),
+        ("https://169.254.169.254./x", False),
+        ("https://127.0.0.1/x", False),
+        ("http://93.184.216.34/x", False),
+        ("not-a-url", False),
+        ("https://[::1", False),
+    ],
+)
+def test_is_verified_public_auth_url(url: str, expected: bool) -> None:
+    """The predicate answers "did pmcp check this?", not "is this allowed?".
+
+    A DNS name is False even though `sanitize_public_auth_url` accepts it --
+    that gap between accepted and checked is the whole of #211.
+    """
+    assert is_verified_public_auth_url(url) is expected

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2666,3 +2666,203 @@ class TestCheckVersionsUnverifiableDisplay:
         assert "All cached descriptions are up to date." in out, out
         assert self.UNVERIFIABLE_HEADING not in out, out
         assert self.FORCE_FOOTER not in out, out
+
+
+# --- #211: the CLI must not present a relayed URL as one pmcp checked -------
+
+
+async def _run_cli_auth(
+    func_name: str, args: argparse.Namespace, payload: dict
+) -> None:
+    from pmcp import cli as cli_module
+
+    call_tool = AsyncMock(
+        return_value={"content": [{"type": "text", "text": json.dumps(payload)}]}
+    )
+    with patch(
+        "pmcp.client.manager.ClientManager.connect_all", new=AsyncMock(return_value=[])
+    ):
+        with patch("pmcp.client.manager.ClientManager.call_tool", new=call_tool):
+            with patch(
+                "pmcp.client.manager.ClientManager.disconnect_all", new=AsyncMock()
+            ):
+                await getattr(cli_module, func_name)(args)
+
+
+def _connect_args(as_json: bool) -> argparse.Namespace:
+    return argparse.Namespace(
+        command="auth",
+        auth_command="connect",
+        server_name="remote-auth",
+        credential=None,
+        env_var=None,
+        scope="user",
+        no_provision=False,
+        policy=None,
+        log_level="warn",
+        json=as_json,
+    )
+
+
+def _provision_payload(url: str, *, url_verified: bool) -> dict:
+    next_step = (
+        "Open the URL out of band, complete consent."
+        if url_verified
+        else (
+            "PMCP has not verified where this URL points -- it checks the URL's "
+            "form and rejects private address literals, but it does not resolve "
+            "host names. Confirm the destination yourself before opening it. "
+            "Once confirmed, open the URL out of band, complete consent."
+        )
+    )
+    return {
+        "ok": False,
+        "server": "remote-auth",
+        "message": "URL-mode elicitation required.",
+        "auth_required": True,
+        "auth_state": "elicitation_required",
+        "next_step": next_step,
+        "url_elicitations": [
+            {
+                "elicitation_id": "consent-1",
+                "url": url,
+                "url_verified": url_verified,
+                "next_step": next_step,
+            }
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_cli_marks_an_unverified_elicitation_url_in_human_text(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Both halves of the operator-facing surface, asserted on emitted text.
+
+    The URL line carries its own qualifier rather than relying on `next_step`
+    alone, so a later edit to the instruction cannot silently un-qualify the URL
+    an operator is looking at.
+    """
+    await _run_cli_auth(
+        "run_auth_connect",
+        _connect_args(as_json=False),
+        _provision_payload("https://auth.vendor.com/consent", url_verified=False),
+    )
+
+    out = capsys.readouterr().out
+    assert "https://auth.vendor.com/consent" in out
+    assert "(destination not verified by pmcp)" in out
+    assert "not verified where this URL points" in out
+
+
+@pytest.mark.asyncio
+async def test_cli_json_output_carries_the_unverified_signal_and_text(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    await _run_cli_auth(
+        "run_auth_connect",
+        _connect_args(as_json=True),
+        _provision_payload("https://auth.vendor.com/consent", url_verified=False),
+    )
+
+    out = capsys.readouterr().out
+    payload = json.loads(out)["provision"]
+    assert payload["url_elicitations"][0]["url_verified"] is False
+    assert "not verified where this URL points" in payload["next_step"]
+
+
+@pytest.mark.asyncio
+async def test_cli_does_not_qualify_a_verified_elicitation_url(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    await _run_cli_auth(
+        "run_auth_connect",
+        _connect_args(as_json=False),
+        _provision_payload("https://93.184.216.34/consent", url_verified=True),
+    )
+
+    out = capsys.readouterr().out
+    assert "https://93.184.216.34/consent" in out
+    assert "not verified" not in out
+
+
+@pytest.mark.asyncio
+async def test_cli_treats_a_missing_url_verified_field_as_unverified(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An older gateway that omits the field must not read as a clean bill."""
+    payload = _provision_payload("https://auth.vendor.com/consent", url_verified=False)
+    del payload["url_elicitations"][0]["url_verified"]
+
+    await _run_cli_auth("run_auth_connect", _connect_args(as_json=False), payload)
+
+    assert "(destination not verified by pmcp)" in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+async def test_cli_acknowledge_qualifies_without_blaming_the_server(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The acknowledge path echoes a URL the *operator* supplied.
+
+    So the copy has to stay provenance-neutral: "came from the server" would be
+    a false statement on this path.
+    """
+    args = argparse.Namespace(
+        command="auth",
+        auth_command="acknowledge",
+        server_name="remote-auth",
+        elicitation_id="consent-1",
+        elicitation_url="https://auth.vendor.com/consent",
+        policy=None,
+        log_level="warn",
+        json=False,
+        credential=None,
+    )
+    payload = {
+        "ok": True,
+        "server": "remote-auth",
+        "message": "Recorded URL-mode elicitation acknowledgement.",
+        "next_step": "Retry gateway.provision(server_name='remote-auth')",
+        "url_elicitation": {
+            "elicitation_id": "consent-1",
+            "url": "https://auth.vendor.com/consent",
+            "url_verified": False,
+        },
+    }
+
+    await _run_cli_auth("run_auth_acknowledge", args, payload)
+
+    out = capsys.readouterr().out
+    assert "(destination not verified by pmcp)" in out
+    assert "came from the server" not in out
+
+
+def test_auth_evidence_summary_flags_an_unverified_elicitation() -> None:
+    from pmcp.cli import _format_auth_evidence
+
+    summary = _format_auth_evidence(
+        {
+            "auth_state": "elicitation_required",
+            "url_elicitations": [
+                {"elicitation_id": "consent-1", "url_verified": False}
+            ],
+        }
+    )
+
+    assert summary is not None
+    assert "url_destination=unverified" in summary
+
+
+def test_auth_evidence_summary_is_quiet_for_a_verified_elicitation() -> None:
+    from pmcp.cli import _format_auth_evidence
+
+    summary = _format_auth_evidence(
+        {
+            "auth_state": "elicitation_required",
+            "url_elicitations": [{"elicitation_id": "consent-1", "url_verified": True}],
+        }
+    )
+
+    assert summary is not None
+    assert "url_destination" not in summary

--- a/tests/test_ssrf_registry.py
+++ b/tests/test_ssrf_registry.py
@@ -135,12 +135,16 @@ def test_fetch_json_metadata_does_not_follow_redirect(monkeypatch) -> None:
 
     monkeypatch.setattr("pmcp.auth.urlopen", fake_urlopen)
 
-    data, error = fetch_json_metadata("https://auth.example/meta?token=secret")
+    # A verified public literal. Since #211 `fetch_json_metadata` refuses an
+    # unresolved name before the opener is reached, so a hostname here would
+    # short-circuit and never exercise the redirect handler this test is for.
+    data, error = fetch_json_metadata("https://93.184.216.34/meta?token=secret")
 
     assert data is None
     assert error is not None
     assert "secret" not in error
     # Only the initial public host is ever contacted.
+    assert seen["url"].startswith("https://93.184.216.34/")
     assert INTERNAL_HOST not in seen["url"]
 
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -6966,3 +6966,163 @@ def test_update_server_docstring_states_both_probe_window_env_contracts() -> Non
         "docstring does not explain WHY an ambient change cannot refuse "
         "(both guard sides derive from one stripped_base, so it cancels out)"
     )
+
+
+# --- #211: the operator path keeps loopback HTTP; the relay path loses it ---
+
+
+def _elicitation_tools() -> GatewayTools:
+    return GatewayTools(
+        client_manager=MockClientManager(),  # type: ignore[arg-type]
+        policy_manager=PolicyManager(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_auth_connect_still_accepts_operator_loopback_http_url() -> None:
+    """The frozen local-OAuth contract survives the #211 split.
+
+    `sanitize_url_elicitation_url` is shared between the downstream payload path
+    and this one, so tightening it globally would have broken the local consent
+    flow: a local authorization server redirects to `http://127.0.0.1`, and this
+    URL is typed by the operator, not relayed by a server.
+    """
+    result = await _elicitation_tools().auth_connect(
+        {
+            "server_name": "remote-auth",
+            "auth_mode": "url_elicitation",
+            "elicitation_id": "consent-1",
+            "elicitation_url": "http://127.0.0.1:8765/cb?code=secret",
+            "consent_acknowledged": True,
+        }
+    )
+
+    assert result.ok is True
+    assert result.url_elicitation is not None
+    assert result.url_elicitation.url == "http://127.0.0.1:8765/cb?code=%5BREDACTED%5D"
+
+
+@pytest.mark.asyncio
+async def test_auth_connect_marks_an_operator_supplied_name_unverified() -> None:
+    """Operator provenance relaxes loopback, not verification.
+
+    Nothing about the operator typing the URL tells pmcp where the name points,
+    so the acknowledgement echo is qualified too -- and provenance-neutrally,
+    since saying it "came from the server" would be false here.
+    """
+    result = await _elicitation_tools().auth_connect(
+        {
+            "server_name": "remote-auth",
+            "auth_mode": "url_elicitation",
+            "elicitation_id": "consent-1",
+            "elicitation_url": "https://auth.vendor.com/consent",
+            "consent_acknowledged": True,
+        }
+    )
+
+    assert result.ok is True
+    assert result.url_elicitation is not None
+    assert result.url_elicitation.url_verified is False
+    next_step = result.url_elicitation.next_step or ""
+    assert "not verified where this URL points" in next_step
+    assert "came from the server" not in next_step
+    assert "gateway.provision" in next_step
+
+
+@pytest.mark.asyncio
+async def test_auth_connect_leaves_a_verified_literal_unqualified() -> None:
+    result = await _elicitation_tools().auth_connect(
+        {
+            "server_name": "remote-auth",
+            "auth_mode": "url_elicitation",
+            "elicitation_id": "consent-1",
+            "elicitation_url": "https://93.184.216.34/consent",
+            "consent_acknowledged": True,
+        }
+    )
+
+    assert result.url_elicitation is not None
+    assert result.url_elicitation.url_verified is True
+    assert "not verified" not in (result.url_elicitation.next_step or "")
+
+
+@pytest.mark.asyncio
+async def test_invoke_relays_an_unverified_elicitation_url_with_a_caveat() -> None:
+    """The gateway output an agent consumes must carry the qualification.
+
+    `InvokeOutput.next_step` is copied from the elicitation, and that string is
+    what an agent follows -- a `url_verified: false` field beside an
+    unqualified "Open the URL" instruction does not close #211.
+    """
+    tool = ToolInfo(
+        tool_id="remote-auth::login",
+        server_name="remote-auth",
+        tool_name="login",
+        description="Login",
+        short_description="Login",
+        input_schema={},
+        tags=[],
+        risk_hint=RiskHint.LOW,
+    )
+    client_manager = MockClientManager([tool])
+
+    async def raise_elicitation(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError(
+            '{"error":{"code":-32042,"data":{"elicitationId":"consent-1",'
+            '"url":"https://metadata.google.internal/consent"}}}'
+        )
+
+    client_manager.call_tool = raise_elicitation  # type: ignore[method-assign]
+    gateway_tools = GatewayTools(
+        client_manager=client_manager,  # type: ignore[arg-type]
+        policy_manager=PolicyManager(),
+    )
+
+    result = await gateway_tools.invoke(
+        {"tool_id": "remote-auth::login", "arguments": {}}
+    )
+
+    assert result.url_elicitations
+    assert result.url_elicitations[0].url_verified is False
+    assert result.url_elicitations[0].url == "https://metadata.google.internal/consent"
+    # The instruction an agent follows, on the top-level output as well.
+    assert result.next_step is not None
+    assert "not verified where this URL points" in result.next_step
+    serialized = result.model_dump_json()
+    assert '"url_verified":false' in serialized
+
+
+@pytest.mark.asyncio
+async def test_invoke_refuses_a_relayed_loopback_http_elicitation() -> None:
+    """#211: this payload used to be relayed to the operator as valid."""
+    tool = ToolInfo(
+        tool_id="remote-auth::login",
+        server_name="remote-auth",
+        tool_name="login",
+        description="Login",
+        short_description="Login",
+        input_schema={},
+        tags=[],
+        risk_hint=RiskHint.LOW,
+    )
+    client_manager = MockClientManager([tool])
+
+    async def raise_elicitation(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError(
+            '{"error":{"code":-32042,"data":{"elicitationId":"consent-1",'
+            '"url":"http://127.0.0.1/cb"}}}'
+        )
+
+    client_manager.call_tool = raise_elicitation  # type: ignore[method-assign]
+    gateway_tools = GatewayTools(
+        client_manager=client_manager,  # type: ignore[arg-type]
+        policy_manager=PolicyManager(),
+    )
+
+    result = await gateway_tools.invoke(
+        {"tool_id": "remote-auth::login", "arguments": {}}
+    )
+
+    assert result.ok is False
+    assert not result.url_elicitations
+    assert "127.0.0.1" not in result.model_dump_json()


### PR DESCRIPTION
See #211.

`sanitize_public_auth_url` classifies IP literals and accepts a DNS name
**without resolving it**. That part is deliberate. The bug is what pmcp did
next: it presented the result as validated. A downstream server could return
`https://metadata.google.internal/...` in a URL-elicitation payload or a
`WWW-Authenticate` header and have pmcp show it to the operator — and hand it
to an *agent* — as though pmcp had checked where it points.

#210 (2.7.2) closed the IP-literal half. Measured on `main` before this branch:

```
https://0xA9FEA9FE/x                rejected    <- #210
https://metadata.google.internal/x  ACCEPTED    <- remained
http://127.0.0.1/cb                 ACCEPTED    <- remained
https://auth.vendor.com/x           ACCEPTED    <- legitimate, must stay
```

## The approach

**Not** "reject names on relay paths". That would refuse a well-behaved
server's `https://auth.vendor.com/...` and kill URL-mode elicitation. Rejecting
is right for a *fetch* and wrong for a *relay*, so the two are split:

**Fail closed on fetches.** `fetch_json_metadata` now requires a host pmcp
verified as a public IP literal, and refuses **before the opener is reached** —
a refused URL is never requested. It is *gated, not deleted*: IF-0-SAFEURL-4
(`plans/phase-plan-v4-safeurl.md:48`) freezes it.

**Stop vouching on relays.** The URL still goes through; pmcp stops implying it
checked it. `UrlElicitationInfo.url_verified`,
`AuthMetadataInfo.verified_urls` and
`AuthChallengeInfo.resource_metadata_url_verified` all default to
**unverified** — a default of "verified" would reintroduce the vouch at any
call site this change missed.

`AuthMetadataInfo` gets a per-field list rather than one object-level bool: its
five URLs are independent, and a single flag would be a lie about one of them
whenever a literal and a name appear together. The URL fields stay
`str | None`, because `transport/http.py:373` interpolates one straight into a
`WWW-Authenticate` header.

**The caveat is threaded into `next_step`.** That string is what an agent
follows. A JSON `url_verified: false` beside an unqualified "Open the URL"
instruction does not close this issue. The CLI carries it in the human text
(on the URL line itself, not only via `next_step`) and in `--json`, and the
copy is provenance-neutral — the acknowledge path echoes a URL the *operator*
typed, so "came from the server" would be false there.

**Provenance split on the shared helper.** `sanitize_url_elicitation_url` is
shared between the downstream path and the operator's `gateway.auth_connect`
acknowledgement. Remote loses loopback HTTP; operator keeps it, because local
OAuth redirects to `http://127.0.0.1` and `plans/phase-plan-v4-elicit.md`
freezes that flow. The default is the strict remote policy so a missed call
site fails closed.

## Verification

The fetch criterion is asserted by patching `pmcp.auth.urlopen` with an opener
that fails the test if it is called at all. Asserting on the return value alone
would pass for an implementation that fetched first and judged afterwards — and
an earlier form of this criterion was satisfied by *unchanged* `main`, since
`https://10.0.0.1/x` was already rejected while the two forms that actually
reached `urlopen` stayed open.

Not attempted, and deliberately so: resolving hostnames. A lookup is
TOCTOU-vulnerable and is not SSRF defence without connection-time IP pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3sT5kftuVtAKVktekR1nS

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790725933&installation_model_id=427051&pr_number=214&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F214&signature=1de9ae55730777d1a1fae61f071aa4de7dd9431c8f4dc1375320d421723fdd4e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->