### PR TITLE
ci: pin every GitHub Action to a commit SHA and guard the form (see #217)

### DIFF
--- a/.consiliency/evidence/mutation-217.md
+++ b/.consiliency/evidence/mutation-217.md
@@ -105,59 +105,68 @@ Base: the implementation commit. `helper` is `_mutate_workflow.sh`'s exit,
 | mutant | expected | helper | commit | checker | reason |
 |---|---|---|---|---|---|
 | *(none: unmutated tree)* | 0 | — | — | 0 | — |
-| `tag-case` | 1 | 0 | `ffd32cd` | **1** | `[release] ` |
-| `tags-deleted` | 1 | 0 | `7ac7cd8` | **1** | `[release] ` |
-| `trigger-pull-request-added` | 1 | 0 | `b116a62` | **1** | `[release] ` |
-| `trigger-push-branches-added` | 1 | 0 | `d647cdd` | **1** | `[release] ` |
-| `trigger-workflow-dispatch-added` | 1 | 0 | `0a84d8c` | **1** | `[release] ` |
-| `trigger-paths-filter-added` | 1 | 0 | `958dac0` | **1** | `[release] ` |
-| `env-dropped` | 1 | 0 | `309a3dd` | **1** | `[release] ` |
-| `env-renamed` | 1 | 0 | `dd5b677` | **1** | `[release] ` |
-| `needs-build-dropped` | 1 | 0 | `1362029` | **1** | `[release] ` |
-| `needs-publish-to-build` | 1 | 0 | `11d3a3b` | **1** | `[release] ` |
-| `continue-on-error-job` | 1 | 0 | `f9a8a6e` | **1** | `[release] ` |
-| `continue-on-error-step` | 1 | 0 | `d3a7590` | **1** | `[release] ` |
-| `if-on-build-job` | 1 | 0 | `a35fecf` | **1** | `[release] ` |
-| `continue-on-error-build-job` | 1 | 0 | `5fd00e4` | **1** | `[release] ` |
-| `new-tag-triggered-workflow` | 1 | 0 | `8f3c17b` | **1** | `[release] ` |
-| `if-on-publish-job` | 1 | 0 | `8233a59` | **1** | `[release] ` |
-| `if-on-publish-step` | 1 | 0 | `e968318` | **1** | `[release] ` |
-| `forked-action` | 1 | 0 | `7b73151` | **1** | `[release] ` |
-| `permissions-job-widened` | 1 | 0 | `e8a72e3` | **1** | `[release] ` |
-| `permissions-workflow-level` | 1 | 0 | `ecd3535` | **1** | `[release] ` |
-| `job-added` | 1 | 0 | `5cbd1d7` | **1** | `[release] ` |
-| `job-deleted` | 1 | 0 | `323aa30` | **1** | `[drift] [release] ` |
-| `file-deleted` | 1 | 0 | `9028241` | **1** | `[drift] [release] ` |
-| `timeout-360` | 1 | 0 | `eca2fac` | **1** | `[timeout] ` |
-| `timeout-1` | 1 | 0 | `572250a` | **1** | `[timeout] ` |
-| `timeout-string` | 1 | 0 | `d34fabe` | **1** | `[timeout] ` |
-| `timeout-bool` | 1 | 0 | `ccf8f57` | **1** | `[timeout] ` |
-| `timeout-deleted` | 1 | 0 | `8333f2e` | **1** | `[timeout] ` |
-| `maintenance-deleted` | 1 | 0 | `496f6be` | **1** | `[drift] ` |
-| `changelog-job-deleted` | 1 | 0 | `dd21b9e` | **1** | `[drift] ` |
-| `workflows-job-deleted` | 1 | 0 | `a13788f` | **1** | `[drift] ` |
-| `tag-pinned-action` | 1 | 0 | `5f65a09` | **1** | `[pin] ` |
-| `sha-comment-dropped` | 1 | 0 | `edc549e` | **1** | `[pin] ` |
-| `sha-moved` | 1 | 0 | `b0f04a3` | **1** | `[release] ` |
-| `pypa-rolled-back` | 1 | 0 | `a5d64e3` | **1** | `[release] ` |
-| `composite-tag-pinned` | 1 | 0 | `51f8c0f` | **1** | `[pin] ` |
-| `needs-as-list` | 0 | 0 | `0e6aba9` | 0 | — |
-| `timeout-below-p100` | 0 | 0 | `d1be6ec` | 0 | — |
-| `concurrency-added` | 0 | 0 | `24fef20` | 0 | — |
-| `guard-self-disabled` | 0 | 0 | `92b9638` | 0 | — |
-| `guard-self-disabled-nonconstant` | 0 | 0 | `a8d5a90` | 0 | — |
-| `guard-step-gutted` | 0 | 0 | `0eb122d` | 0 | — |
+| `tag-case` | 1 | 0 | `3e339ad` | **1** | `[release]` |
+| `tags-deleted` | 1 | 0 | `07a838e` | **1** | `[release]` |
+| `trigger-pull-request-added` | 1 | 0 | `fa37b8b` | **1** | `[release]` |
+| `trigger-push-branches-added` | 1 | 0 | `ef8ed1a` | **1** | `[release]` |
+| `trigger-workflow-dispatch-added` | 1 | 0 | `e105218` | **1** | `[release]` |
+| `trigger-paths-filter-added` | 1 | 0 | `e3ce0fc` | **1** | `[release]` |
+| `env-dropped` | 1 | 0 | `916c3d2` | **1** | `[release]` |
+| `env-renamed` | 1 | 0 | `53b8ebd` | **1** | `[release]` |
+| `needs-build-dropped` | 1 | 0 | `81aa64e` | **1** | `[release]` |
+| `needs-publish-to-build` | 1 | 0 | `1d1a2e6` | **1** | `[release]` |
+| `continue-on-error-job` | 1 | 0 | `b834dfb` | **1** | `[release]` |
+| `continue-on-error-step` | 1 | 0 | `576dc00` | **1** | `[release]` |
+| `if-on-build-job` | 1 | 0 | `d81ecf0` | **1** | `[release]` |
+| `continue-on-error-build-job` | 1 | 0 | `7e220c8` | **1** | `[release]` |
+| `new-tag-triggered-workflow` | 1 | 0 | `4636780` | **1** | `[release]` |
+| `if-on-publish-job` | 1 | 0 | `aef994f` | **1** | `[release]` |
+| `if-on-publish-step` | 1 | 0 | `66b53dd` | **1** | `[release]` |
+| `forked-action` | 1 | 0 | `7caa446` | **1** | `[release]` |
+| `permissions-job-widened` | 1 | 0 | `75fb7c0` | **1** | `[release]` |
+| `permissions-workflow-level` | 1 | 0 | `3b3a383` | **1** | `[release]` |
+| `job-added` | 1 | 0 | `6a392ca` | **1** | `[release]` |
+| `job-deleted` | 1 | 0 | `1ae3523` | **1** | `[drift] [release]` |
+| `file-deleted` | 1 | 0 | `7a7feb1` | **1** | `[drift] [release]` |
+| `timeout-360` | 1 | 0 | `1422282` | **1** | `[timeout]` |
+| `timeout-1` | 1 | 0 | `1db916e` | **1** | `[timeout]` |
+| `timeout-string` | 1 | 0 | `9552665` | **1** | `[timeout]` |
+| `timeout-bool` | 1 | 0 | `aa5f6c6` | **1** | `[timeout]` |
+| `timeout-deleted` | 1 | 0 | `248fa75` | **1** | `[timeout]` |
+| `maintenance-deleted` | 1 | 0 | `3d08225` | **1** | `[drift]` |
+| `changelog-job-deleted` | 1 | 0 | `fec6b04` | **1** | `[drift]` |
+| `workflows-job-deleted` | 1 | 0 | `8ec7556` | **1** | `[drift]` |
+| `tag-pinned-action` | 1 | 0 | `4b83073` | **1** | `[pin]` |
+| `sha-comment-dropped` | 1 | 0 | `7ff6f57` | **1** | `[pin]` |
+| `sha-moved` | 1 | 0 | `4140843` | **1** | `[release]` |
+| `pypa-rolled-back` | 1 | 0 | `7cc269a` | **1** | `[release]` |
+| `composite-tag-pinned` | 1 | 0 | `7595c0d` | **1** | `[pin]` |
+| `uses-quoted-key` | 1 | 0 | `4d2886b` | **1** | `[pin]` |
+| `needs-as-list` | 0 | 0 | `0edbb5b` | 0 | — |
+| `timeout-below-p100` | 0 | 0 | `815da29` | 0 | — |
+| `concurrency-added` | 0 | 0 | `6d0edfe` | 0 | — |
+| `guard-self-disabled` | 0 | 0 | `6469415` | 0 | — |
+| `guard-self-disabled-nonconstant` | 0 | 0 | `96519f6` | 0 | — |
+| `guard-step-gutted` | 0 | 0 | `9cf53be` | 0 | — |
 
-42 rows, 36 expected to fail, 6 expected green; every helper exit 0, every hash
+43 rows, 37 expected to fail, 6 expected green; every helper exit 0, every hash
 distinct, every expected failure reported by the expected check, every expected
 green row green.
 
-### What the five new rows prove
+### What the six new rows prove
 
 - `tag-pinned-action`, `composite-tag-pinned`, `sha-comment-dropped` — the
   **form** check, in a workflow, in the composite (which runs with
   `id-token: write` and `contents: write`), and for a missing comment. The
   composite row is the one Dependabot's root entry could never have produced.
+- `uses-quoted-key` — `"uses": actions/setup-node@v4` in the composite: valid
+  YAML that GitHub runs and the line scan cannot see. It was a real bypass of
+  the first cut of this guard (found by the board on #218): `"uses":`,
+  `uses :`, `{uses: x}` and `uses: >-` all parsed as executable steps while
+  `remote_uses` returned nothing. Killed now by the parsed-inventory
+  cross-check — the parsed document's remote `uses:` values must equal the
+  raw scan's, per file — which turns every unreadable spelling into a failure.
+  Five such forms are pinned by test.
 - `sha-moved`, `pypa-rolled-back` — form-valid pins to the **wrong commit**,
   killed by `EXPECTED_USES` and tagged `[release]`, not `[pin]`. The pin
   invariant does not and cannot catch these; the evidence says so rather than
@@ -177,4 +186,6 @@ The six expected-green rows are the cases the checker deliberately does not
 own (`release-diff-ack` and the `test` job do). Also not covered here, by
 design: whether a pinned SHA is *current* — Dependabot owns currency, the guard
 owns form; and `docker://` references, which the guard reports rather than
-admits until that decision is made in `check_workflows.py`.
+admits until that decision is made in `check_workflows.py`. A `uses:` in a
+form the line scan cannot read is **not** a residual: the parsed-inventory
+cross-check fails it (`uses-quoted-key`).

--- a/.consiliency/evidence/mutation-217.md
+++ b/.consiliency/evidence/mutation-217.md
@@ -1,0 +1,180 @@
+# Mutation evidence — Consiliency/pmcp#217
+
+Every remote `uses:` in `.github/workflows/` and in the local composite action
+`.github/actions/pipeline-bootstrap-setup/action.yml` is pinned to a commit SHA
+with the release named in a trailing comment, and `scripts/check_workflows.py`
+refuses any other form. This document is the transcript of the loop that proves
+the guard sees each way that can regress.
+
+Two checks divide the work. `all_uses_are_sha_pinned` runs on **raw text**
+(`yaml.safe_load` drops the comment, so parsed YAML cannot see half the
+convention) and rejects the *form*: a mutable tag, a branch, a missing comment.
+It cannot know which commit is right. `EXPECTED_USES`, now in SHA form, rejects
+the *commit* on `release.yml`: a moved digit, or a real older release with an
+honest comment. The matrix names which check killed each mutant, so a mutant
+killed by the wrong one is a loop failure, not a pass.
+
+## Before pinning
+
+The invariant was wired and run against the unpinned tree **before** any pin
+was made. It reported **30 `[pin]` failures** — 29 in the workflows and 1 in
+the composite — plus 3 `[release]` mismatches from the already-SHA-form
+allowlist: 33 in total. A guard that starts green has not seen the problem.
+
+## Resolution
+
+Each pin is the commit its *original* mutable ref resolved to on 2026-09-01,
+peeled through annotated tags (`astral-sh/setup-uv@v7` and every pypa release
+tag are annotated; pinning the tag object's SHA would pass a form check and
+break only at tag push). The verifier in the plan checks two things per pin:
+(a) the trailing comment's tag resolves to the pinned SHA, and (b) the multiset
+of `repo@commit` over the pre-pin refs on `origin/main` equals the multiset of
+pinned `repo@sha` in the tree. (b) is the "no behaviour change" proof, keyed per
+line because `actions/setup-node` is `@v4` in the composite and `@v7` in the
+workflows.
+
+```
+checked 30 pinned refs (expect 30)          # 30 × OK(a)
+OK(b)    all 30 pins equal their original refs' commits
+exit 0
+```
+
+Fail-closed, both branches seen to fire:
+
+```
+# one hex digit of the pypa SHA altered
+MISMATCH(a) pypa/gh-action-pypi-publish@…73ba34  # v1.14.2 -> …73ba33
+exit 1
+# pypa set to v1.9.0's REAL commit with an honest "# v1.9.0" comment
+OK(a)    pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0  # v1.9.0
+MISMATCH(b):
+< pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
+> pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0
+exit 1
+```
+
+The second proof is the one that matters: (a) alone accepts a correct-looking
+rollback. v1.9.0 is 144 commits behind v1.14.2 and below the
+GHSA-vxmw-7h4f-hqxh floor (`< 1.13.0`). `release/v1` and `v1.14.2` resolved to
+the same commit (`dc37677b…`) on the day, so the pypa pin changes nothing that
+runs; the composite's `setup-node@v4` pins to v4.4.0 (`49933ea…`), likewise.
+
+| original ref | pinned | release |
+|---|---|---|
+| `actions/checkout@v7` ×12 | `3d3c42e5aac5ba805825da76410c181273ba90b1` | v7.0.1 |
+| `actions/download-artifact@v7` ×2 | `37930b1c2abaa49bbe596cd826c3c89aef350131` | v7.0.0 |
+| `actions/setup-node@v7` ×2 | `820762786026740c76f36085b0efc47a31fe5020` | v7.0.0 |
+| `actions/setup-node@v4` ×1 (composite) | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
+| `actions/upload-artifact@v7` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | v7.0.1 |
+| `astral-sh/setup-uv@v7` ×7 | `37802adc94f370d6bfd71619e3f0bf239e1f3b78` | v7.6.0 |
+| `docker/build-push-action@v7` | `53b7df96c91f9c12dcc8a07bcb9ccacbed38856a` | v7.3.0 |
+| `docker/login-action@v4` | `dbcb813823bdd20940b903addbd779551569679f` | v4.6.0 |
+| `docker/metadata-action@v6` | `dc802804100637a589fabce1cb79ff13a1411302` | v6.2.0 |
+| `docker/setup-buildx-action@v4` | `37fe631027851001ddb9b187196cc803df7f5f0e` | v4.3.0 |
+| `pypa/gh-action-pypi-publish@release/v1` | `dc37677b2e1c63e2034f94d8a5b11f265b73ba33` | v1.14.2 |
+
+## Protocol
+
+As in `mutation-189.md`: mutants are **committed on a scratch branch**, never
+left in the working tree (drift uses a three-dot diff and only sees committed
+changes). This loop additionally records the **helper's exit code and the
+mutant's commit hash**. That column exists because three mutants anchored on
+`@release/v1`; after pinning, an un-updated anchor matches zero times,
+`replace()` refuses, nothing is committed, the checker runs on the clean tree
+and exits 0 — and the survivor looks like a helper hiccup. A row whose helper
+exit is not 0, or whose hash equals the base, is a loop failure regardless of
+the checker column. `PYTHONDONTWRITEBYTECODE=1` throughout.
+
+```bash
+git switch -c scratch-mutants
+BASE=$(git rev-parse HEAD)
+./scripts/_mutate_workflow.sh --list | while IFS='|' read -r name expected tags desc; do
+  ./scripts/_mutate_workflow.sh "$name"; hexit=$?
+  [ $hexit -eq 0 ] && git add -A && git commit -qm "mutant: $name"
+  uv run python scripts/check_workflows.py --base-ref "$BASE"; echo "$name helper=$hexit commit=$(git rev-parse --short HEAD) checker=$?"
+  git switch -q -C scratch-mutants "$BASE"      # not `reset --hard`, not `stash`
+done
+```
+
+## Matrix
+
+Base: the implementation commit. `helper` is `_mutate_workflow.sh`'s exit,
+`commit` the mutant's committed hash (all distinct from base), `checker` is
+`check_workflows.py --base-ref <base>`, `reason` the tag(s) it reported.
+
+| mutant | expected | helper | commit | checker | reason |
+|---|---|---|---|---|---|
+| *(none: unmutated tree)* | 0 | — | — | 0 | — |
+| `tag-case` | 1 | 0 | `ffd32cd` | **1** | `[release] ` |
+| `tags-deleted` | 1 | 0 | `7ac7cd8` | **1** | `[release] ` |
+| `trigger-pull-request-added` | 1 | 0 | `b116a62` | **1** | `[release] ` |
+| `trigger-push-branches-added` | 1 | 0 | `d647cdd` | **1** | `[release] ` |
+| `trigger-workflow-dispatch-added` | 1 | 0 | `0a84d8c` | **1** | `[release] ` |
+| `trigger-paths-filter-added` | 1 | 0 | `958dac0` | **1** | `[release] ` |
+| `env-dropped` | 1 | 0 | `309a3dd` | **1** | `[release] ` |
+| `env-renamed` | 1 | 0 | `dd5b677` | **1** | `[release] ` |
+| `needs-build-dropped` | 1 | 0 | `1362029` | **1** | `[release] ` |
+| `needs-publish-to-build` | 1 | 0 | `11d3a3b` | **1** | `[release] ` |
+| `continue-on-error-job` | 1 | 0 | `f9a8a6e` | **1** | `[release] ` |
+| `continue-on-error-step` | 1 | 0 | `d3a7590` | **1** | `[release] ` |
+| `if-on-build-job` | 1 | 0 | `a35fecf` | **1** | `[release] ` |
+| `continue-on-error-build-job` | 1 | 0 | `5fd00e4` | **1** | `[release] ` |
+| `new-tag-triggered-workflow` | 1 | 0 | `8f3c17b` | **1** | `[release] ` |
+| `if-on-publish-job` | 1 | 0 | `8233a59` | **1** | `[release] ` |
+| `if-on-publish-step` | 1 | 0 | `e968318` | **1** | `[release] ` |
+| `forked-action` | 1 | 0 | `7b73151` | **1** | `[release] ` |
+| `permissions-job-widened` | 1 | 0 | `e8a72e3` | **1** | `[release] ` |
+| `permissions-workflow-level` | 1 | 0 | `ecd3535` | **1** | `[release] ` |
+| `job-added` | 1 | 0 | `5cbd1d7` | **1** | `[release] ` |
+| `job-deleted` | 1 | 0 | `323aa30` | **1** | `[drift] [release] ` |
+| `file-deleted` | 1 | 0 | `9028241` | **1** | `[drift] [release] ` |
+| `timeout-360` | 1 | 0 | `eca2fac` | **1** | `[timeout] ` |
+| `timeout-1` | 1 | 0 | `572250a` | **1** | `[timeout] ` |
+| `timeout-string` | 1 | 0 | `d34fabe` | **1** | `[timeout] ` |
+| `timeout-bool` | 1 | 0 | `ccf8f57` | **1** | `[timeout] ` |
+| `timeout-deleted` | 1 | 0 | `8333f2e` | **1** | `[timeout] ` |
+| `maintenance-deleted` | 1 | 0 | `496f6be` | **1** | `[drift] ` |
+| `changelog-job-deleted` | 1 | 0 | `dd21b9e` | **1** | `[drift] ` |
+| `workflows-job-deleted` | 1 | 0 | `a13788f` | **1** | `[drift] ` |
+| `tag-pinned-action` | 1 | 0 | `5f65a09` | **1** | `[pin] ` |
+| `sha-comment-dropped` | 1 | 0 | `edc549e` | **1** | `[pin] ` |
+| `sha-moved` | 1 | 0 | `b0f04a3` | **1** | `[release] ` |
+| `pypa-rolled-back` | 1 | 0 | `a5d64e3` | **1** | `[release] ` |
+| `composite-tag-pinned` | 1 | 0 | `51f8c0f` | **1** | `[pin] ` |
+| `needs-as-list` | 0 | 0 | `0e6aba9` | 0 | — |
+| `timeout-below-p100` | 0 | 0 | `d1be6ec` | 0 | — |
+| `concurrency-added` | 0 | 0 | `24fef20` | 0 | — |
+| `guard-self-disabled` | 0 | 0 | `92b9638` | 0 | — |
+| `guard-self-disabled-nonconstant` | 0 | 0 | `a8d5a90` | 0 | — |
+| `guard-step-gutted` | 0 | 0 | `0eb122d` | 0 | — |
+
+42 rows, 36 expected to fail, 6 expected green; every helper exit 0, every hash
+distinct, every expected failure reported by the expected check, every expected
+green row green.
+
+### What the five new rows prove
+
+- `tag-pinned-action`, `composite-tag-pinned`, `sha-comment-dropped` — the
+  **form** check, in a workflow, in the composite (which runs with
+  `id-token: write` and `contents: write`), and for a missing comment. The
+  composite row is the one Dependabot's root entry could never have produced.
+- `sha-moved`, `pypa-rolled-back` — form-valid pins to the **wrong commit**,
+  killed by `EXPECTED_USES` and tagged `[release]`, not `[pin]`. The pin
+  invariant does not and cannot catch these; the evidence says so rather than
+  implying it.
+
+### Re-anchored mutants
+
+`continue-on-error-step`, `if-on-publish-step` and `forked-action` all anchored
+on `uses: pypa/gh-action-pypi-publish@release/v1`. Their rows show helper 0
+and a fresh hash: they still mutate. `forked-action` keeps the SHA form and the
+comment, so only the allowlist sees the owner change — as the row's `[release]`
+says.
+
+### Not covered, unchanged from #189
+
+The six expected-green rows are the cases the checker deliberately does not
+own (`release-diff-ack` and the `test` job do). Also not covered here, by
+design: whether a pinned SHA is *current* — Dependabot owns currency, the guard
+owns form; and `docker://` references, which the guard reports rather than
+admits until that decision is made in `check_workflows.py`.

--- a/.consiliency/plans/detailed-sha-pin-actions-20260901-1000.md
+++ b/.consiliency/plans/detailed-sha-pin-actions-20260901-1000.md
@@ -1,0 +1,191 @@
+# Detailed plan: pin every GitHub Action to a commit SHA, and guard the convention
+
+## Task
+
+Close Consiliency/pmcp#217. All 30 `uses:` references in `.github/workflows/`
+resolve a **mutable tag**. Pin each to its commit SHA with the version kept as a
+trailing comment, and add a guard so the convention cannot regress.
+
+## Research summary
+
+Verified in this worktree.
+
+**The inventory.** 30 refs, 11 distinct actions, 0 SHA-pinned:
+`actions/checkout@v7` ×12, `astral-sh/setup-uv@v7` ×7,
+`actions/download-artifact@v7` ×2, `actions/setup-node@v7` ×2,
+`actions/upload-artifact@v7`, `docker/build-push-action@v7`,
+`docker/metadata-action@v6`, `docker/login-action@v4`,
+`docker/setup-buildx-action@v4`, and **`pypa/gh-action-pypi-publish@release/v1`**.
+`./.github/actions/pipeline-bootstrap-setup` is a local path — not a ref, not
+in scope.
+
+**The one that matters most.** `pypa/gh-action-pypi-publish@release/v1` runs in
+`release.yml`'s `publish` job with `id-token: write` — the PyPI trusted-publishing
+identity. `release/v1` is a floating ref by the action's own design. For this
+repo the tag push *is* the publish, so a moved ref runs new code with PyPI
+credentials in scope and **no diff, no PR, no review**.
+
+**Dependabot already handles SHA pins.** `.github/dependabot.yml` tracks
+`github-actions` weekly. Dependabot's native behaviour for a SHA-pinned action
+is to bump the SHA and maintain a trailing `# vX.Y.Z` comment. Pinning costs
+nothing in automation — *provided the comment convention is followed*, because
+Dependabot reads the comment to know which release line to track.
+
+**The #189 guard already asserts `release.yml`'s refs exactly.**
+`EXPECTED_USES` at `scripts/check_workflows.py:59` lists each job's `uses:`
+values verbatim, and `_mutate_workflow.sh:285`'s `forked-action` mutant proves a
+repoint fails. Both are written against the current tag strings. Pinning
+`release.yml` therefore **requires updating both in the same PR**, or the
+`workflows` job goes red on the pinning PR itself.
+
+**The cost, which is the point.** After this, a Dependabot bump touching
+`release.yml` fails `workflows` until `EXPECTED_USES` is updated alongside it.
+That converts a one-file bot PR into a two-file human PR — for `release.yml`
+only. That is exactly the deliberate-change property #189 exists to enforce on
+that file, so it is accepted rather than worked around.
+
+## Changes
+
+### `.github/workflows/*.yml` (modify — all five)
+
+- Every `uses: owner/action@<tag>` — modify — to
+  `uses: owner/action@<40-hex-sha> # <tag>`. Resolve each SHA **at
+  implementation time** from the tag the file currently names, via
+  `gh api repos/<owner>/<action>/git/ref/tags/<tag>` (dereferencing an annotated
+  tag to its commit — `git/ref/tags/` can return a tag object, whose `object.sha`
+  must be followed once more). Do not copy SHAs from this plan or from memory;
+  a SHA that does not match the tag it claims is worse than the tag.
+- The trailing comment carries the **exact release** (`# v7.0.0`), not the
+  major (`# v7`), where the tag resolves to a specific release. Dependabot uses
+  it; a human reading the file needs it; and it makes drift visible.
+- `pypa/gh-action-pypi-publish@release/v1` — modify — pin to the commit
+  `release/v1` currently points at, comment `# release/v1 (<vX.Y.Z>)` naming the
+  release it corresponds to. This is the highest-value pin in the tree.
+
+### `scripts/check_workflows.py` (modify)
+
+- `EXPECTED_USES` (`:59`) — modify — to the pinned forms, **including the
+  comment**, so that a pin whose comment has been silently dropped also fails.
+  The existing exact-match invariant then catches a moved SHA for free.
+- `all_uses_are_sha_pinned(paths)` — add — a new invariant across **every**
+  workflow file: each `uses:` that is not a local path (`./…`) or a reusable
+  workflow must match `^[\w.-]+/[\w.-]+@[0-9a-f]{40}\s+#\s*\S+`. Reason text
+  names the offending file, job, and ref. Without this the convention regresses
+  the first time someone pastes `@v4` from a README.
+- The module docstring (`:22`) — modify — state the pin convention and that
+  `EXPECTED_USES` now includes comments.
+
+### `scripts/_mutate_workflow.sh` (modify)
+
+- `forked-action` (`:285`) — modify — the mutant must repoint the **pinned**
+  string; today it replaces a tag string that will no longer exist, so the
+  mutant would silently stop mutating and the matrix would show it "killed"
+  because the sed matched nothing and the tree was unchanged. **Verify the sed
+  actually changed the file** before recording the exit code.
+- `tag-pinned-action` — add — reverts one ref in `test.yml` to `@v7`. Must
+  fail via the new invariant.
+- `sha-comment-dropped` — add — keeps the SHA but removes the `# vX.Y.Z`
+  comment on one ref. Must fail: a pin without its comment is unmaintainable.
+- `sha-moved` — add — changes one release.yml SHA by a digit. Must fail via
+  `EXPECTED_USES`, proving the exact-match still bites after pinning.
+
+### `tests/test_workflow_guards.py` (modify)
+
+- `TestShaPinning` — add — one test per new mutant above, in memory, plus the
+  positive case: a correctly pinned ref with a comment passes.
+- `TestMutationHelperContract` — the helper list must gain the three new
+  mutants, and the bidirectional inclusion test will enforce it.
+
+### `.consiliency/evidence/mutation-217.md` (create)
+
+- Extend the #189 matrix with the new rows and **real committed-mutant exit
+  codes**, including a check that each mutant's sed actually modified the tree.
+
+## Documentation impact
+
+- `CHANGELOG.md` — add — `### Changed`: every action is now SHA-pinned; name the
+  PyPI publish action explicitly, since that is the one an operator would want to
+  know about.
+- `SECURITY.md` — modify — the supply-chain section, if present, should state
+  the pin convention; if absent, add one sentence under the existing
+  release-path discussion (`:39` area). Check before editing.
+- `.github/dependabot.yml` — **no change**. Confirm in the PR body that the
+  existing `github-actions` entry handles SHA pins, so a reader does not assume
+  automation was lost.
+
+## Dependencies & order
+
+1. The new `all_uses_are_sha_pinned` invariant and its tests **first, against
+   unchanged workflows** — it must go RED on the current tree. That is the proof
+   the guard sees the problem before anything is pinned.
+2. Resolve SHAs and pin all five workflow files.
+3. Update `EXPECTED_USES` and the `forked-action` mutant in the same commit as
+   the `release.yml` pins — otherwise `workflows` is red between commits.
+4. New mutants, evidence matrix.
+5. Docs.
+
+## Verification
+
+```bash
+uv run pytest -q tests/test_workflow_guards.py
+uv run python scripts/check_workflows.py --base-ref origin/main   # exit 0 after pinning
+
+# Every SHA must resolve to the tag it claims -- assert it, do not eyeball it:
+grep -rhoE "uses:\s*\S+@[0-9a-f]{40}\s*#\s*\S+" .github/workflows/*.yml | while read -r line; do
+  ref=$(echo "$line" | sed -E 's/uses:\s*//; s/\s*#.*//'); tag=$(echo "$line" | sed -E 's/.*#\s*//')
+  repo=${ref%@*}; sha=${ref#*@}
+  got=$(gh api "repos/$repo/git/ref/tags/$tag" -q .object.sha 2>/dev/null)
+  # annotated tags: follow one level
+  [ "$(gh api "repos/$repo/git/ref/tags/$tag" -q .object.type)" = tag ] && got=$(gh api "repos/$repo/git/tags/$got" -q .object.sha)
+  [ "$got" = "$sha" ] && echo "OK   $ref" || echo "MISMATCH $ref (tag $tag -> $got)"
+done
+
+# Mutants committed on a scratch branch; check each sed changed the tree.
+uv run ruff check src/ tests/ scripts/ && uv run mypy src/
+```
+
+Edge cases: an annotated tag (two-level dereference — `actions/*` use these);
+an action whose tag was retagged upstream between resolution and merge (re-run
+the resolver script in CI's `workflows` job? — no: that is a network call in a
+guard, rejected; the guard asserts *form*, Dependabot asserts *currency*); a
+`uses:` at **job** level for a reusable workflow (none exist today — the
+invariant must skip `uses:` whose value contains `.yml@`, and a test must pin
+that skip so a future reusable workflow is not misreported).
+
+## Acceptance criteria
+
+- [ ] `all_uses_are_sha_pinned` is **RED against unchanged `main`** and reports
+      all 29 non-local refs — proven by running the new invariant before any
+      workflow is edited. A guard that starts green has not seen the problem.
+- [ ] After pinning, the checker exits 0 on the tree, and the SHA-resolution
+      loop above reports **29 OK, 0 MISMATCH**. A pin whose SHA does not match
+      its claimed tag must not pass.
+- [ ] The three new mutants (`tag-pinned-action`, `sha-comment-dropped`,
+      `sha-moved`) each exit non-zero as **committed** scratch-branch mutants,
+      with evidence that each sed **actually modified the file** — the existing
+      `forked-action` mutant would otherwise silently stop mutating once its
+      target string is gone.
+- [ ] A correctly pinned ref with its comment **passes** the new invariant, and
+      a job-level reusable-workflow `uses:` is **skipped**, not flagged — proven
+      by a synthetic fixture.
+- [ ] `TestMutationHelperContract`'s bidirectional check passes with the new
+      mutants present, so the helper and the tests still name the same set.
+- [ ] Every remaining `uses:` in `.github/workflows/` is either a local path or
+      matches the pinned form — asserted by grep in the evidence file, count 29.
+- [ ] Full suite green.
+
+## Non-goals
+
+- Pinning the local composite action `./.github/actions/pipeline-bootstrap-setup`
+  — it is repo-owned source, reviewed like any other file.
+- Changing Dependabot's cadence or grouping.
+- Verifying SHA currency inside the CI guard. That would put a network call on
+  the merge path; Dependabot owns currency, the guard owns form.
+- Pinning Docker base images in `docker.yml`'s Dockerfile — same class, separate
+  ecosystem, its own issue if wanted.
+
+## Execution Policy
+
+- execute: effort=medium, reason=mechanical edits across five files, but the
+  guard and mutant updates must land atomically with the release.yml pins or CI
+  is red mid-sequence, and a wrong SHA is a silent supply-chain failure

--- a/.consiliency/plans/detailed-sha-pin-actions-20260901-1000.md
+++ b/.consiliency/plans/detailed-sha-pin-actions-20260901-1000.md
@@ -179,7 +179,9 @@ refused as non-unique; new anchors need step context.
 ### `tests/test_workflow_guards.py` (modify)
 
 - `TestShaPinning` — add — one test per new mutant plus: a correctly pinned ref
-  with comment **passes**; a job-level reusable-workflow `uses:` is **skipped**;
+  with comment **passes**; a job-level reusable workflow that is a `./` same-repo
+  path is **skipped**, and a **remote** one (`owner/repo/.github/workflows/x.yml@…`)
+  is **required to be SHA-pinned** — `@main` fails, `@<sha> # vX` passes;
   a subdirectory action `owner/repo/path@<sha> # v1` **passes**; a `docker://`
   `uses:` is reported (it is not pinnable by this scheme — decide: skip with a
   named reason, or fail; there are none today, so pin the decision by test).
@@ -255,7 +257,8 @@ uv run ruff check src/ tests/ scripts/ && uv run mypy src/
 ```
 
 Edge cases: annotated vs lightweight tags (both present); a `uses:` at job level
-for a reusable workflow (none today — skip pinned by test); `docker://` refs
+for a reusable workflow (none today — the **remote-must-pin / `./`-skip** split is
+pinned by test, not a blanket skip); `docker://` refs
 (none today — decision pinned by test); the composite action's `runs:` block
 must not be mistaken for a step list.
 

--- a/.consiliency/plans/detailed-sha-pin-actions-20260901-1000.md
+++ b/.consiliency/plans/detailed-sha-pin-actions-20260901-1000.md
@@ -1,128 +1,166 @@
 # Detailed plan: pin every GitHub Action to a commit SHA, and guard the convention
 
+> **Revision 2 (2026-09-01).** Rev 1 boarded 2 DISAGREE / 1 AGREE. Three defects,
+> each verified: (1) `EXPECTED_USES` with comments could **never match**, because
+> `yaml.safe_load` strips comments before `_collect_uses` runs — every correctly
+> pinned `release.yml` would have failed; (2) **three** mutants anchor on
+> `@release/v1`, not one, and `replace()` refuses a non-unique anchor, so all
+> three would have become silent survivors; (3) the local composite action's own
+> `actions/setup-node@v4` runs with `id-token: write` and was wrongly out of
+> scope. Also: `release/v1` is a **branch**, 144 commits past pypa's newest
+> release — the operator chose to pin to the release tag instead.
+
 ## Task
 
-Close Consiliency/pmcp#217. All 30 `uses:` references in `.github/workflows/`
-resolve a **mutable tag**. Pin each to its commit SHA with the version kept as a
-trailing comment, and add a guard so the convention cannot regress.
+Close Consiliency/pmcp#217. Every `uses:` reference in `.github/workflows/`
+and in the local composite action resolves a **mutable tag** (or, for pypa, a
+**branch**). Pin each to a commit SHA with the version as a trailing comment,
+and add a guard so the convention cannot regress.
 
 ## Research summary
 
 Verified in this worktree.
 
-**The inventory.** 30 refs, 11 distinct actions, 0 SHA-pinned:
-`actions/checkout@v7` ×12, `astral-sh/setup-uv@v7` ×7,
-`actions/download-artifact@v7` ×2, `actions/setup-node@v7` ×2,
-`actions/upload-artifact@v7`, `docker/build-push-action@v7`,
-`docker/metadata-action@v6`, `docker/login-action@v4`,
-`docker/setup-buildx-action@v4`, and **`pypa/gh-action-pypi-publish@release/v1`**.
-`./.github/actions/pipeline-bootstrap-setup` is a local path — not a ref, not
-in scope.
+**The inventory, corrected.** 30 refs in `.github/workflows/`, of which 29 are
+remote actions and 1 is the local path `./.github/actions/pipeline-bootstrap-setup`.
+**Plus** that composite action's own `action.yml:7`: `actions/setup-node@v4`.
+It runs inside `pipeline-bootstrap.yml`'s job with **`id-token: write` and
+`contents: write`** (`:76-78`) — so it is not "repo-owned source reviewed like
+any file"; it is a mutable ref with credentials in scope. **30 remote refs total,
+0 SHA-pinned.** Rev 1 said 30 and excluded the composite; both were wrong.
 
-**The one that matters most.** `pypa/gh-action-pypi-publish@release/v1` runs in
-`release.yml`'s `publish` job with `id-token: write` — the PyPI trusted-publishing
-identity. `release/v1` is a floating ref by the action's own design. For this
-repo the tag push *is* the publish, so a moved ref runs new code with PyPI
-credentials in scope and **no diff, no PR, no review**.
+**Dependabot has never touched `.github/actions/`.** Twenty Dependabot PRs on
+this repo, zero under that path, and the composite still says `@v4` while every
+workflow moved to `@v7`. Dependabot's `github-actions` ecosystem with
+`directory: "/"` is evidently not scanning it here. A second `directory` entry
+is required or the composite's pin freezes forever.
 
-**Dependabot already handles SHA pins.** `.github/dependabot.yml` tracks
-`github-actions` weekly. Dependabot's native behaviour for a SHA-pinned action
-is to bump the SHA and maintain a trailing `# vX.Y.Z` comment. Pinning costs
-nothing in automation — *provided the comment convention is followed*, because
-Dependabot reads the comment to know which release line to track.
+**`pypa/gh-action-pypi-publish@release/v1` is a branch, not a tag.**
+`git/ref/tags/release/v1` returns nothing usable; `git/ref/heads/release%2Fv1`
+resolves. Its head is **144 commits ahead of v1.9.0**, the newest release. So
+the repo has been publishing to PyPI with an *unreleased* build of the publish
+action on every tag push. Pinning to the branch head would freeze an unreleased
+commit with no version to name; the operator chose to pin to **`v1.9.0`**
+(annotated tag → commit `ec4db0b4ddc6…`, full SHA resolved at implementation).
+That is a **rollback of 144 commits on the publish path** and must be stated as
+a behaviour change, not hidden as a pin.
 
-**The #189 guard already asserts `release.yml`'s refs exactly.**
-`EXPECTED_USES` at `scripts/check_workflows.py:59` lists each job's `uses:`
-values verbatim, and `_mutate_workflow.sh:285`'s `forked-action` mutant proves a
-repoint fails. Both are written against the current tag strings. Pinning
-`release.yml` therefore **requires updating both in the same PR**, or the
-`workflows` job goes red on the pinning PR itself.
+**Resolution procedure, corrected.** `git/ref/tags/<name>` with a slash in the
+name is a prefix match and returns garbage. Use `git/matching-refs/tags/<name>`
+and select the exact ref, or URL-encode. Annotated tags (`astral-sh/setup-uv@v7`
+is one; the pypa release tags all are) need a second dereference through
+`git/tags/<sha>`. 8 of the 10 distinct actions use lightweight tags.
 
-**The cost, which is the point.** After this, a Dependabot bump touching
-`release.yml` fails `workflows` until `EXPECTED_USES` is updated alongside it.
-That converts a one-file bot PR into a two-file human PR — for `release.yml`
-only. That is exactly the deliberate-change property #189 exists to enforce on
-that file, so it is accepted rather than worked around.
+**`yaml.safe_load` strips comments.** `_load` (`check_workflows.py:525-527`)
+and the `:413` path both parse with `safe_load`, so by the time `_collect_uses`
+(`:134`) sees a `uses:` value the `# vX.Y.Z` is gone. Any expected value that
+includes a comment can never match. The comment convention must be checked on
+**raw text**; the parsed `EXPECTED_USES` must hold the SHA form only.
+
+**`replace()` in `_mutate_workflow.sh:104-120` refuses an anchor that does not
+match exactly once.** After pinning, three mutants' anchors match zero times:
+`continue-on-error-step` (`:229,232`), `if-on-publish-step` (`:245,248`), and
+`forked-action` (`:286`). In the evidence loop (`mutate && commit; checker`) a
+refused helper never commits, the checker runs on the clean tree, exits 0, and
+the mutant is recorded as a **survivor** — while looking like a helper hiccup.
+Rev 1 updated only `forked-action`. And `actions/checkout` appears 8× in
+`test.yml` and 2× in `release.yml`, so any SHA-only anchor for a new mutant is
+refused as non-unique; new anchors need step context.
 
 ## Changes
 
-### `.github/workflows/*.yml` (modify — all five)
+### `.github/workflows/*.yml` and `.github/actions/pipeline-bootstrap-setup/action.yml` (modify)
 
-- Every `uses: owner/action@<tag>` — modify — to
-  `uses: owner/action@<40-hex-sha> # <tag>`. Resolve each SHA **at
-  implementation time** from the tag the file currently names, via
-  `gh api repos/<owner>/<action>/git/ref/tags/<tag>` (dereferencing an annotated
-  tag to its commit — `git/ref/tags/` can return a tag object, whose `object.sha`
-  must be followed once more). Do not copy SHAs from this plan or from memory;
-  a SHA that does not match the tag it claims is worse than the tag.
-- The trailing comment carries the **exact release** (`# v7.0.0`), not the
-  major (`# v7`), where the tag resolves to a specific release. Dependabot uses
-  it; a human reading the file needs it; and it makes drift visible.
-- `pypa/gh-action-pypi-publish@release/v1` — modify — pin to the commit
-  `release/v1` currently points at, comment `# release/v1 (<vX.Y.Z>)` naming the
-  release it corresponds to. This is the highest-value pin in the tree.
+- Every remote `uses: owner/action@<tag>` — modify — to
+  `uses: owner/action@<40-hex-sha> # <exact release>`. Resolve at implementation
+  time with `git/matching-refs/tags/`, dereferencing annotated tags. **Do not
+  copy SHAs from this plan.** The comment names the exact release (`# v7.0.0`),
+  which is what Dependabot reads and what a human needs.
+- `pypa/gh-action-pypi-publish` — modify — pin to **v1.9.0**'s commit, comment
+  `# v1.9.0`. This changes what runs at publish: from an unreleased branch head
+  to the newest release. Say so in the PR body and the CHANGELOG.
+- The composite action's `setup-node@v4` — modify — pin to v7's commit like its
+  workflow siblings, comment `# v7.0.0`.
+
+### `.github/dependabot.yml` (modify)
+
+- Add a second `github-actions` entry with
+  `directory: "/.github/actions/pipeline-bootstrap-setup"`. **WAS WRONG (rev 1):**
+  "no change" — Dependabot demonstrably does not scan that path here.
 
 ### `scripts/check_workflows.py` (modify)
 
-- `EXPECTED_USES` (`:59`) — modify — to the pinned forms, **including the
-  comment**, so that a pin whose comment has been silently dropped also fails.
-  The existing exact-match invariant then catches a moved SHA for free.
-- `all_uses_are_sha_pinned(paths)` — add — a new invariant across **every**
-  workflow file: each `uses:` that is not a local path (`./…`) or a reusable
-  workflow must match `^[\w.-]+/[\w.-]+@[0-9a-f]{40}\s+#\s*\S+`. Reason text
-  names the offending file, job, and ref. Without this the convention regresses
-  the first time someone pastes `@v4` from a README.
-- The module docstring (`:22`) — modify — state the pin convention and that
-  `EXPECTED_USES` now includes comments.
+- `EXPECTED_USES` (`:59`) — modify — to the **SHA form without comments**.
+  **WAS WRONG (rev 1):** it put comments in; they can never match parsed YAML.
+- `all_uses_are_sha_pinned(paths)` — add — **operates on raw text, not parsed
+  YAML**, so it can see the comment. For every line matching `uses:` under
+  `.github/workflows/*.yml` **and** `.github/actions/**/action.yml`: skip a value
+  starting `./` (local path) or containing `.yml@` / `.yaml@` (reusable
+  workflow); otherwise require
+  `^\s*-?\s*uses:\s*[\w.-]+/[\w./-]+@[0-9a-f]{40}\s+#\s*\S+`. The `[\w./-]+`
+  admits subdirectory actions (`owner/repo/path@sha`). Reason text names file,
+  line, and ref.
+- **Call it from `main()`.** **WAS WRONG (rev 1):** unstated. The evidence loop
+  runs the CLI, not pytest; a tests-only function lets the new mutants survive.
+- Module docstring (`:22`) — modify — state the convention, and that comments are
+  checked on raw text because the parser drops them.
 
 ### `scripts/_mutate_workflow.sh` (modify)
 
-- `forked-action` (`:285`) — modify — the mutant must repoint the **pinned**
-  string; today it replaces a tag string that will no longer exist, so the
-  mutant would silently stop mutating and the matrix would show it "killed"
-  because the sed matched nothing and the tree was unchanged. **Verify the sed
-  actually changed the file** before recording the exit code.
-- `tag-pinned-action` — add — reverts one ref in `test.yml` to `@v7`. Must
-  fail via the new invariant.
-- `sha-comment-dropped` — add — keeps the SHA but removes the `# vX.Y.Z`
-  comment on one ref. Must fail: a pin without its comment is unmaintainable.
-- `sha-moved` — add — changes one release.yml SHA by a digit. Must fail via
-  `EXPECTED_USES`, proving the exact-match still bites after pinning.
+- **All three** `@release/v1` anchors — modify — to the pinned string:
+  `continue-on-error-step`, `if-on-publish-step`, `forked-action`.
+  **WAS WRONG (rev 1):** only `forked-action`.
+- `tag-pinned-action` — add — reverts the `setup-node` pin in `test.yml`'s
+  `test` job to `@v7` (unique: use the step context, since `checkout` is not
+  unique). Fails via the new invariant.
+- `sha-comment-dropped` — add — strips the comment from `release.yml`'s
+  `upload-artifact` line (unique in the tree). Fails via the new invariant.
+- `sha-moved` — add — alters one hex digit of the pypa SHA in `release.yml`
+  (unique). Fails via `EXPECTED_USES`.
+- `composite-tag-pinned` — add — reverts the composite action's pin to `@v4`.
+  Fails via the new invariant; proves the composite is in scope.
+- The evidence loop — modify — record **the helper's exit code and the commit
+  hash** per mutant, not only the checker's exit. A helper that refused never
+  mutated, and its "kill" is fiction.
 
 ### `tests/test_workflow_guards.py` (modify)
 
-- `TestShaPinning` — add — one test per new mutant above, in memory, plus the
-  positive case: a correctly pinned ref with a comment passes.
-- `TestMutationHelperContract` — the helper list must gain the three new
-  mutants, and the bidirectional inclusion test will enforce it.
+- `TestShaPinning` — add — one test per new mutant plus: a correctly pinned ref
+  with comment **passes**; a job-level reusable-workflow `uses:` is **skipped**;
+  a subdirectory action `owner/repo/path@<sha> # v1` **passes**; a `docker://`
+  `uses:` is reported (it is not pinnable by this scheme — decide: skip with a
+  named reason, or fail; there are none today, so pin the decision by test).
+- `TestMutationHelperContract` gains the four new mutants via its bidirectional
+  check.
 
 ### `.consiliency/evidence/mutation-217.md` (create)
 
-- Extend the #189 matrix with the new rows and **real committed-mutant exit
-  codes**, including a check that each mutant's sed actually modified the tree.
+- The matrix, with per-mutant **helper exit, commit hash, checker exit, reason
+  tag**. Include a row proving the three re-anchored mutants still mutate (their
+  commit hash differs from base).
 
 ## Documentation impact
 
-- `CHANGELOG.md` — add — `### Changed`: every action is now SHA-pinned; name the
-  PyPI publish action explicitly, since that is the one an operator would want to
-  know about.
-- `SECURITY.md` — modify — the supply-chain section, if present, should state
-  the pin convention; if absent, add one sentence under the existing
-  release-path discussion (`:39` area). Check before editing.
-- `.github/dependabot.yml` — **no change**. Confirm in the PR body that the
-  existing `github-actions` entry handles SHA pins, so a reader does not assume
-  automation was lost.
+- `CHANGELOG.md` — add — `### Changed`, two bullets: every action is SHA-pinned
+  (name the count and the PyPI publish action explicitly); and **the PyPI publish
+  action moves from an unreleased `release/v1` head to the v1.9.0 release** —
+  a rollback of 144 upstream commits on the publish path, deliberate.
+- `SECURITY.md` — add — a short supply-chain paragraph stating the pin
+  convention and that Dependabot maintains it. **WAS WRONG (rev 1):** it pointed
+  at `:39`, which is the JWKS sentence, not a release-path section.
 
 ## Dependencies & order
 
-1. The new `all_uses_are_sha_pinned` invariant and its tests **first, against
-   unchanged workflows** — it must go RED on the current tree. That is the proof
-   the guard sees the problem before anything is pinned.
-2. Resolve SHAs and pin all five workflow files.
-3. Update `EXPECTED_USES` and the `forked-action` mutant in the same commit as
-   the `release.yml` pins — otherwise `workflows` is red between commits.
-4. New mutants, evidence matrix.
-5. Docs.
+1. `all_uses_are_sha_pinned` on raw text, wired into `main()`, with tests —
+   **RED against unchanged `main`, reporting 30 refs.** The guard must see the
+   problem before anything is pinned.
+2. Resolve every SHA with the corrected procedure; record the resolution output.
+3. Pin all five workflows **and** the composite action.
+4. **In the same commit as the `release.yml` pins:** update `EXPECTED_USES` and
+   all three `@release/v1` mutant anchors. Otherwise `workflows` is red between
+   commits and three mutants are silently dead.
+5. `dependabot.yml` entry, new mutants, evidence matrix.
+6. Docs.
 
 ## Verification
 
@@ -130,62 +168,66 @@ that file, so it is accepted rather than worked around.
 uv run pytest -q tests/test_workflow_guards.py
 uv run python scripts/check_workflows.py --base-ref origin/main   # exit 0 after pinning
 
-# Every SHA must resolve to the tag it claims -- assert it, do not eyeball it:
-grep -rhoE "uses:\s*\S+@[0-9a-f]{40}\s*#\s*\S+" .github/workflows/*.yml | while read -r line; do
-  ref=$(echo "$line" | sed -E 's/uses:\s*//; s/\s*#.*//'); tag=$(echo "$line" | sed -E 's/.*#\s*//')
+# Every SHA must resolve to the release its comment names. Aggregate exit; a
+# MISMATCH is a failure, not a printout.
+fail=0
+grep -rnE "uses:\s*[^./ ][^ ]*@[0-9a-f]{40}\s*#" .github/workflows/*.yml .github/actions/*/action.yml \
+| while IFS= read -r line; do
+  ref=$(echo "$line" | sed -E 's/.*uses:\s*//; s/\s*#.*//'); tag=$(echo "$line" | sed -E 's/.*#\s*//; s/\s.*//')
   repo=${ref%@*}; sha=${ref#*@}
-  got=$(gh api "repos/$repo/git/ref/tags/$tag" -q .object.sha 2>/dev/null)
-  # annotated tags: follow one level
-  [ "$(gh api "repos/$repo/git/ref/tags/$tag" -q .object.type)" = tag ] && got=$(gh api "repos/$repo/git/tags/$got" -q .object.sha)
-  [ "$got" = "$sha" ] && echo "OK   $ref" || echo "MISMATCH $ref (tag $tag -> $got)"
+  got=$(gh api "repos/$repo/git/matching-refs/tags/$tag" 2>/dev/null \
+        | python3 -c "import sys,json;rs=[r for r in json.load(sys.stdin) if r['ref']=='refs/tags/$tag'];print(rs[0]['object']['sha'] if rs else '')")
+  typ=$(gh api "repos/$repo/git/matching-refs/tags/$tag" 2>/dev/null \
+        | python3 -c "import sys,json;rs=[r for r in json.load(sys.stdin) if r['ref']=='refs/tags/$tag'];print(rs[0]['object']['type'] if rs else '')")
+  [ "$typ" = tag ] && got=$(gh api "repos/$repo/git/tags/$got" -q .object.sha)
+  if [ "$got" = "$sha" ]; then echo "OK       $ref  # $tag"; else echo "MISMATCH $ref  # $tag -> $got"; fail=1; fi
 done
+# (run the loop in the current shell, not a pipe subshell, so $fail propagates; exit $fail)
 
-# Mutants committed on a scratch branch; check each sed changed the tree.
 uv run ruff check src/ tests/ scripts/ && uv run mypy src/
 ```
 
-Edge cases: an annotated tag (two-level dereference — `actions/*` use these);
-an action whose tag was retagged upstream between resolution and merge (re-run
-the resolver script in CI's `workflows` job? — no: that is a network call in a
-guard, rejected; the guard asserts *form*, Dependabot asserts *currency*); a
-`uses:` at **job** level for a reusable workflow (none exist today — the
-invariant must skip `uses:` whose value contains `.yml@`, and a test must pin
-that skip so a future reusable workflow is not misreported).
+Edge cases: annotated vs lightweight tags (both present); a `uses:` at job level
+for a reusable workflow (none today — skip pinned by test); `docker://` refs
+(none today — decision pinned by test); the composite action's `runs:` block
+must not be mistaken for a step list.
 
 ## Acceptance criteria
 
 - [ ] `all_uses_are_sha_pinned` is **RED against unchanged `main`** and reports
-      all 29 non-local refs — proven by running the new invariant before any
-      workflow is edited. A guard that starts green has not seen the problem.
-- [ ] After pinning, the checker exits 0 on the tree, and the SHA-resolution
-      loop above reports **29 OK, 0 MISMATCH**. A pin whose SHA does not match
-      its claimed tag must not pass.
-- [ ] The three new mutants (`tag-pinned-action`, `sha-comment-dropped`,
-      `sha-moved`) each exit non-zero as **committed** scratch-branch mutants,
-      with evidence that each sed **actually modified the file** — the existing
-      `forked-action` mutant would otherwise silently stop mutating once its
-      target string is gone.
-- [ ] A correctly pinned ref with its comment **passes** the new invariant, and
-      a job-level reusable-workflow `uses:` is **skipped**, not flagged — proven
-      by a synthetic fixture.
-- [ ] `TestMutationHelperContract`'s bidirectional check passes with the new
-      mutants present, so the helper and the tests still name the same set.
-- [ ] Every remaining `uses:` in `.github/workflows/` is either a local path or
-      matches the pinned form — asserted by grep in the evidence file, count 29.
+      **30** refs across `.github/workflows/` and the composite action. A guard
+      that starts green has not seen the problem. Count is 30, not 29:
+      rev 1 excluded the composite's ref.
+- [ ] After pinning, the checker exits 0, and the resolution loop reports
+      **30 OK, 0 MISMATCH with a non-zero aggregate exit on any mismatch** — a
+      pin whose SHA does not match its claimed release must not pass.
+      **WAS WRONG (rev 1):** its loop printed MISMATCH and exited 0.
+- [ ] The three re-anchored mutants (`continue-on-error-step`,
+      `if-on-publish-step`, `forked-action`) each **still mutate** — evidence
+      shows a commit hash differing from base — and still exit non-zero. Rev 1
+      would have left all three as silent survivors.
+- [ ] The four new mutants each exit non-zero as committed scratch-branch
+      mutants, with the same helper-exit + commit-hash evidence.
+- [ ] A correctly pinned ref with comment passes; a reusable-workflow `uses:` is
+      skipped; a subdirectory action passes. All three by synthetic fixture.
+- [ ] `EXPECTED_USES` contains **no comments** and matches the pinned
+      `release.yml` — proven by the checker exiting 0 on it, which rev 1's form
+      could never have done.
+- [ ] The pypa pin is `v1.9.0`'s commit, and the CHANGELOG states the 144-commit
+      rollback explicitly.
+- [ ] `dependabot.yml` has the composite-action directory entry.
 - [ ] Full suite green.
 
 ## Non-goals
 
-- Pinning the local composite action `./.github/actions/pipeline-bootstrap-setup`
-  — it is repo-owned source, reviewed like any other file.
-- Changing Dependabot's cadence or grouping.
-- Verifying SHA currency inside the CI guard. That would put a network call on
-  the merge path; Dependabot owns currency, the guard owns form.
-- Pinning Docker base images in `docker.yml`'s Dockerfile — same class, separate
-  ecosystem, its own issue if wanted.
+- Verifying SHA currency inside the CI guard — a network call on the merge path.
+  Dependabot owns currency; the guard owns form.
+- Pinning `python:3.12-slim` in the `Dockerfile` by digest. Same class, different
+  ecosystem, its own issue.
+- Changing what the composite action *does*; only its one `uses:` is pinned.
 
 ## Execution Policy
 
-- execute: effort=medium, reason=mechanical edits across five files, but the
-  guard and mutant updates must land atomically with the release.yml pins or CI
-  is red mid-sequence, and a wrong SHA is a silent supply-chain failure
+- execute: effort=medium, reason=mechanical across seven files, but three
+  mutant anchors and the guard constants must land atomically with the
+  release.yml pins, and the pypa pin is a deliberate rollback on the publish path

--- a/.consiliency/plans/detailed-sha-pin-actions-20260901-1000.md
+++ b/.consiliency/plans/detailed-sha-pin-actions-20260901-1000.md
@@ -1,5 +1,14 @@
 # Detailed plan: pin every GitHub Action to a commit SHA, and guard the convention
 
+> **Revision 3 (2026-09-01).** Rev 2 carried a **false premise of mine**: it said
+> `release/v1` is 144 commits ahead of pypa's newest release, v1.9.0. The tag
+> list was sorted lexically, so `v1.14.x` sorted before `v1.8`. The newest
+> release is **v1.14.2**, and `release/v1`'s head **is** v1.14.2 — same commit.
+> The 144 commits are between v1.9.0 and v1.14.2, i.e. five months of released
+> work that a v1.9.0 pin would have **rolled back**. The operator's "pin to the
+> release tag" decision was made on that error; it and "freeze today's head"
+> now resolve to the same commit, so there is no rollback and no fork.
+>
 > **Revision 2 (2026-09-01).** Rev 1 boarded 2 DISAGREE / 1 AGREE. Three defects,
 > each verified: (1) `EXPECTED_USES` with comments could **never match**, because
 > `yaml.safe_load` strips comments before `_collect_uses` runs — every correctly
@@ -37,13 +46,24 @@ is required or the composite's pin freezes forever.
 
 **`pypa/gh-action-pypi-publish@release/v1` is a branch, not a tag.**
 `git/ref/tags/release/v1` returns nothing usable; `git/ref/heads/release%2Fv1`
-resolves. Its head is **144 commits ahead of v1.9.0**, the newest release. So
-the repo has been publishing to PyPI with an *unreleased* build of the publish
-action on every tag push. Pinning to the branch head would freeze an unreleased
-commit with no version to name; the operator chose to pin to **`v1.9.0`**
-(annotated tag → commit `ec4db0b4ddc6…`, full SHA resolved at implementation).
-That is a **rollback of 144 commits on the publish path** and must be stated as
-a behaviour change, not hidden as a pin.
+resolves to `dc37677b2e1c…`. **That commit is exactly v1.14.2**, pypa's newest
+release (2026-07-29). So the branch is their stable channel pointing at the
+current release — not an unreleased build.
+
+**WAS WRONG (rev 2):** it claimed the head was 144 commits ahead of the newest
+release, v1.9.0, and that pinning meant choosing between an unreleased head
+and a rollback. Both halves were a version-sort artifact: `matching-refs/tags/v1`
+returns lexical order, in which `v1.14.2` precedes `v1.8.6`, so "the last five"
+were v1.8.x–v1.9.0. Verified with `compare/`: `v1.14.2...release/v1` is
+`identical, ahead_by=0`; `v1.9.0...v1.14.2` is `ahead_by=144`. **A v1.9.0 pin
+would have been a real 144-commit rollback of the publish action.** Pin to
+**v1.14.2** — which is both the release tag and today's head, so there is **no
+behaviour change** and the comment `# v1.14.2` is honest and Dependabot-trackable.
+
+**Version comparison must be numeric, not lexical.** Any "newest tag" step in
+implementation or verification uses `sort -V` or the releases API's
+`releases/latest`, never the raw tag list order. This mistake reached an
+operator decision; it must not reach the code.
 
 **Resolution procedure, corrected.** `git/ref/tags/<name>` with a slash in the
 name is a prefix match and returns garbage. Use `git/matching-refs/tags/<name>`
@@ -76,9 +96,11 @@ refused as non-unique; new anchors need step context.
   time with `git/matching-refs/tags/`, dereferencing annotated tags. **Do not
   copy SHAs from this plan.** The comment names the exact release (`# v7.0.0`),
   which is what Dependabot reads and what a human needs.
-- `pypa/gh-action-pypi-publish` — modify — pin to **v1.9.0**'s commit, comment
-  `# v1.9.0`. This changes what runs at publish: from an unreleased branch head
-  to the newest release. Say so in the PR body and the CHANGELOG.
+- `pypa/gh-action-pypi-publish` — modify — pin to **v1.14.2**'s commit
+  (`dc37677b2e1c…`, full SHA resolved at implementation and asserted equal to
+  the `release/v1` head), comment `# v1.14.2`. **No behaviour change**: this is
+  the commit that runs today. **WAS WRONG (rev 2):** v1.9.0, a 144-commit
+  rollback.
 - The composite action's `setup-node@v4` — modify — pin to v7's commit like its
   workflow siblings, comment `# v7.0.0`.
 
@@ -117,6 +139,10 @@ refused as non-unique; new anchors need step context.
   `upload-artifact` line (unique in the tree). Fails via the new invariant.
 - `sha-moved` — add — alters one hex digit of the pypa SHA in `release.yml`
   (unique). Fails via `EXPECTED_USES`.
+- `pypa-rolled-back` — add — replaces the pypa SHA with v1.9.0's commit
+  (`ec4db0b4ddc6…`) and its comment with `# v1.9.0`. A valid SHA, a
+  correct-looking comment, a real release — and 144 commits behind. Must fail
+  via `EXPECTED_USES`. This is the mutant that would have caught rev 2's error.
 - `composite-tag-pinned` — add — reverts the composite action's pin to `@v4`.
   Fails via the new invariant; proves the composite is in scope.
 - The evidence loop — modify — record **the helper's exit code and the commit
@@ -141,10 +167,11 @@ refused as non-unique; new anchors need step context.
 
 ## Documentation impact
 
-- `CHANGELOG.md` — add — `### Changed`, two bullets: every action is SHA-pinned
-  (name the count and the PyPI publish action explicitly); and **the PyPI publish
-  action moves from an unreleased `release/v1` head to the v1.9.0 release** —
-  a rollback of 144 upstream commits on the publish path, deliberate.
+- `CHANGELOG.md` — add — `### Changed`, one bullet: every action is SHA-pinned
+  (name the count, and that the PyPI publish action is pinned to v1.14.2, the
+  commit `release/v1` already pointed at — so nothing runs differently).
+  **WAS WRONG (rev 2):** a bullet announcing a 144-commit rollback that must not
+  happen.
 - `SECURITY.md` — add — a short supply-chain paragraph stating the pin
   convention and that Dependabot maintains it. **WAS WRONG (rev 1):** it pointed
   at `:39`, which is the JWKS sentence, not a release-path section.
@@ -213,8 +240,13 @@ must not be mistaken for a step list.
 - [ ] `EXPECTED_USES` contains **no comments** and matches the pinned
       `release.yml` — proven by the checker exiting 0 on it, which rev 1's form
       could never have done.
-- [ ] The pypa pin is `v1.9.0`'s commit, and the CHANGELOG states the 144-commit
-      rollback explicitly.
+- [ ] The pypa pin is **v1.14.2**'s commit **and equals the `release/v1` branch
+      head at implementation time** — asserted by resolving both and comparing,
+      so the "no behaviour change" claim is proven rather than assumed. If they
+      have diverged by then, stop and re-decide; do not silently pick one.
+- [ ] The resolution script determines "newest release" with `sort -V` or
+      `releases/latest`, never lexical tag order — asserted by a test feeding it
+      `v1.9.0, v1.14.2, v1.8.6` and requiring `v1.14.2`.
 - [ ] `dependabot.yml` has the composite-action directory entry.
 - [ ] Full suite green.
 

--- a/.consiliency/plans/detailed-sha-pin-actions-20260901-1000.md
+++ b/.consiliency/plans/detailed-sha-pin-actions-20260901-1000.md
@@ -295,7 +295,9 @@ done < <(grep -rhE "uses:\s*[^./ ][^ ]*@[0-9a-f]{40}\s*#" .github/workflows/*.y*
 echo "checked $n pinned refs (expect 30)"; [ "$n" -eq 30 ] || fail=1
 # (b): multiset equality. Any line here is a pin that is not the commit its
 # original ref resolves to today (or an original ref that resolved to nothing).
-if d=$(diff <(printf '%s' "$expected") <(printf '%s' "$actual" | sort)); then echo "OK(b)    all $n pins equal their original refs' commits"
+# printf '%s\n' on the left: $(...) strips the trailing newline, `| sort` on the
+# right keeps it, and diff then flags the last line on a clean tree.
+if d=$(diff <(printf '%s\n' "$expected") <(printf '%s' "$actual" | sort)); then echo "OK(b)    all $n pins equal their original refs' commits"
 else echo "MISMATCH(b):"; echo "$d"; fail=1; fi
 exit "$fail"
 

--- a/.consiliency/plans/detailed-sha-pin-actions-20260901-1000.md
+++ b/.consiliency/plans/detailed-sha-pin-actions-20260901-1000.md
@@ -1,5 +1,23 @@
 # Detailed plan: pin every GitHub Action to a commit SHA, and guard the convention
 
+> **Revision 5 (2026-09-01).** Rev 4.1 boarded 2 DISAGREE (grok, codex; gemini
+> errored, Claude seat unavailable). Five findings, all verified against this
+> file: (1) the Execution Policy still called the pypa pin "a deliberate
+> rollback" — a rev 2 sentence contradicting the v1.14.2 decision; (2) the
+> verifier's comment promised check (b), SHA == the *original mutable ref's*
+> commit, but the code only resolved the comment's tag, so an old-but-real
+> release with its matching SHA passed; (3) an acceptance criterion demanded a
+> "resolution script" that picks the newest release with `sort -V` — no such
+> script existed in Changes, and picking "newest" is not the pin rule anyway;
+> (4) Changes listed five new mutants, two other sections said four; (5) the
+> composite's `setup-node` was bumped v4 → v7 in a job with `id-token: write`
+> while Non-goals said "changing what the composite does" is out of scope.
+> Operator decision: **pin v4's current commit (v4.4.0) — zero behaviour change
+> anywhere in this PR**; Dependabot's new directory entry will propose v7 as its
+> own reviewable PR. Check (b) is now actually scripted: the verifier reads the
+> *pre-pin* refs from `origin/main`, resolves each (tag or branch, peeled), and
+> requires the pinned SHA to equal that commit.
+>
 > **Revision 4 (2026-09-01).** Rev 2's board (2 DISAGREE; one seat errored)
 > returned after rev 3. Its pypa finding matched rev 3's correction and added
 > **GHSA-vxmw-7h4f-hqxh** — `pypa/gh-action-pypi-publish < 1.13.0` is vulnerable
@@ -8,7 +26,8 @@
 > verifier's `grep | while` subshell lost its failure flag; the reusable-workflow
 > exemption was a hole; `.yaml` forms were unguarded; the `tag-pinned-action`
 > anchor was not unique; and the verifier proved SHA↔comment but not
-> SHA↔*current target*, so a correct-looking rollback passed it.
+> SHA↔*current target*, so a correct-looking rollback passed it. (Rev 4 only
+> *described* that last fix in a comment; rev 5 scripts it.)
 >
 > **Revision 3 (2026-09-01).** Rev 2 carried a **false premise of mine**: it said
 > `release/v1` is 144 commits ahead of pypa's newest release, v1.9.0. The tag
@@ -76,16 +95,22 @@ expansions in action steps, `pypa/gh-action-pypi-publish < 1.13.0`, patched in
 months stale — it would have reintroduced a published advisory on the publish
 path. v1.14.2 is clear. Any future re-pin must stay `>= 1.13.0`.
 
-**Version comparison must be numeric, not lexical.** Any "newest tag" step in
-implementation or verification uses `sort -V` or the releases API's
-`releases/latest`, never the raw tag list order. This mistake reached an
-operator decision; it must not reach the code.
+**Version comparison must be numeric, not lexical.** This change contains
+**no** "pick the newest tag" step — the pin rule is "the commit the original
+mutable ref resolves to today", full stop. That is precisely because a
+newest-picker sorted lexically is how rev 2 chose v1.9.0. If a future re-pin
+ever needs "newest", it must use `sort -V` or the releases API's
+`releases/latest`; this plan adds no such code and no test for it.
 
 **Resolution procedure, corrected.** `git/ref/tags/<name>` with a slash in the
 name is a prefix match and returns garbage. Use `git/matching-refs/tags/<name>`
 and select the exact ref, or URL-encode. Annotated tags (`astral-sh/setup-uv@v7`
 is one; the pypa release tags all are) need a second dereference through
 `git/tags/<sha>`. 8 of the 10 distinct actions use lightweight tags.
+Equivalent and simpler: `git ls-remote https://github.com/<repo> refs/tags/<ref>
+'refs/tags/<ref>^{}' refs/heads/<ref>` — the `^{}` line is the peeled commit
+when the tag is annotated; take it when present, else the plain line. The
+verifier below uses this form because it handles tags and branches uniformly.
 
 **`yaml.safe_load` strips comments.** `_load` (`check_workflows.py:525-527`)
 and the `:413` path both parse with `safe_load`, so by the time `_collect_uses`
@@ -117,8 +142,12 @@ refused as non-unique; new anchors need step context.
   the `release/v1` head), comment `# v1.14.2`. **No behaviour change**: this is
   the commit that runs today. **WAS WRONG (rev 2):** v1.9.0, a 144-commit
   rollback.
-- The composite action's `setup-node@v4` — modify — pin to v7's commit like its
-  workflow siblings, comment `# v7.0.0`.
+- The composite action's `setup-node@v4` — modify — pin to **the commit `v4`
+  resolves to today** (`49933ea…` = **v4.4.0**, re-resolved at implementation),
+  comment `# v4.4.0`. **Not** v7: that would be a major-version bump inside a
+  job holding `id-token: write` and `contents: write`, contradicting the
+  Non-goals. **WAS WRONG (rev 2–4.1):** bumped to v7. Dependabot's new entry
+  for this directory (below) will propose v7 as its own reviewable PR.
 
 ### `.github/dependabot.yml` (modify)
 
@@ -185,8 +214,11 @@ refused as non-unique; new anchors need step context.
   a subdirectory action `owner/repo/path@<sha> # v1` **passes**; a `docker://`
   `uses:` is reported (it is not pinnable by this scheme — decide: skip with a
   named reason, or fail; there are none today, so pin the decision by test).
-- `TestMutationHelperContract` gains the four new mutants via its bidirectional
-  check.
+- `TestMutationHelperContract` gains the **five** new mutants
+  (`tag-pinned-action`, `sha-comment-dropped`, `sha-moved`, `pypa-rolled-back`,
+  `composite-tag-pinned`) via its bidirectional check — the existing contract
+  (`test_workflow_guards.py:~752`) requires exact set equality with `--list`, so
+  all five must be listed there. **WAS WRONG (rev 2–4.1):** said four.
 
 ### `.consiliency/evidence/mutation-217.md` (create)
 
@@ -198,12 +230,12 @@ refused as non-unique; new anchors need step context.
 
 - `CHANGELOG.md` — add — `### Changed`: every action is SHA-pinned (name the
   count, and that the PyPI publish action is pinned to v1.14.2, the commit
-  `release/v1` already pointed at — so nothing runs differently there). **A
-  second bullet**: the composite action's `setup-node` moves **v4 → v7** to match
-  its workflow siblings. That is a major-version bump, not a pin of the current
-  ref, and is the one place this change alters what runs.
-  **WAS WRONG (rev 2):** a bullet announcing a 144-commit rollback that must not
-  happen.
+  `release/v1` already pointed at — so nothing runs differently there). State
+  plainly that **every** pin, the composite's `setup-node@v4` → v4.4.0 included,
+  is the commit the mutable ref resolved to on the day — **no action runs a
+  different version after this change**. Reference as "see #217", never a
+  closing keyword. **WAS WRONG (rev 2):** a bullet announcing a 144-commit
+  rollback; **(rev 2–4.1):** a bullet announcing a v4 → v7 bump.
 - `SECURITY.md` — add — a short supply-chain paragraph stating the pin
   convention and that Dependabot maintains it. **WAS WRONG (rev 1):** it pointed
   at `:39`, which is the JWKS sentence, not a release-path section.
@@ -213,7 +245,8 @@ refused as non-unique; new anchors need step context.
 1. `all_uses_are_sha_pinned` on raw text, wired into `main()`, with tests —
    **RED against unchanged `main`, reporting 30 refs.** The guard must see the
    problem before anything is pinned.
-2. Resolve every SHA with the corrected procedure; record the resolution output.
+2. Resolve every SHA with the corrected procedure (from the refs on
+   `origin/main`, never from a "newest" pick); record the resolution output.
 3. Pin all five workflows **and** the composite action.
 4. **In the same commit as the `release.yml` pins:** update `EXPECTED_USES` and
    all three `@release/v1` mutant anchors. Otherwise `workflows` is red between
@@ -227,31 +260,49 @@ refused as non-unique; new anchors need step context.
 uv run pytest -q tests/test_workflow_guards.py
 uv run python scripts/check_workflows.py --base-ref origin/main   # exit 0 after pinning
 
-# Every SHA must (a) resolve to the release its comment names AND (b) equal the
-# commit the ORIGINAL mutable ref points at today -- (b) is what proves "no
-# behaviour change"; (a) alone accepted a correct-looking rollback.
+# Every pinned SHA must (a) resolve to the release its trailing comment names
+# AND (b) equal the commit the ORIGINAL mutable ref (as it stood on origin/main
+# before pinning) resolves to today. (b) is the "no behaviour change" proof;
+# (a) alone accepts an old-but-real release with its matching SHA.
+# **WAS WRONG (rev 4/4.1):** promised (b) in a comment, coded only (a).
 # Aggregate exit. NOT `grep | while` -- under bash that loop is a subshell and
-# `fail=1` is lost. **WAS WRONG (rev 2)**: exactly that, with `exit "$fail"`
-# living only in a comment.
+# `fail=1` is lost. **WAS WRONG (rev 2)**: exactly that.
+resolve() {  # resolve <owner/repo> <ref>  -> peeled commit sha, or empty
+  git ls-remote "https://github.com/$1" "refs/tags/$2" "refs/tags/$2^{}" "refs/heads/$2" 2>/dev/null \
+    | awk -v want="$2" '$2=="refs/tags/"want"^{}"{p=$1} $2=="refs/tags/"want||$2=="refs/heads/"want{c=$1} END{print (p!=""?p:c)}'
+}
 fail=0
+# (b): the multiset of (repo, resolved-commit) over the PRE-PIN refs on
+# origin/main must equal the multiset of (repo, pinned-sha) in the working
+# tree. Keyed per LINE, not per repo: `actions/setup-node` is `@v4` in the
+# composite and `@v7` in the workflows, and a per-repo map would take whichever
+# came first. **WAS WRONG (rev 5 draft):** per-repo map.
+files=$(git ls-tree -r --name-only origin/main .github/ | grep -E '^\.github/(workflows/[^/]+|actions/.*/action)\.ya?ml$')
+expected=$(for f in $files; do git show "origin/main:$f"; done \
+  | grep -E "uses:\s*[^./ ][^ ]*@" | grep -v "uses:\s*\./" \
+  | sed -E 's/.*uses:\s*//; s/\s*#.*//; s/\s+$//' \
+  | while IFS= read -r ref; do repo=${ref%@*}; c=$(resolve "$repo" "${ref#*@}"); \
+      [ -n "$c" ] || { echo "UNRESOLVED $ref" >&2; echo "UNRESOLVED@$ref"; }; echo "$repo@$c"; done | sort)
+n=0; actual=""
 while IFS= read -r line; do
+  n=$((n+1))
   ref=$(echo "$line" | sed -E 's/.*uses:\s*//; s/\s*#.*//'); tag=$(echo "$line" | sed -E 's/.*#\s*//; s/\s.*//')
   repo=${ref%@*}; sha=${ref#*@}
-  got=$(gh api "repos/$repo/git/matching-refs/tags/$tag" 2>/dev/null \
-        | python3 -c "import sys,json;rs=[r for r in json.load(sys.stdin) if r['ref']=='refs/tags/$tag'];print(rs[0]['object']['sha'] if rs else '')")
-  typ=$(gh api "repos/$repo/git/matching-refs/tags/$tag" 2>/dev/null \
-        | python3 -c "import sys,json;rs=[r for r in json.load(sys.stdin) if r['ref']=='refs/tags/$tag'];print(rs[0]['object']['type'] if rs else '')")
-  [ "$typ" = tag ] && got=$(gh api "repos/$repo/git/tags/$got" -q .object.sha)
-  # PEEL annotated tags: the tag object's sha is NOT the commit. Pinning the tag
-  # object sha would pass a form check, agree with EXPECTED_USES, and break only
-  # on tag push. (setup-uv and every pypa release tag are annotated.)
-  if [ "$got" = "$sha" ]; then echo "OK       $ref  # $tag"; else echo "MISMATCH $ref  # $tag -> $got"; fail=1; fi
-done < <(grep -rnE "uses:\s*[^./ ][^ ]*@[0-9a-f]{40}\s*#" .github/workflows/*.y*ml .github/actions/*/action.y*ml)
+  a=$(resolve "$repo" "$tag")                 # (a) comment tag -> peeled commit
+  if [ "$a" = "$sha" ]; then echo "OK(a)    $ref  # $tag"; else echo "MISMATCH(a) $ref  # $tag -> ${a:-?}"; fail=1; fi
+  actual="$actual$repo@$sha"$'\n'
+done < <(grep -rhE "uses:\s*[^./ ][^ ]*@[0-9a-f]{40}\s*#" .github/workflows/*.y*ml .github/actions/*/action.y*ml)
+echo "checked $n pinned refs (expect 30)"; [ "$n" -eq 30 ] || fail=1
+# (b): multiset equality. Any line here is a pin that is not the commit its
+# original ref resolves to today (or an original ref that resolved to nothing).
+if d=$(diff <(printf '%s' "$expected") <(printf '%s' "$actual" | sort)); then echo "OK(b)    all $n pins equal their original refs' commits"
+else echo "MISMATCH(b):"; echo "$d"; fail=1; fi
 exit "$fail"
 
-# Prove the loop FAILS CLOSED: run it once against a copy with one SHA altered
-# by a digit and require exit 1. Thirty OKs prove nothing about the mismatch
-# branch until that branch has been seen to fire.
+# Prove the loop FAILS CLOSED, both branches: (1) alter one SHA digit in a copy
+# -> MISMATCH, exit 1; (2) set a line to v1.9.0's real SHA with comment
+# `# v1.9.0` -> (a) passes, (b) MISMATCHes, exit 1. Thirty OKs prove nothing
+# about the mismatch branch until it has been seen to fire.
 
 uv run ruff check src/ tests/ scripts/ && uv run mypy src/
 ```
@@ -274,18 +325,23 @@ must not be mistaken for a step list.
       `grep | while` subshell, so `fail=1` was lost and the exit was always 0;
       the criterion demanded fail-closed but the script could not deliver it.
 - [ ] For **every** pinned ref, the pinned SHA equals the **peeled** commit that
-      the original mutable ref (`v7`, `release/v1`, …) resolves to at
-      implementation time — recorded per ref. This is the "no behaviour change"
-      proof, and it is the check that rejects a correct-looking rollback such as
-      `pypa-rolled-back`. The composite's `setup-node` is the one **declared
-      exception** (v4 → v7), recorded as such.
+      the original mutable ref (`v4`, `v7`, `release/v1`, …) resolves to at
+      implementation time — recorded per ref by the verifier's check (b), which
+      reads the original refs from `origin/main`. This is the "no behaviour
+      change" proof, and it is the check that rejects a correct-looking rollback
+      such as `pypa-rolled-back` (proven by running it against that mutant and
+      seeing MISMATCH). **No exceptions**: the composite's `setup-node` pins to
+      v4.4.0, the commit `v4` resolves to. **WAS WRONG (rev 2–4.1):** a
+      "declared exception" bumping it to v7.
 - [ ] The pypa pin is `>= 1.13.0` (GHSA-vxmw-7h4f-hqxh) — asserted numerically.
 - [ ] The three re-anchored mutants (`continue-on-error-step`,
       `if-on-publish-step`, `forked-action`) each **still mutate** — evidence
       shows a commit hash differing from base — and still exit non-zero. Rev 1
       would have left all three as silent survivors.
-- [ ] The four new mutants each exit non-zero as committed scratch-branch
-      mutants, with the same helper-exit + commit-hash evidence.
+- [ ] The **five** new mutants (`tag-pinned-action`, `sha-comment-dropped`,
+      `sha-moved`, `pypa-rolled-back`, `composite-tag-pinned`) each exit
+      non-zero as committed scratch-branch mutants, with the same helper-exit +
+      commit-hash evidence.
 - [ ] A correctly pinned ref with comment passes; a `./` local path is skipped;
       a subdirectory action passes; a **remote reusable workflow** pinned to a SHA
       passes and one pinned to `@main` **fails**; an `action.yaml` composite is
@@ -298,9 +354,11 @@ must not be mistaken for a step list.
       head at implementation time** — asserted by resolving both and comparing,
       so the "no behaviour change" claim is proven rather than assumed. If they
       have diverged by then, stop and re-decide; do not silently pick one.
-- [ ] The resolution script determines "newest release" with `sort -V` or
-      `releases/latest`, never lexical tag order — asserted by a test feeding it
-      `v1.9.0, v1.14.2, v1.8.6` and requiring `v1.14.2`.
+- [ ] No code or script added by this change sorts or ranks version strings;
+      every pin is derived from the original ref's resolved commit (`grep -n
+      "sort\|newest\|latest" scripts/ tests/test_workflow_guards.py` shows no
+      new version-ranking logic). **WAS WRONG (rev 4/4.1):** demanded a
+      "resolution script" with a `sort -V` test that no Changes entry created.
 - [ ] `dependabot.yml` has the composite-action directory entry.
 - [ ] Full suite green.
 
@@ -314,6 +372,4 @@ must not be mistaken for a step list.
 
 ## Execution Policy
 
-- execute: effort=medium, reason=mechanical across seven files, but three
-  mutant anchors and the guard constants must land atomically with the
-  release.yml pins, and the pypa pin is a deliberate rollback on the publish path
+- execute: effort=medium, reason=mechanical across eight files but the three mutant anchors and EXPECTED_USES must land atomically with the release.yml pins; every pin including pypa v1.14.2 and the composite setup-node v4.4.0 is the commit its mutable ref resolves to today so nothing runs differently

--- a/.consiliency/plans/detailed-sha-pin-actions-20260901-1000.md
+++ b/.consiliency/plans/detailed-sha-pin-actions-20260901-1000.md
@@ -1,5 +1,15 @@
 # Detailed plan: pin every GitHub Action to a commit SHA, and guard the convention
 
+> **Revision 4 (2026-09-01).** Rev 2's board (2 DISAGREE; one seat errored)
+> returned after rev 3. Its pypa finding matched rev 3's correction and added
+> **GHSA-vxmw-7h4f-hqxh** — `pypa/gh-action-pypi-publish < 1.13.0` is vulnerable
+> to injectable expression expansions, so the v1.9.0 pin would have been a
+> *vulnerable* rollback. Five further verified defects fixed below: the
+> verifier's `grep | while` subshell lost its failure flag; the reusable-workflow
+> exemption was a hole; `.yaml` forms were unguarded; the `tag-pinned-action`
+> anchor was not unique; and the verifier proved SHA↔comment but not
+> SHA↔*current target*, so a correct-looking rollback passed it.
+>
 > **Revision 3 (2026-09-01).** Rev 2 carried a **false premise of mine**: it said
 > `release/v1` is 144 commits ahead of pypa's newest release, v1.9.0. The tag
 > list was sorted lexically, so `v1.14.x` sorted before `v1.8`. The newest
@@ -60,6 +70,12 @@ would have been a real 144-commit rollback of the publish action.** Pin to
 **v1.14.2** — which is both the release tag and today's head, so there is **no
 behaviour change** and the comment `# v1.14.2` is honest and Dependabot-trackable.
 
+**And v1.9.0 was vulnerable.** GHSA-vxmw-7h4f-hqxh (low): injectable expression
+expansions in action steps, `pypa/gh-action-pypi-publish < 1.13.0`, patched in
+1.13.0. Verified via the advisories API. So rev 2's pin was not merely five
+months stale — it would have reintroduced a published advisory on the publish
+path. v1.14.2 is clear. Any future re-pin must stay `>= 1.13.0`.
+
 **Version comparison must be numeric, not lexical.** Any "newest tag" step in
 implementation or verification uses `sort -V` or the releases API's
 `releases/latest`, never the raw tag list order. This mistake reached an
@@ -115,13 +131,20 @@ refused as non-unique; new anchors need step context.
 - `EXPECTED_USES` (`:59`) — modify — to the **SHA form without comments**.
   **WAS WRONG (rev 1):** it put comments in; they can never match parsed YAML.
 - `all_uses_are_sha_pinned(paths)` — add — **operates on raw text, not parsed
-  YAML**, so it can see the comment. For every line matching `uses:` under
-  `.github/workflows/*.yml` **and** `.github/actions/**/action.yml`: skip a value
-  starting `./` (local path) or containing `.yml@` / `.yaml@` (reusable
-  workflow); otherwise require
-  `^\s*-?\s*uses:\s*[\w.-]+/[\w./-]+@[0-9a-f]{40}\s+#\s*\S+`. The `[\w./-]+`
-  admits subdirectory actions (`owner/repo/path@sha`). Reason text names file,
-  line, and ref.
+  YAML**, so it can see the comment. Scan `.github/workflows/*.yml` **and**
+  `*.yaml`, and `.github/actions/**/action.yml` **and** `action.yaml`.
+  **WAS WRONG (rev 2):** `*.yml` / `action.yml` only. GitHub runs both
+  extensions, `workflow_files()` (`check_workflows.py:~533`) already globs both
+  *with a docstring saying why*, and renaming the composite to `action.yaml`
+  would have kept it executable while removing it from the guard.
+  Skip **only** a value starting `./` (same-repository path). Otherwise require
+  `^\s*-?\s*uses:\s*[\w.-]+/[\w./-]+@[0-9a-f]{40}\s+#\s*\S+`, which admits
+  subdirectory actions and **remote reusable workflows**
+  (`owner/repo/.github/workflows/x.yml@<sha>`).
+  **WAS WRONG (rev 2):** it exempted any value containing `.yml@`/`.yaml@`. That
+  let `owner/repo/.github/workflows/build.yml@main` — mutable remote code — pass
+  the guard. Reusable workflows are SHA-pinnable and GitHub documents SHA as the
+  safest form. Reason text names file, line, and ref.
 - **Call it from `main()`.** **WAS WRONG (rev 1):** unstated. The evidence loop
   runs the CLI, not pytest; a tests-only function lets the new mutants survive.
 - Module docstring (`:22`) — modify — state the convention, and that comments are
@@ -133,8 +156,12 @@ refused as non-unique; new anchors need step context.
   `continue-on-error-step`, `if-on-publish-step`, `forked-action`.
   **WAS WRONG (rev 1):** only `forked-action`.
 - `tag-pinned-action` — add — reverts the `setup-node` pin in `test.yml`'s
-  `test` job to `@v7` (unique: use the step context, since `checkout` is not
-  unique). Fails via the new invariant.
+  `install-smoke` job to `@v7`. **WAS WRONG (rev 2):** "use the step context" —
+  the three-line `setup-node` block is **byte-identical** in the `test` and
+  `install-smoke` jobs (`test.yml:38-40` and `:81-83`), so a step-level anchor
+  matches twice and `replace()` refuses it. The anchor must include a line that
+  exists only in one job (the `install-smoke` job header, or its preceding
+  unique step). Fails via the new invariant.
 - `sha-comment-dropped` — add — strips the comment from `release.yml`'s
   `upload-artifact` line (unique in the tree). Fails via the new invariant.
 - `sha-moved` — add — alters one hex digit of the pypa SHA in `release.yml`
@@ -167,9 +194,12 @@ refused as non-unique; new anchors need step context.
 
 ## Documentation impact
 
-- `CHANGELOG.md` — add — `### Changed`, one bullet: every action is SHA-pinned
-  (name the count, and that the PyPI publish action is pinned to v1.14.2, the
-  commit `release/v1` already pointed at — so nothing runs differently).
+- `CHANGELOG.md` — add — `### Changed`: every action is SHA-pinned (name the
+  count, and that the PyPI publish action is pinned to v1.14.2, the commit
+  `release/v1` already pointed at — so nothing runs differently there). **A
+  second bullet**: the composite action's `setup-node` moves **v4 → v7** to match
+  its workflow siblings. That is a major-version bump, not a pin of the current
+  ref, and is the one place this change alters what runs.
   **WAS WRONG (rev 2):** a bullet announcing a 144-commit rollback that must not
   happen.
 - `SECURITY.md` — add — a short supply-chain paragraph stating the pin
@@ -195,11 +225,14 @@ refused as non-unique; new anchors need step context.
 uv run pytest -q tests/test_workflow_guards.py
 uv run python scripts/check_workflows.py --base-ref origin/main   # exit 0 after pinning
 
-# Every SHA must resolve to the release its comment names. Aggregate exit; a
-# MISMATCH is a failure, not a printout.
+# Every SHA must (a) resolve to the release its comment names AND (b) equal the
+# commit the ORIGINAL mutable ref points at today -- (b) is what proves "no
+# behaviour change"; (a) alone accepted a correct-looking rollback.
+# Aggregate exit. NOT `grep | while` -- under bash that loop is a subshell and
+# `fail=1` is lost. **WAS WRONG (rev 2)**: exactly that, with `exit "$fail"`
+# living only in a comment.
 fail=0
-grep -rnE "uses:\s*[^./ ][^ ]*@[0-9a-f]{40}\s*#" .github/workflows/*.yml .github/actions/*/action.yml \
-| while IFS= read -r line; do
+while IFS= read -r line; do
   ref=$(echo "$line" | sed -E 's/.*uses:\s*//; s/\s*#.*//'); tag=$(echo "$line" | sed -E 's/.*#\s*//; s/\s.*//')
   repo=${ref%@*}; sha=${ref#*@}
   got=$(gh api "repos/$repo/git/matching-refs/tags/$tag" 2>/dev/null \
@@ -207,9 +240,16 @@ grep -rnE "uses:\s*[^./ ][^ ]*@[0-9a-f]{40}\s*#" .github/workflows/*.yml .github
   typ=$(gh api "repos/$repo/git/matching-refs/tags/$tag" 2>/dev/null \
         | python3 -c "import sys,json;rs=[r for r in json.load(sys.stdin) if r['ref']=='refs/tags/$tag'];print(rs[0]['object']['type'] if rs else '')")
   [ "$typ" = tag ] && got=$(gh api "repos/$repo/git/tags/$got" -q .object.sha)
+  # PEEL annotated tags: the tag object's sha is NOT the commit. Pinning the tag
+  # object sha would pass a form check, agree with EXPECTED_USES, and break only
+  # on tag push. (setup-uv and every pypa release tag are annotated.)
   if [ "$got" = "$sha" ]; then echo "OK       $ref  # $tag"; else echo "MISMATCH $ref  # $tag -> $got"; fail=1; fi
-done
-# (run the loop in the current shell, not a pipe subshell, so $fail propagates; exit $fail)
+done < <(grep -rnE "uses:\s*[^./ ][^ ]*@[0-9a-f]{40}\s*#" .github/workflows/*.y*ml .github/actions/*/action.y*ml)
+exit "$fail"
+
+# Prove the loop FAILS CLOSED: run it once against a copy with one SHA altered
+# by a digit and require exit 1. Thirty OKs prove nothing about the mismatch
+# branch until that branch has been seen to fire.
 
 uv run ruff check src/ tests/ scripts/ && uv run mypy src/
 ```
@@ -226,17 +266,28 @@ must not be mistaken for a step list.
       that starts green has not seen the problem. Count is 30, not 29:
       rev 1 excluded the composite's ref.
 - [ ] After pinning, the checker exits 0, and the resolution loop reports
-      **30 OK, 0 MISMATCH with a non-zero aggregate exit on any mismatch** — a
-      pin whose SHA does not match its claimed release must not pass.
-      **WAS WRONG (rev 1):** its loop printed MISMATCH and exited 0.
+      **30 OK, 0 MISMATCH** — and, run against a copy with one SHA altered by a
+      digit, **exits 1**. Both directions. **WAS WRONG (rev 2):** the loop was a
+      `grep | while` subshell, so `fail=1` was lost and the exit was always 0;
+      the criterion demanded fail-closed but the script could not deliver it.
+- [ ] For **every** pinned ref, the pinned SHA equals the **peeled** commit that
+      the original mutable ref (`v7`, `release/v1`, …) resolves to at
+      implementation time — recorded per ref. This is the "no behaviour change"
+      proof, and it is the check that rejects a correct-looking rollback such as
+      `pypa-rolled-back`. The composite's `setup-node` is the one **declared
+      exception** (v4 → v7), recorded as such.
+- [ ] The pypa pin is `>= 1.13.0` (GHSA-vxmw-7h4f-hqxh) — asserted numerically.
 - [ ] The three re-anchored mutants (`continue-on-error-step`,
       `if-on-publish-step`, `forked-action`) each **still mutate** — evidence
       shows a commit hash differing from base — and still exit non-zero. Rev 1
       would have left all three as silent survivors.
 - [ ] The four new mutants each exit non-zero as committed scratch-branch
       mutants, with the same helper-exit + commit-hash evidence.
-- [ ] A correctly pinned ref with comment passes; a reusable-workflow `uses:` is
-      skipped; a subdirectory action passes. All three by synthetic fixture.
+- [ ] A correctly pinned ref with comment passes; a `./` local path is skipped;
+      a subdirectory action passes; a **remote reusable workflow** pinned to a SHA
+      passes and one pinned to `@main` **fails**; an `action.yaml` composite is
+      **scanned**. All by synthetic fixture. **WAS WRONG (rev 2):** reusable
+      workflows were exempted wholesale.
 - [ ] `EXPECTED_USES` contains **no comments** and matches the pinned
       `release.yml` — proven by the checker exiting 0 on it, which rev 1's form
       could never have done.

--- a/.github/actions/pipeline-bootstrap-setup/action.yml
+++ b/.github/actions/pipeline-bootstrap-setup/action.yml
@@ -4,7 +4,7 @@ description: Install Node 24 and bootstrap-script dependencies for the pipeline-
 runs:
   using: composite
   steps:
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: 24
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,18 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+
+  # The local composite action has its own `uses:` (Consiliency/pmcp#217).
+  # `directory: "/"` above demonstrably never scanned it: it sat on
+  # setup-node@v4 through twenty Dependabot PRs while every workflow moved to v7.
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/pipeline-bootstrap-setup"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,14 +22,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - name: Log in to Container Registry
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -37,7 +37,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -48,7 +48,7 @@ jobs:
             type=sha,prefix=
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/pipeline-bootstrap.yml
+++ b/.github/workflows/pipeline-bootstrap.yml
@@ -78,7 +78,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: ./.github/actions/pipeline-bootstrap-setup
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -30,7 +30,7 @@ jobs:
         run: uv build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/
@@ -45,13 +45,13 @@ jobs:
 
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         # Uses trusted publishing - no token needed
         # Configure at: https://pypi.org/manage/project/pmcp/settings/publishing/
 
@@ -63,10 +63,10 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Download artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: dist
           path: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The npm identity resolver (Consiliency/pmcp#195) drives the HOST npm's
       # own parser, so the resolver-active half of the identity suite only runs
@@ -35,12 +35,12 @@ jobs:
       # resolver refuses an `npx-cli.js` it does not recognise, so an image that
       # silently moved to a different npm major would turn that half of the
       # suite from covering production into skipping.
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       # The npm identity resolver (Consiliency/pmcp#195) drives the HOST npm's
       # own parser, so the resolver-active half of the identity suite only runs
@@ -78,12 +78,12 @@ jobs:
       # resolver refuses an `npx-cli.js` it does not recognise, so an image that
       # silently moved to a different npm major would turn that half of the
       # suite from covering production into skipping.
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -145,10 +145,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -221,10 +221,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -258,7 +258,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # actions/checkout defaults to a shallow (depth-1) clone, which
           # doesn't contain the PR base ref needed for the three-dot diff
@@ -327,10 +327,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -360,7 +360,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # job_set_drift compares each changed workflow against its BASE
           # revision with a three-dot diff. The default depth-1 clone does not
@@ -373,7 +373,7 @@ jobs:
       # image. Without a Python setup the guard dies with ModuleNotFoundError
       # while `uv run` still passes locally — a guard that guards nothing.
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 
@@ -463,7 +463,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Needed for the three-dot diff against the PR base.
           fetch-depth: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Every GitHub Action is pinned to a commit SHA.** All 30 remote `uses:`
+  references — 29 across the five workflows and the one inside the local
+  composite action `.github/actions/pipeline-bootstrap-setup` — now read
+  `owner/action@<40-hex-sha> # vX.Y.Z`. Every pin is the commit its previous
+  mutable ref resolved to on the day, so **no action runs a different version
+  after this change**: the PyPI publish action is pinned to v1.14.2, the commit
+  `release/v1` already pointed at, and the composite's `setup-node@v4` to
+  v4.4.0, the commit `v4` pointed at. `scripts/check_workflows.py` gains a
+  raw-text invariant that fails CI on any remote `uses:` not in that form —
+  in workflows and in local actions, `.yml` and `.yaml` alike — and its exact
+  allowlist for `release.yml` now names commits, so a form-valid pin to the
+  wrong commit (a moved digit, or a real older release with an honest comment)
+  is rejected too. Dependabot gains an entry for the composite action's
+  directory, which its root entry had never scanned. Five new mutants prove
+  each of those catches (`.consiliency/evidence/mutation-217.md`); see
+  [#217](https://github.com/Consiliency/pmcp/issues/217).
+- CI: `actions/setup-node` v4 → v7 in the workflows (Dependabot, #216).
+
 ## [2.7.3] - 2026-08-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `release/v1` already pointed at, and the composite's `setup-node@v4` to
   v4.4.0, the commit `v4` pointed at. `scripts/check_workflows.py` gains a
   raw-text invariant that fails CI on any remote `uses:` not in that form —
-  in workflows and in local actions, `.yml` and `.yaml` alike — and its exact
+  in workflows and in local actions, `.yml` and `.yaml` alike, and cross-checks
+  that inventory against the parsed document so a `uses:` spelled in a form the
+  line scan cannot see (`"uses":`, `{uses: …}`, a block scalar) fails rather than
+  runs unpinned — and its exact
   allowlist for `release.yml` now names commits, so a form-valid pin to the
   wrong commit (a moved digit, or a real older release with an honest comment)
   is rejected too. Dependabot gains an entry for the composite action's
-  directory, which its root entry had never scanned. Five new mutants prove
+  directory, which its root entry had never scanned. Six new mutants prove
   each of those catches (`.consiliency/evidence/mutation-217.md`); see
   [#217](https://github.com/Consiliency/pmcp/issues/217).
 - CI: `actions/setup-node` v4 → v7 in the workflows (Dependabot, #216).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,6 +62,17 @@ PMCP is a local-first MCP gateway. Its default security posture assumes:
   credential as its relaxer. Every unset, malformed, self-referencing, or
   placeholder (`${VAR}`) relaxer value fails closed and the credential stays
   required (Consiliency/pmcp#114).
+- **Mutable CI dependencies**: every GitHub Action this repository runs — in
+  `.github/workflows/` and in the local composite action under
+  `.github/actions/` — is pinned to a full commit SHA with the release named in
+  a trailing comment (`owner/action@<sha> # vX.Y.Z`). A tag or branch is
+  mutable: whoever controls the action's repository controls what runs with
+  the job's permissions, and the release workflow holds `id-token: write` for
+  PyPI trusted publishing. `scripts/check_workflows.py` fails CI on any remote
+  `uses:` that is not in that form, and on any change to the release
+  workflow's exact action set; Dependabot maintains the pins, including a
+  dedicated entry for the composite action's directory
+  ([#217](https://github.com/Consiliency/pmcp/issues/217)).
 
 ### Known limitations
 

--- a/scripts/_mutate_workflow.sh
+++ b/scripts/_mutate_workflow.sh
@@ -36,6 +36,7 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RELEASE="${REPO_ROOT}/.github/workflows/release.yml"
 TEST_WF="${REPO_ROOT}/.github/workflows/test.yml"
 MAINTENANCE="${REPO_ROOT}/.github/workflows/maintenance.yml"
+COMPOSITE="${REPO_ROOT}/.github/actions/pipeline-bootstrap-setup/action.yml"
 
 MUTANTS="$(
 	cat <<'TSV'
@@ -70,6 +71,11 @@ timeout-deleted|1|[timeout]|release.yml build: timeout-minutes removed, restorin
 maintenance-deleted|1|[drift]|maintenance.yml deleted; invisible to the release and timeout invariants, which only see surviving files
 changelog-job-deleted|1|[drift]|test.yml: the changelog job deleted; the file stays valid and every surviving job keeps its timeout
 workflows-job-deleted|1|[drift]|test.yml: this guard's own job deleted (see the residual note in mutation-189.md)
+tag-pinned-action|1|[pin]|test.yml: install-smoke's setup-node pin reverted to the mutable @v7 tag; whoever controls that tag controls what runs
+sha-comment-dropped|1|[pin]|release.yml: the "# v7.0.1" comment stripped from the upload-artifact pin; the SHA is exact but unreadable and Dependabot-untrackable
+sha-moved|1|[release]|release.yml: one hex digit of the pypa SHA altered; form-valid, honest-looking comment, a commit that is not the release. Only the exact allowlist sees it
+pypa-rolled-back|1|[release]|release.yml: pypa pinned to v1.9.0's REAL commit with an honest "# v1.9.0" comment; 144 commits behind and below the GHSA-vxmw-7h4f-hqxh floor. Form-valid; only the exact allowlist sees it
+composite-tag-pinned|1|[pin]|.github/actions/pipeline-bootstrap-setup/action.yml: setup-node pin reverted to @v4; proves the composite (id-token: write in scope) is in the scan
 needs-as-list|0|-|release.yml: needs: build -> needs: [build]; a legitimate equivalent form that must NOT false-positive
 timeout-below-p100|0|-|NOT COVERED: release.yml build timeout-minutes 20 -> 12, above the floor but potentially below a future p100
 concurrency-added|0|-|NOT COVERED by invariant: workflow-level concurrency with cancel-in-progress on release.yml; release-diff-ack covers it by label
@@ -141,6 +147,30 @@ start, end = starts[0], ends[0]
 if end <= start:
     sys.exit(f"end anchor precedes start anchor in {path}")
 path.write_text("".join(lines[:start] + lines[end:]))
+PY
+}
+
+# replace_after FILE MARKER OLD NEW -- MARKER must occur exactly once; OLD must
+# occur exactly once AFTER it. For an edit whose target line is byte-identical
+# in several jobs (setup-node in `test` and `install-smoke`), where the job
+# header is the only unique context.
+replace_after() {
+	MUT_FILE="$1" MUT_MARKER="$2" MUT_OLD="$3" MUT_NEW="$4" python3 - <<'PY'
+import os
+import pathlib
+import sys
+
+path = pathlib.Path(os.environ["MUT_FILE"])
+text = path.read_text()
+marker = os.environ["MUT_MARKER"]
+old = os.environ["MUT_OLD"]
+new = os.environ["MUT_NEW"]
+if text.count(marker) != 1:
+    sys.exit(f"marker matched {text.count(marker)} times (expected exactly 1) in {path}:\n{marker!r}")
+head, tail = text.split(marker, 1)
+if tail.count(old) != 1:
+    sys.exit(f"anchor matched {tail.count(old)} times after marker (expected exactly 1) in {path}:\n{old!r}")
+path.write_text(head + marker + tail.replace(old, new, 1))
 PY
 }
 
@@ -226,10 +256,10 @@ continue-on-error-job)
 	;;
 continue-on-error-step)
 	replace "$RELEASE" '      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 ' '      - name: Publish to PyPI
         continue-on-error: true
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 '
 	;;
 if-on-publish-job)
@@ -242,10 +272,10 @@ if-on-publish-job)
 	;;
 if-on-publish-step)
 	replace "$RELEASE" '      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 ' '      - name: Publish to PyPI
         if: ${{ github.actor != '"'"'nobody'"'"' }}
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 '
 	;;
 if-on-build-job)
@@ -283,8 +313,10 @@ jobs:
 YAML
 	;;
 forked-action)
-	replace "$RELEASE" 'uses: pypa/gh-action-pypi-publish@release/v1' \
-		'uses: attacker-fork/gh-action-pypi-publish@release/v1'
+	# Keeps the SHA form and the comment, so the pin invariant passes and only
+	# the exact EXPECTED_USES allowlist can see the owner change.
+	replace "$RELEASE" 'uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2' \
+		'uses: attacker-fork/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2'
 	;;
 permissions-job-widened)
 	replace "$RELEASE" '      id-token: write  # Required for trusted publishing
@@ -372,6 +404,28 @@ guard-self-disabled-nonconstant)
     if: ${{ github.actor == '"'"'nobody-at-all'"'"' }}
     runs-on: ubuntu-latest
 '
+	;;
+tag-pinned-action)
+	replace_after "$TEST_WF" '  install-smoke:
+' '      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+' '      - uses: actions/setup-node@v7
+'
+	;;
+sha-comment-dropped)
+	replace "$RELEASE" 'uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1' \
+		'uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a'
+	;;
+sha-moved)
+	replace "$RELEASE" 'uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2' \
+		'uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba34 # v1.14.2'
+	;;
+pypa-rolled-back)
+	replace "$RELEASE" 'uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2' \
+		'uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0'
+	;;
+composite-tag-pinned)
+	replace "$COMPOSITE" 'uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0' \
+		'uses: actions/setup-node@v4'
 	;;
 guard-step-gutted)
 	replace "$TEST_WF" \

--- a/scripts/_mutate_workflow.sh
+++ b/scripts/_mutate_workflow.sh
@@ -76,6 +76,7 @@ sha-comment-dropped|1|[pin]|release.yml: the "# v7.0.1" comment stripped from th
 sha-moved|1|[release]|release.yml: one hex digit of the pypa SHA altered; form-valid, honest-looking comment, a commit that is not the release. Only the exact allowlist sees it
 pypa-rolled-back|1|[release]|release.yml: pypa pinned to v1.9.0's REAL commit with an honest "# v1.9.0" comment; 144 commits behind and below the GHSA-vxmw-7h4f-hqxh floor. Form-valid; only the exact allowlist sees it
 composite-tag-pinned|1|[pin]|.github/actions/pipeline-bootstrap-setup/action.yml: setup-node pin reverted to @v4; proves the composite (id-token: write in scope) is in the scan
+uses-quoted-key|1|[pin]|.github/actions/pipeline-bootstrap-setup/action.yml: the pin reverted to @v4 AND the key written as "uses":; valid YAML that GitHub runs and the line scan cannot see. Caught only by the parsed-inventory cross-check
 needs-as-list|0|-|release.yml: needs: build -> needs: [build]; a legitimate equivalent form that must NOT false-positive
 timeout-below-p100|0|-|NOT COVERED: release.yml build timeout-minutes 20 -> 12, above the floor but potentially below a future p100
 concurrency-added|0|-|NOT COVERED by invariant: workflow-level concurrency with cancel-in-progress on release.yml; release-diff-ack covers it by label
@@ -426,6 +427,10 @@ pypa-rolled-back)
 composite-tag-pinned)
 	replace "$COMPOSITE" 'uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0' \
 		'uses: actions/setup-node@v4'
+	;;
+uses-quoted-key)
+	replace "$COMPOSITE" '- uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0' \
+		'- "uses": actions/setup-node@v4'
 	;;
 guard-step-gutted)
 	replace "$TEST_WF" \

--- a/scripts/check_workflows.py
+++ b/scripts/check_workflows.py
@@ -7,8 +7,13 @@ breaks, and the worst mutants are silent — changing the tag filter ``v*`` to
 ``V*`` leaves a valid workflow that simply never runs, so there is no red X
 anywhere and a version sits tagged-but-unshipped.
 
-Three independent checks run here:
+Four independent checks run here:
 
+``all_uses_are_sha_pinned``
+    Every remote ``uses:`` in every workflow *and* in every local composite
+    action under ``.github/actions/`` must name a 40-hex commit SHA with a
+    trailing ``# <release>`` comment (Consiliency/pmcp#217). Checked on the
+    **raw text**, because ``yaml.safe_load`` drops comments.
 ``release_invariants``
     Asserts the *state* of ``release.yml`` against the committed shape.
 ``timeout_invariants``
@@ -25,15 +30,18 @@ uses one, granting a scope — must update the constants in this file in the
 same PR. That is intended: on the one workflow with no PR-time feedback, a
 change should be deliberate enough to be spelled twice.
 
-Note also what these constants do *not* buy: pinning
-``pypa/gh-action-pypi-publish@release/v1`` exactly makes a *change* to it
-fail, but ``@release/v1`` is a mutable tag, so the pin is not a supply-chain
-control. See ``.consiliency/evidence/mutation-189.md``.
+The ``uses:`` allowlist holds the **SHA form without the comment**, because
+the parser never sees the comment. An exact SHA in ``EXPECTED_USES`` is what
+rejects a *valid-looking* pin to the wrong commit — a moved digit, or a real
+older release with an honest comment (``pypa-rolled-back`` in
+``.consiliency/evidence/mutation-217.md``). The SHA-pin invariant rejects the
+*form* (a mutable tag, a missing comment); it cannot know which commit is right.
 """
 
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -42,6 +50,7 @@ from typing import Any
 import yaml
 
 WORKFLOW_DIR = Path(".github/workflows")
+ACTIONS_DIR = Path(".github/actions")
 RELEASE_PATH = WORKFLOW_DIR / "release.yml"
 
 # --- committed shape of release.yml -----------------------------------------
@@ -56,19 +65,26 @@ EXPECTED_JOB_PERMISSIONS: dict[str, dict[str, str] | None] = {
     "publish": {"id-token": "write"},
     "github-release": {"contents": "write"},
 }
+# SHA form ONLY — no `# vX.Y.Z` here. `yaml.safe_load` strips the comment before
+# `_collect_uses` runs, so a value carrying one could never match anything.
+# The comment lives in release.yml and is enforced on raw text by
+# `all_uses_are_sha_pinned`; the commit is enforced here.
 EXPECTED_USES = {
     "build": [
-        "actions/checkout@v7",
-        "astral-sh/setup-uv@v7",
-        "actions/upload-artifact@v7",
+        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+        "astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78",
+        "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
     ],
     "publish": [
-        "actions/download-artifact@v7",
-        "pypa/gh-action-pypi-publish@release/v1",
+        "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131",
+        # v1.14.2 == the release/v1 head on the day of pinning. Any re-pin must
+        # stay >= 1.13.0: GHSA-vxmw-7h4f-hqxh (injectable expression expansions)
+        # affects every earlier release.
+        "pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33",
     ],
     "github-release": [
-        "actions/checkout@v7",
-        "actions/download-artifact@v7",
+        "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+        "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131",
     ],
 }
 # Jobs whose execution must not be made conditional or best-effort, at job
@@ -374,6 +390,86 @@ def timeout_invariants(doc: Any, path: str | Path) -> list[str]:
     return reasons
 
 
+# --- SHA pinning ----------------------------------------------------------------
+
+# A `uses:` line, at step level (`- uses:`) or job level (reusable workflow).
+_USES_LINE = re.compile(r"^\s*-?\s*uses:\s*(?P<value>\S.*?)\s*$")
+# The only accepted form for a remote reference: owner/repo[/path]@<40 hex>,
+# then a trailing `# <something>` naming the release. Subdirectory actions and
+# remote reusable workflows (`owner/repo/.github/workflows/x.yml@<sha>`) are
+# admitted by the path segment; they are remote code and must be pinned too.
+SHA_PINNED_USES = re.compile(
+    r"^\s*-?\s*uses:\s*[\w.-]+/[\w./-]+@[0-9a-f]{40}\s+#\s*\S+"
+)
+
+
+def action_files() -> list[Path]:
+    """Every local composite/JS action definition under ``.github/actions/``.
+
+    Both extensions: an ``action.yaml`` runs exactly like an ``action.yml``,
+    so renaming one would otherwise remove it from the scan while keeping it
+    executable.
+    """
+    if not ACTIONS_DIR.is_dir():
+        return []
+    found = set(ACTIONS_DIR.rglob("action.yml")) | set(ACTIONS_DIR.rglob("action.yaml"))
+    return sorted(found)
+
+
+def pin_scan_files() -> list[Path]:
+    return workflow_files() + action_files()
+
+
+def remote_uses(paths: list[Path]) -> list[tuple[Path, int, str]]:
+    """Every ``uses:`` value that refers to code outside this repository.
+
+    ``./path`` is same-repository code, reviewed like any other file, and is
+    the ONLY thing skipped. ``docker://`` is remote and is *not* skipped: it is
+    not pinnable by this scheme, so it is reported until the decision to admit
+    it (by digest) is made deliberately here rather than by default.
+    """
+    found: list[tuple[Path, int, str]] = []
+    for path in paths:
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            match = _USES_LINE.match(line)
+            if not match:
+                continue
+            value = match.group("value")
+            if value.startswith("./"):
+                continue
+            found.append((path, lineno, value))
+    return found
+
+
+def all_uses_are_sha_pinned(paths: list[Path]) -> list[str]:
+    """Every remote ``uses:`` must be ``owner/action@<40-hex-sha> # <release>``.
+
+    Raw text, not parsed YAML: the parser drops the comment, and the comment is
+    half of the convention — it is what Dependabot reads to propose the next
+    release and what a reviewer reads to know which one this is.
+    """
+    reasons: list[str] = []
+    tag = "[pin]"
+    for path, lineno, value in remote_uses(paths):
+        line = path.read_text().splitlines()[lineno - 1]
+        if SHA_PINNED_USES.match(line):
+            continue
+        if value.startswith("docker://"):
+            reasons.append(
+                f"{tag} {path}:{lineno} uses {value!r} — a docker:// reference is "
+                "remote code this guard cannot pin by commit SHA; admit it by "
+                "digest deliberately, in this file, not by default"
+            )
+            continue
+        reasons.append(
+            f"{tag} {path}:{lineno} uses {value!r} — not pinned to a 40-hex commit "
+            "SHA with a trailing `# <release>` comment. A tag or branch is "
+            "mutable: whoever controls the action's repository controls what "
+            "runs here, with this job's permissions"
+        )
+    return reasons
+
+
 # --- drift -------------------------------------------------------------------
 
 
@@ -574,6 +670,10 @@ def main(argv: list[str] | None = None) -> int:
             continue
         failures.extend(timeout_invariants(doc, path))
         failures.extend(tag_trigger_invariants(doc, path))
+
+    # 2b. SHA pinning — raw text, every workflow AND every local action. Wired
+    # here, not only into pytest: the evidence loop runs this CLI.
+    failures.extend(all_uses_are_sha_pinned(pin_scan_files()))
 
     # 3. job-set drift — only against a base.
     if base_ref is None:

--- a/scripts/check_workflows.py
+++ b/scripts/check_workflows.py
@@ -441,15 +441,77 @@ def remote_uses(paths: list[Path]) -> list[tuple[Path, int, str]]:
     return found
 
 
+def _parsed_uses(node: Any) -> list[str]:
+    """Every string ``uses:`` value the YAML parser sees, anywhere in ``node``.
+
+    Deliberately over-collects (a ``uses`` key under ``with:`` would count):
+    over-collection can only make the cross-check below fail, never pass.
+    """
+    found: list[str] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            if key == "uses" and isinstance(value, str):
+                found.append(value)
+            else:
+                found.extend(_parsed_uses(value))
+    elif isinstance(node, list):
+        for item in node:
+            found.extend(_parsed_uses(item))
+    return found
+
+
+_TRAILING_COMMENT = re.compile(r"\s+#.*$")
+
+
+def _unseen_by_raw_scan(path: Path) -> list[str]:
+    """Cross-check the raw-text inventory against the parsed one.
+
+    The raw scan is line-based, so it can see the comment the parser drops —
+    but it recognises only the canonical ``uses: value`` line. ``"uses":``,
+    ``uses :``, a flow mapping ``{uses: x}`` and a block scalar ``uses: >-``
+    are all valid YAML that GitHub runs and that the line scan does not see.
+    Requiring the two inventories to be EQUAL makes every such form fail
+    closed instead of running unpinned.
+    """
+    doc, err = _load(path)
+    if err:
+        return [err]
+    parsed = sorted(v for v in _parsed_uses(doc) if not v.startswith("./"))
+    raw = sorted(
+        _TRAILING_COMMENT.sub("", value) for _, _, value in remote_uses([path])
+    )
+    if parsed == raw:
+        return []
+    only_parsed = sorted(set(parsed) - set(raw))
+    only_raw = sorted(set(raw) - set(parsed))
+    detail = []
+    if only_parsed:
+        detail.append(f"seen by the parser but not the scan: {only_parsed}")
+    if only_raw:
+        detail.append(f"seen by the scan but not the parser: {only_raw}")
+    if not detail:
+        detail.append(f"parser counts {len(parsed)}, scan counts {len(raw)}")
+    return [
+        f"[pin] {path}: uses: inventory mismatch — {'; '.join(detail)}. Every "
+        "uses: must be a plain single-line `uses: owner/action@<sha> # <release>` "
+        "(unquoted key, no space before the colon, no flow mapping, no block "
+        "scalar), because only that form lets the scan see the release comment"
+    ]
+
+
 def all_uses_are_sha_pinned(paths: list[Path]) -> list[str]:
     """Every remote ``uses:`` must be ``owner/action@<40-hex-sha> # <release>``.
 
     Raw text, not parsed YAML: the parser drops the comment, and the comment is
     half of the convention — it is what Dependabot reads to propose the next
-    release and what a reviewer reads to know which one this is.
+    release and what a reviewer reads to know which one this is. The parsed
+    document is then used as a second inventory that the raw one must equal,
+    so a ``uses:`` spelled in a form the line scan cannot see fails closed.
     """
     reasons: list[str] = []
     tag = "[pin]"
+    for path in paths:
+        reasons.extend(_unseen_by_raw_scan(path))
     for path, lineno, value in remote_uses(paths):
         line = path.read_text().splitlines()[lineno - 1]
         if SHA_PINNED_USES.match(line):

--- a/tests/test_workflow_guards.py
+++ b/tests/test_workflow_guards.py
@@ -170,6 +170,13 @@ PIN_MUTANTS: dict[str, tuple[Path, str, str]] = {
         "uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0",
         "uses: actions/setup-node@v4",
     ),
+    # Valid YAML GitHub runs; invisible to the line scan. Only the
+    # parsed-inventory cross-check sees it.
+    "uses-quoted-key": (
+        REPO_ROOT / ".github" / "actions" / "pipeline-bootstrap-setup" / "action.yml",
+        "- uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0",
+        '- "uses": actions/setup-node@v4',
+    ),
 }
 
 # Every mutant these tests exercise. Asserted EQUAL to the helper's expected-1
@@ -439,6 +446,52 @@ class TestShaPinning:
     def test_step_level_forms(self, tmp_path: Path, uses: str, ok: bool) -> None:
         path = _write(tmp_path, ".github/workflows/x.yml", _wf(uses))
         assert (cw.all_uses_are_sha_pinned([path]) == []) is ok, uses
+
+    @pytest.mark.parametrize(
+        "step",
+        [
+            '- "uses": actions/checkout@v7',  # quoted key
+            "- uses : actions/checkout@v7",  # space before the colon
+            "- {uses: actions/checkout@v7}",  # flow mapping
+            "- uses: >-\n          actions/checkout@v7",  # block scalar
+            "- uses: 'actions/checkout@v7'",  # quoted value
+        ],
+    )
+    def test_a_uses_the_line_scan_cannot_see_fails_closed(
+        self, tmp_path: Path, step: str
+    ) -> None:
+        # All valid YAML that GitHub executes as a mutable-ref step. The raw
+        # scan sees none of them; the parsed inventory does, and the two must
+        # be equal. A guard that only reads lines would let these run unpinned.
+        body = (
+            "name: x\non:\n  push:\njobs:\n  j:\n    timeout-minutes: 10\n"
+            f"    steps:\n      {step}\n"
+        )
+        path = _write(tmp_path, ".github/workflows/x.yml", body)
+        assert [s.get("uses") for s in yaml.safe_load(body)["jobs"]["j"]["steps"]] == [
+            "actions/checkout@v7"
+        ]
+        reasons = cw.all_uses_are_sha_pinned([path])
+        assert any("inventory mismatch" in r for r in reasons), (step, reasons)
+
+    def test_a_quoted_value_with_a_valid_pin_still_fails_closed(
+        self, tmp_path: Path
+    ) -> None:
+        # Even a correct pin in a form the scan cannot read is refused: the
+        # convention is one spelling, so the comment is always visible.
+        path = _write(
+            tmp_path,
+            ".github/workflows/x.yml",
+            _wf(f"'actions/checkout@{_SHA}' # v7.0.1"),
+        )
+        assert cw.all_uses_are_sha_pinned([path]) != []
+
+    def test_the_inventories_agree_on_the_committed_tree(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.chdir(REPO_ROOT)
+        for path in cw.pin_scan_files():
+            assert cw._unseen_by_raw_scan(path) == [], path
 
     def test_a_same_repository_path_is_skipped(self, tmp_path: Path) -> None:
         path = _write(

--- a/tests/test_workflow_guards.py
+++ b/tests/test_workflow_guards.py
@@ -67,6 +67,10 @@ def _on(doc: dict[str, Any]) -> dict[str, Any]:
 # the in-memory mutation and the committed one cannot drift apart.
 _IF_EXPR = "${{ github.actor != 'nobody' }}"
 
+# The committed pypa pin, SHA form (what the parser yields). Read from the
+# checker so the tests cannot drift from the allowlist they exercise.
+_PYPA_PIN = next(u for u in cw.EXPECTED_USES["publish"] if u.startswith("pypa/"))
+
 # Each key is a mutant name in scripts/_mutate_workflow.sh; the callable is the
 # same edit applied to the parsed document.
 RELEASE_MUTANTS: dict[str, Any] = {
@@ -102,8 +106,21 @@ RELEASE_MUTANTS: dict[str, Any] = {
     "continue-on-error-build-job": lambda d: d["jobs"]["build"].update(
         {"continue-on-error": True}
     ),
+    # SHA form kept, so the pin invariant passes and only the exact allowlist
+    # sees the owner change.
     "forked-action": lambda d: _pypi_step(d).update(
-        {"uses": "attacker-fork/gh-action-pypi-publish@release/v1"}
+        {"uses": "attacker-fork/" + _PYPA_PIN.split("/", 1)[1]}
+    ),
+    # Form-valid, honest-looking, wrong commit. The pin invariant cannot know
+    # which commit is right; EXPECTED_USES can.
+    "sha-moved": lambda d: _pypi_step(d).update(
+        {"uses": _PYPA_PIN[:-1] + ("4" if _PYPA_PIN[-1] != "4" else "5")}
+    ),
+    # A REAL older release with its real commit: 144 commits behind v1.14.2 and
+    # below the GHSA-vxmw-7h4f-hqxh floor (< 1.13.0). Nothing about its form is
+    # wrong; only the exact allowlist rejects it.
+    "pypa-rolled-back": lambda d: _pypi_step(d).update(
+        {"uses": "pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0"}
     ),
     "permissions-job-widened": lambda d: _publish(d)["permissions"].update(
         {"contents": "write"}
@@ -135,6 +152,26 @@ DRIFT_MUTANTS = (
     "workflows-job-deleted",
 )
 
+# Mutants of the FORM of a pin, caught by `all_uses_are_sha_pinned` on raw
+# text. Each is the same edit the shell helper makes, applied to a copy.
+PIN_MUTANTS: dict[str, tuple[Path, str, str]] = {
+    "tag-pinned-action": (
+        TEST_YML,
+        "- uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0",
+        "- uses: actions/setup-node@v7",
+    ),
+    "sha-comment-dropped": (
+        RELEASE_YML,
+        "uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1",
+        "uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+    ),
+    "composite-tag-pinned": (
+        REPO_ROOT / ".github" / "actions" / "pipeline-bootstrap-setup" / "action.yml",
+        "uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0",
+        "uses: actions/setup-node@v4",
+    ),
+}
+
 # Every mutant these tests exercise. Asserted EQUAL to the helper's expected-1
 # rows — in BOTH directions — by TestMutationHelperContract, because the
 # evidence matrix is generated from that TSV: a phantom row there would
@@ -143,6 +180,7 @@ TESTED_MUTANTS = (
     set(RELEASE_MUTANTS)
     | set(TIMEOUT_MUTANTS)
     | set(DRIFT_MUTANTS)
+    | set(PIN_MUTANTS)
     | {"file-deleted", "timeout-deleted", "new-tag-triggered-workflow"}
 )
 
@@ -310,6 +348,158 @@ class TestTimeoutInvariants:
         # invalid YAML.
         doc = {"jobs": {"call": {"uses": "./.github/workflows/other.yml"}}}
         assert cw.timeout_invariants(doc, "x.yml") == []
+
+
+_SHA = "0123456789abcdef0123456789abcdef01234567"
+_COMPOSITE_YML = (
+    REPO_ROOT / ".github" / "actions" / "pipeline-bootstrap-setup" / "action.yml"
+)
+
+
+def _write(tmp_path: Path, rel: str, body: str) -> Path:
+    path = tmp_path / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return path
+
+
+def _wf(uses: str) -> str:
+    return f"name: x\non:\n  push:\njobs:\n  j:\n    timeout-minutes: 10\n    steps:\n      - uses: {uses}\n"
+
+
+class TestShaPinning:
+    """Consiliency/pmcp#217: every remote `uses:` is `owner/action@<sha> # <release>`."""
+
+    def test_every_committed_file_passes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(REPO_ROOT)
+        assert cw.all_uses_are_sha_pinned(cw.pin_scan_files()) == []
+
+    def test_the_scan_covers_the_composite_action(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # It runs inside a job holding id-token: write and contents: write, and
+        # Dependabot's root entry had never scanned it.
+        monkeypatch.chdir(REPO_ROOT)
+        assert _COMPOSITE_YML.resolve() in {p.resolve() for p in cw.pin_scan_files()}
+
+    def test_the_committed_tree_has_thirty_remote_refs(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Spelled twice on purpose, like EXPECTED_USES: a new remote action is a
+        # deliberate event. 29 in the workflows + 1 in the composite.
+        monkeypatch.chdir(REPO_ROOT)
+        assert len(cw.remote_uses(cw.pin_scan_files())) == 30
+
+    def test_expected_uses_is_sha_form_without_comments(self) -> None:
+        # yaml.safe_load strips comments before _collect_uses runs, so a value
+        # carrying `# vX` could never match; a mutable tag defeats the point.
+        for job, values in cw.EXPECTED_USES.items():
+            for value in values:
+                assert cw.re.fullmatch(r"[\w.-]+/[\w./-]+@[0-9a-f]{40}", value), (
+                    job,
+                    value,
+                )
+
+    def test_the_pypa_pin_is_at_or_above_the_advisory_floor(self) -> None:
+        # GHSA-vxmw-7h4f-hqxh: < 1.13.0 is vulnerable. Compared NUMERICALLY —
+        # a lexical comparison is how v1.9.0 once looked newer than v1.14.2.
+        line = next(
+            ln
+            for ln in RELEASE_YML.read_text().splitlines()
+            if "pypa/gh-action-pypi-publish@" in ln
+        )
+        comment = line.split("#", 1)[1].strip()
+        assert comment.startswith("v")
+        version = tuple(int(part) for part in comment[1:].split("."))
+        assert version >= (1, 13, 0), comment
+
+    @pytest.mark.parametrize("mutant", sorted(PIN_MUTANTS))
+    def test_mutant_is_rejected(self, mutant: str, tmp_path: Path) -> None:
+        source, old, new = PIN_MUTANTS[mutant]
+        text = source.read_text()
+        assert text.count(old) >= 1, f"{mutant}: anchor gone from {source.name}"
+        copy_path = _write(tmp_path, source.name, text.replace(old, new))
+        reasons = cw.all_uses_are_sha_pinned([copy_path])
+        assert reasons and all(r.startswith("[pin]") for r in reasons), reasons
+
+    @pytest.mark.parametrize(
+        ("uses", "ok"),
+        [
+            (f"actions/checkout@{_SHA} # v7.0.1", True),
+            (f"actions/checkout@{_SHA} #v7.0.1", True),
+            (f"owner/repo/sub/dir@{_SHA} # v1", True),  # subdirectory action
+            ("actions/checkout@v7", False),  # mutable tag
+            ("actions/checkout@main", False),  # branch
+            (f"actions/checkout@{_SHA}", False),  # no comment
+            (f"actions/checkout@{_SHA[:39]} # v7", False),  # 39 hex
+            (f"actions/checkout@{_SHA.upper()} # v7", False),  # not lowercase hex
+            ("docker://alpine:3.20", False),  # remote, not pinnable here
+        ],
+    )
+    def test_step_level_forms(self, tmp_path: Path, uses: str, ok: bool) -> None:
+        path = _write(tmp_path, ".github/workflows/x.yml", _wf(uses))
+        assert (cw.all_uses_are_sha_pinned([path]) == []) is ok, uses
+
+    def test_a_same_repository_path_is_skipped(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path, ".github/workflows/x.yml", _wf("./.github/actions/local")
+        )
+        assert cw.all_uses_are_sha_pinned([path]) == []
+        assert cw.remote_uses([path]) == []
+
+    @pytest.mark.parametrize(
+        ("uses", "ok"),
+        [
+            (f"owner/repo/.github/workflows/build.yml@{_SHA} # v1.2.3", True),
+            ("owner/repo/.github/workflows/build.yml@main", False),
+            ("./.github/workflows/build.yml", True),
+        ],
+    )
+    def test_job_level_reusable_workflows(
+        self, tmp_path: Path, uses: str, ok: bool
+    ) -> None:
+        # A remote reusable workflow is remote code and must be pinned; a
+        # same-repository one is reviewed like any file. NOT a blanket skip.
+        path = _write(
+            tmp_path,
+            ".github/workflows/x.yml",
+            f"name: x\non:\n  push:\njobs:\n  call:\n    uses: {uses}\n",
+        )
+        assert (cw.all_uses_are_sha_pinned([path]) == []) is ok, uses
+
+    def test_both_extensions_are_scanned_for_actions_and_workflows(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Renaming to .yaml keeps the file executable; it must not leave the scan.
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path, ".github/workflows/a.yaml", _wf("actions/checkout@v7"))
+        _write(
+            tmp_path,
+            ".github/actions/thing/action.yaml",
+            "name: t\nruns:\n  using: composite\n  steps:\n    - uses: actions/setup-node@v4\n",
+        )
+        reasons = cw.all_uses_are_sha_pinned(cw.pin_scan_files())
+        assert len(reasons) == 2, reasons
+        assert any("a.yaml" in r for r in reasons)
+        assert any("action.yaml" in r for r in reasons)
+
+    def test_a_composite_runs_block_is_scanned_as_steps(self, tmp_path: Path) -> None:
+        path = _write(
+            tmp_path,
+            ".github/actions/thing/action.yml",
+            f"name: t\nruns:\n  using: composite\n  steps:\n    - uses: actions/setup-node@{_SHA} # v4.4.0\n",
+        )
+        assert cw.remote_uses([path]) == [
+            (path, 5, f"actions/setup-node@{_SHA} # v4.4.0")
+        ]
+        assert cw.all_uses_are_sha_pinned([path]) == []
+
+    def test_the_reason_names_file_line_and_ref(self, tmp_path: Path) -> None:
+        path = _write(tmp_path, ".github/workflows/x.yml", _wf("actions/checkout@v7"))
+        (reason,) = cw.all_uses_are_sha_pinned([path])
+        assert reason.startswith("[pin]")
+        assert f"{path}:8" in reason
+        assert "actions/checkout@v7" in reason
 
 
 def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -778,6 +968,20 @@ class TestMutationHelperContract:
         # catch them.
         rows = {row[0]: row for row in self._rows()}
         assert rows[mutant][2] == "[drift]"
+
+    @pytest.mark.parametrize("mutant", sorted(PIN_MUTANTS))
+    def test_the_pin_mutants_declare_pin_as_their_catcher(self, mutant: str) -> None:
+        rows = {row[0]: row for row in self._rows()}
+        assert rows[mutant][2] == "[pin]"
+
+    @pytest.mark.parametrize("mutant", ["sha-moved", "pypa-rolled-back"])
+    def test_the_wrong_commit_mutants_are_caught_by_the_allowlist_not_the_form(
+        self, mutant: str
+    ) -> None:
+        # Both are form-valid pins; if the tag said [pin] the evidence would be
+        # claiming a catch the pin invariant cannot make.
+        rows = {row[0]: row for row in self._rows()}
+        assert rows[mutant][2] == "[release]"
 
     @pytest.mark.parametrize(
         "mutant",


### PR DESCRIPTION
See Consiliency/pmcp#217.

All 30 remote `uses:` references — 29 across the five workflows and the one inside the local composite action — now read `owner/action@<40-hex-sha> # vX.Y.Z`. **Every pin is the commit its previous mutable ref resolved to today, so nothing runs a different version**: `pypa/gh-action-pypi-publish` → v1.14.2 (the commit `release/v1` already pointed at; ≥ 1.13.0 per GHSA-vxmw-7h4f-hqxh), the composite's `setup-node@v4` → v4.4.0.

Guard:
- `scripts/check_workflows.py`: `all_uses_are_sha_pinned` on **raw text** (yaml.safe_load drops the comment) over `.github/workflows/*.y*ml` and `.github/actions/**/action.y*ml`, skipping only `./` paths; remote reusable workflows must be pinned too; `docker://` is reported, not admitted. **Board finding (87e5974):** the line scan could not see `"uses":`, `uses :`, `{uses: x}` or `uses: >-` — valid YAML GitHub runs — so the parsed inventory of remote `uses:` must now equal the raw one per file; any unreadable spelling fails closed (five forms pinned by test, mutant `uses-quoted-key`). `EXPECTED_USES` in SHA form (no comments — they could never match parsed YAML).
- `scripts/_mutate_workflow.sh`: the three `@release/v1` anchors re-pointed with the pins; six new mutants (`tag-pinned-action`, `sha-comment-dropped`, `sha-moved`, `pypa-rolled-back`, `composite-tag-pinned`, `uses-quoted-key`); `replace_after` for the byte-identical `setup-node` blocks.
- `tests/test_workflow_guards.py`: `TestShaPinning`; the bidirectional mutation contract now covers 37 expected-kill rows.
- `.github/dependabot.yml`: entry for the composite's directory (the root entry had never scanned it — it sat on `@v4` through 20 Dependabot PRs).
- `SECURITY.md` supply-chain paragraph; CHANGELOG `[Unreleased]` (this and #216).

Evidence: `.consiliency/evidence/mutation-217.md` — invariant RED with 30 refs before pinning; 43-row committed-mutant matrix with helper exit + commit hash per row, all as expected; verifier proving every pin equals its original ref's commit today, with both fail-closed branches shown to fire (digit-flip, and a real v1.9.0 rollback that passes the comment check and fails the original-ref check).

Local: `tests/test_workflow_guards.py` 192 passed; ruff, ruff format, mypy clean.

`release.yml` changes here are the seven pins only — every other release invariant is unchanged; this PR needs the `release-diff-ack` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NR2LKqZgn7CXVH2816gaa

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/218"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790840831&installation_model_id=427051&pr_number=218&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F218&signature=c8944fcde5371a29d0492b523d1c6f7438c1ae0d81ced42caef0b131a84cac01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->