### PR TITLE
chore: v2.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.3] - 2026-08-31
+
 ### Changed
 - **PMCP no longer implies it verified where a server-supplied auth URL
   points.** It never did: `_is_public_auth_host` classifies IP literals and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pmcp"
-version = "2.7.2"
+version = "2.7.3"
 description = "PMCP - Progressive MCP: Minimal context bloat with on-demand tool discovery"
 readme = "README.md"
 license = "MIT"

--- a/src/pmcp/__init__.py
+++ b/src/pmcp/__init__.py
@@ -1,3 +1,3 @@
 """PMCP - A meta-server for minimal Claude Code tool bloat."""
 
-__version__ = "2.7.2"
+__version__ = "2.7.3"

--- a/uv.lock
+++ b/uv.lock
@@ -1068,7 +1068,7 @@ wheels = [
 
 [[package]]
 name = "pmcp"
-version = "2.7.2"
+version = "2.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Cuts 2.7.3. Ships #211 (PR #214).

## What changes

- **A downstream server can no longer induce a loopback HTTP elicitation URL.** `sanitize_url_elicitation_url` now splits by provenance: the remote path loses loopback HTTP, the operator's local-OAuth acknowledgement path keeps it. Default is strict, so a missed call site fails closed.
- **`fetch_json_metadata` requires a verified public IP literal and refuses before opening a connection.** Previously `http://127.0.0.1/x` and `https://metadata.google.internal/x` both reached `urlopen`. Gated rather than deleted — it is frozen as IF-0-SAFEURL-4.
- **Relayed URLs carry a verification signal**, defaulting to unverified, and the caveat appears in the `next_step` text an agent follows — not only in JSON and CLI output.

Patch rather than minor: no API removals, and `AuthMetadataInfo`'s URL fields keep their `str | None` types (`transport/http.py:373` interpolates one into a `WWW-Authenticate` header, pinned by a test).

## What this is not

A presentation control, not a block. Someone handed a URL can still follow it. Rejecting host names outright was tried and rejected — it would refuse a well-behaved server's `https://auth.vendor.com/...` and break the elicitation feature. An operator allowlist remains a clean upgrade if that trade stops looking right.

## Verified

Provenance split holds both directions; the fetch gate refuses an unresolvable host with **zero opener invocations**; `https://auth.vendor.com/...` still accepted on the remote path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T61zMNiPF4K29186r3uqc3

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790727105&installation_model_id=427051&pr_number=215&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F215&signature=2b90d693ba6386fc35386ae10ad405f0a2ae26906739b1ff1d1307611cf16506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->