### PR TITLE
ci(mutants): locate pinned uses: lines by pattern, never by literal SHA (see #217)

### DIFF
--- a/.consiliency/evidence/mutation-217.md
+++ b/.consiliency/evidence/mutation-217.md
@@ -105,49 +105,49 @@ Base: the implementation commit. `helper` is `_mutate_workflow.sh`'s exit,
 | mutant | expected | helper | commit | checker | reason |
 |---|---|---|---|---|---|
 | *(none: unmutated tree)* | 0 | — | — | 0 | — |
-| `tag-case` | 1 | 0 | `3e339ad` | **1** | `[release]` |
-| `tags-deleted` | 1 | 0 | `07a838e` | **1** | `[release]` |
-| `trigger-pull-request-added` | 1 | 0 | `fa37b8b` | **1** | `[release]` |
-| `trigger-push-branches-added` | 1 | 0 | `ef8ed1a` | **1** | `[release]` |
-| `trigger-workflow-dispatch-added` | 1 | 0 | `e105218` | **1** | `[release]` |
-| `trigger-paths-filter-added` | 1 | 0 | `e3ce0fc` | **1** | `[release]` |
-| `env-dropped` | 1 | 0 | `916c3d2` | **1** | `[release]` |
-| `env-renamed` | 1 | 0 | `53b8ebd` | **1** | `[release]` |
-| `needs-build-dropped` | 1 | 0 | `81aa64e` | **1** | `[release]` |
-| `needs-publish-to-build` | 1 | 0 | `1d1a2e6` | **1** | `[release]` |
-| `continue-on-error-job` | 1 | 0 | `b834dfb` | **1** | `[release]` |
-| `continue-on-error-step` | 1 | 0 | `576dc00` | **1** | `[release]` |
-| `if-on-build-job` | 1 | 0 | `d81ecf0` | **1** | `[release]` |
-| `continue-on-error-build-job` | 1 | 0 | `7e220c8` | **1** | `[release]` |
-| `new-tag-triggered-workflow` | 1 | 0 | `4636780` | **1** | `[release]` |
-| `if-on-publish-job` | 1 | 0 | `aef994f` | **1** | `[release]` |
-| `if-on-publish-step` | 1 | 0 | `66b53dd` | **1** | `[release]` |
-| `forked-action` | 1 | 0 | `7caa446` | **1** | `[release]` |
-| `permissions-job-widened` | 1 | 0 | `75fb7c0` | **1** | `[release]` |
-| `permissions-workflow-level` | 1 | 0 | `3b3a383` | **1** | `[release]` |
-| `job-added` | 1 | 0 | `6a392ca` | **1** | `[release]` |
-| `job-deleted` | 1 | 0 | `1ae3523` | **1** | `[drift] [release]` |
-| `file-deleted` | 1 | 0 | `7a7feb1` | **1** | `[drift] [release]` |
-| `timeout-360` | 1 | 0 | `1422282` | **1** | `[timeout]` |
-| `timeout-1` | 1 | 0 | `1db916e` | **1** | `[timeout]` |
-| `timeout-string` | 1 | 0 | `9552665` | **1** | `[timeout]` |
-| `timeout-bool` | 1 | 0 | `aa5f6c6` | **1** | `[timeout]` |
-| `timeout-deleted` | 1 | 0 | `248fa75` | **1** | `[timeout]` |
-| `maintenance-deleted` | 1 | 0 | `3d08225` | **1** | `[drift]` |
-| `changelog-job-deleted` | 1 | 0 | `fec6b04` | **1** | `[drift]` |
-| `workflows-job-deleted` | 1 | 0 | `8ec7556` | **1** | `[drift]` |
-| `tag-pinned-action` | 1 | 0 | `4b83073` | **1** | `[pin]` |
-| `sha-comment-dropped` | 1 | 0 | `7ff6f57` | **1** | `[pin]` |
-| `sha-moved` | 1 | 0 | `4140843` | **1** | `[release]` |
-| `pypa-rolled-back` | 1 | 0 | `7cc269a` | **1** | `[release]` |
-| `composite-tag-pinned` | 1 | 0 | `7595c0d` | **1** | `[pin]` |
-| `uses-quoted-key` | 1 | 0 | `4d2886b` | **1** | `[pin]` |
-| `needs-as-list` | 0 | 0 | `0edbb5b` | 0 | — |
-| `timeout-below-p100` | 0 | 0 | `815da29` | 0 | — |
-| `concurrency-added` | 0 | 0 | `6d0edfe` | 0 | — |
-| `guard-self-disabled` | 0 | 0 | `6469415` | 0 | — |
-| `guard-self-disabled-nonconstant` | 0 | 0 | `96519f6` | 0 | — |
-| `guard-step-gutted` | 0 | 0 | `9cf53be` | 0 | — |
+| `tag-case` | 1 | 0 | `71d0591` | **1** | `[release]` |
+| `tags-deleted` | 1 | 0 | `012aa87` | **1** | `[release]` |
+| `trigger-pull-request-added` | 1 | 0 | `88aec17` | **1** | `[release]` |
+| `trigger-push-branches-added` | 1 | 0 | `531135f` | **1** | `[release]` |
+| `trigger-workflow-dispatch-added` | 1 | 0 | `b6aa0ac` | **1** | `[release]` |
+| `trigger-paths-filter-added` | 1 | 0 | `d0300a9` | **1** | `[release]` |
+| `env-dropped` | 1 | 0 | `cc34cec` | **1** | `[release]` |
+| `env-renamed` | 1 | 0 | `dea8f64` | **1** | `[release]` |
+| `needs-build-dropped` | 1 | 0 | `f5fca3f` | **1** | `[release]` |
+| `needs-publish-to-build` | 1 | 0 | `452520b` | **1** | `[release]` |
+| `continue-on-error-job` | 1 | 0 | `edfd0f7` | **1** | `[release]` |
+| `continue-on-error-step` | 1 | 0 | `f6acee8` | **1** | `[release]` |
+| `if-on-build-job` | 1 | 0 | `dbe90c6` | **1** | `[release]` |
+| `continue-on-error-build-job` | 1 | 0 | `3f7fd30` | **1** | `[release]` |
+| `new-tag-triggered-workflow` | 1 | 0 | `d78d7c2` | **1** | `[release]` |
+| `if-on-publish-job` | 1 | 0 | `eca06df` | **1** | `[release]` |
+| `if-on-publish-step` | 1 | 0 | `0f80261` | **1** | `[release]` |
+| `forked-action` | 1 | 0 | `1fa72c5` | **1** | `[release]` |
+| `permissions-job-widened` | 1 | 0 | `93009de` | **1** | `[release]` |
+| `permissions-workflow-level` | 1 | 0 | `dbc0efb` | **1** | `[release]` |
+| `job-added` | 1 | 0 | `a36fdaa` | **1** | `[release]` |
+| `job-deleted` | 1 | 0 | `bb42751` | **1** | `[drift] [release]` |
+| `file-deleted` | 1 | 0 | `f29256d` | **1** | `[drift] [release]` |
+| `timeout-360` | 1 | 0 | `583eb9d` | **1** | `[timeout]` |
+| `timeout-1` | 1 | 0 | `35f8f2a` | **1** | `[timeout]` |
+| `timeout-string` | 1 | 0 | `d0195eb` | **1** | `[timeout]` |
+| `timeout-bool` | 1 | 0 | `a5ecf95` | **1** | `[timeout]` |
+| `timeout-deleted` | 1 | 0 | `a33022e` | **1** | `[timeout]` |
+| `maintenance-deleted` | 1 | 0 | `ce938c0` | **1** | `[drift]` |
+| `changelog-job-deleted` | 1 | 0 | `1c04129` | **1** | `[drift]` |
+| `workflows-job-deleted` | 1 | 0 | `2e7fc1e` | **1** | `[drift]` |
+| `tag-pinned-action` | 1 | 0 | `430c549` | **1** | `[pin]` |
+| `sha-comment-dropped` | 1 | 0 | `2dd6774` | **1** | `[pin]` |
+| `sha-moved` | 1 | 0 | `10b6f01` | **1** | `[release]` |
+| `pypa-rolled-back` | 1 | 0 | `b6b79b7` | **1** | `[release]` |
+| `composite-tag-pinned` | 1 | 0 | `45b0cf8` | **1** | `[pin]` |
+| `uses-quoted-key` | 1 | 0 | `8a3784e` | **1** | `[pin]` |
+| `needs-as-list` | 0 | 0 | `6930fca` | 0 | — |
+| `timeout-below-p100` | 0 | 0 | `b54e1c0` | 0 | — |
+| `concurrency-added` | 0 | 0 | `aada7f6` | 0 | — |
+| `guard-self-disabled` | 0 | 0 | `fafa2ba` | 0 | — |
+| `guard-self-disabled-nonconstant` | 0 | 0 | `a47eb2c` | 0 | — |
+| `guard-step-gutted` | 0 | 0 | `eff41d7` | 0 | — |
 
 43 rows, 37 expected to fail, 6 expected green; every helper exit 0, every hash
 distinct, every expected failure reported by the expected check, every expected
@@ -171,6 +171,17 @@ green row green.
   killed by `EXPECTED_USES` and tagged `[release]`, not `[pin]`. The pin
   invariant does not and cannot catch these; the evidence says so rather than
   implying it.
+
+### Anchors match the form of a pin, not its value
+
+The first Dependabot bump of the composite's pin (#219, v4.4.0 → v7.0.0) went
+red: two mutants and two tests had anchored on the literal
+`@49933ea… # v4.4.0`. Every anchor that contains a pinned `uses:` line now
+matches `@<40 hex> # <release>` by regex (`replace_re`, `replace_after_re`,
+`flip_last_hex`), still exactly-once and fail-loud, and a contract test
+forbids any 40-hex literal in the helper or the tests other than the
+deliberate v1.9.0 rollback target. The matrix above was re-run after that
+change; every row still mutates and is still killed.
 
 ### Re-anchored mutants
 

--- a/.consiliency/evidence/mutation-217.md
+++ b/.consiliency/evidence/mutation-217.md
@@ -105,49 +105,49 @@ Base: the implementation commit. `helper` is `_mutate_workflow.sh`'s exit,
 | mutant | expected | helper | commit | checker | reason |
 |---|---|---|---|---|---|
 | *(none: unmutated tree)* | 0 | — | — | 0 | — |
-| `tag-case` | 1 | 0 | `71d0591` | **1** | `[release]` |
-| `tags-deleted` | 1 | 0 | `012aa87` | **1** | `[release]` |
-| `trigger-pull-request-added` | 1 | 0 | `88aec17` | **1** | `[release]` |
-| `trigger-push-branches-added` | 1 | 0 | `531135f` | **1** | `[release]` |
-| `trigger-workflow-dispatch-added` | 1 | 0 | `b6aa0ac` | **1** | `[release]` |
-| `trigger-paths-filter-added` | 1 | 0 | `d0300a9` | **1** | `[release]` |
-| `env-dropped` | 1 | 0 | `cc34cec` | **1** | `[release]` |
-| `env-renamed` | 1 | 0 | `dea8f64` | **1** | `[release]` |
-| `needs-build-dropped` | 1 | 0 | `f5fca3f` | **1** | `[release]` |
-| `needs-publish-to-build` | 1 | 0 | `452520b` | **1** | `[release]` |
-| `continue-on-error-job` | 1 | 0 | `edfd0f7` | **1** | `[release]` |
-| `continue-on-error-step` | 1 | 0 | `f6acee8` | **1** | `[release]` |
-| `if-on-build-job` | 1 | 0 | `dbe90c6` | **1** | `[release]` |
-| `continue-on-error-build-job` | 1 | 0 | `3f7fd30` | **1** | `[release]` |
-| `new-tag-triggered-workflow` | 1 | 0 | `d78d7c2` | **1** | `[release]` |
-| `if-on-publish-job` | 1 | 0 | `eca06df` | **1** | `[release]` |
-| `if-on-publish-step` | 1 | 0 | `0f80261` | **1** | `[release]` |
-| `forked-action` | 1 | 0 | `1fa72c5` | **1** | `[release]` |
-| `permissions-job-widened` | 1 | 0 | `93009de` | **1** | `[release]` |
-| `permissions-workflow-level` | 1 | 0 | `dbc0efb` | **1** | `[release]` |
-| `job-added` | 1 | 0 | `a36fdaa` | **1** | `[release]` |
-| `job-deleted` | 1 | 0 | `bb42751` | **1** | `[drift] [release]` |
-| `file-deleted` | 1 | 0 | `f29256d` | **1** | `[drift] [release]` |
-| `timeout-360` | 1 | 0 | `583eb9d` | **1** | `[timeout]` |
-| `timeout-1` | 1 | 0 | `35f8f2a` | **1** | `[timeout]` |
-| `timeout-string` | 1 | 0 | `d0195eb` | **1** | `[timeout]` |
-| `timeout-bool` | 1 | 0 | `a5ecf95` | **1** | `[timeout]` |
-| `timeout-deleted` | 1 | 0 | `a33022e` | **1** | `[timeout]` |
-| `maintenance-deleted` | 1 | 0 | `ce938c0` | **1** | `[drift]` |
-| `changelog-job-deleted` | 1 | 0 | `1c04129` | **1** | `[drift]` |
-| `workflows-job-deleted` | 1 | 0 | `2e7fc1e` | **1** | `[drift]` |
-| `tag-pinned-action` | 1 | 0 | `430c549` | **1** | `[pin]` |
-| `sha-comment-dropped` | 1 | 0 | `2dd6774` | **1** | `[pin]` |
-| `sha-moved` | 1 | 0 | `10b6f01` | **1** | `[release]` |
-| `pypa-rolled-back` | 1 | 0 | `b6b79b7` | **1** | `[release]` |
-| `composite-tag-pinned` | 1 | 0 | `45b0cf8` | **1** | `[pin]` |
-| `uses-quoted-key` | 1 | 0 | `8a3784e` | **1** | `[pin]` |
-| `needs-as-list` | 0 | 0 | `6930fca` | 0 | — |
-| `timeout-below-p100` | 0 | 0 | `b54e1c0` | 0 | — |
-| `concurrency-added` | 0 | 0 | `aada7f6` | 0 | — |
-| `guard-self-disabled` | 0 | 0 | `fafa2ba` | 0 | — |
-| `guard-self-disabled-nonconstant` | 0 | 0 | `a47eb2c` | 0 | — |
-| `guard-step-gutted` | 0 | 0 | `eff41d7` | 0 | — |
+| `tag-case` | 1 | 0 | `1a8fc37` | **1** | `[release]` |
+| `tags-deleted` | 1 | 0 | `e61def3` | **1** | `[release]` |
+| `trigger-pull-request-added` | 1 | 0 | `d447146` | **1** | `[release]` |
+| `trigger-push-branches-added` | 1 | 0 | `c59397d` | **1** | `[release]` |
+| `trigger-workflow-dispatch-added` | 1 | 0 | `308bdae` | **1** | `[release]` |
+| `trigger-paths-filter-added` | 1 | 0 | `645dee9` | **1** | `[release]` |
+| `env-dropped` | 1 | 0 | `0852603` | **1** | `[release]` |
+| `env-renamed` | 1 | 0 | `06bd9e3` | **1** | `[release]` |
+| `needs-build-dropped` | 1 | 0 | `a9c2b7a` | **1** | `[release]` |
+| `needs-publish-to-build` | 1 | 0 | `362d92a` | **1** | `[release]` |
+| `continue-on-error-job` | 1 | 0 | `92721fb` | **1** | `[release]` |
+| `continue-on-error-step` | 1 | 0 | `49f354a` | **1** | `[release]` |
+| `if-on-build-job` | 1 | 0 | `c8c1f75` | **1** | `[release]` |
+| `continue-on-error-build-job` | 1 | 0 | `8b44be0` | **1** | `[release]` |
+| `new-tag-triggered-workflow` | 1 | 0 | `560ec69` | **1** | `[release]` |
+| `if-on-publish-job` | 1 | 0 | `cc191d0` | **1** | `[release]` |
+| `if-on-publish-step` | 1 | 0 | `8ce1ab4` | **1** | `[release]` |
+| `forked-action` | 1 | 0 | `e18dcc1` | **1** | `[release]` |
+| `permissions-job-widened` | 1 | 0 | `7a8868f` | **1** | `[release]` |
+| `permissions-workflow-level` | 1 | 0 | `d9db91b` | **1** | `[release]` |
+| `job-added` | 1 | 0 | `692d0bf` | **1** | `[release]` |
+| `job-deleted` | 1 | 0 | `1f08ddf` | **1** | `[drift] [release]` |
+| `file-deleted` | 1 | 0 | `fa5b354` | **1** | `[drift] [release]` |
+| `timeout-360` | 1 | 0 | `5b86267` | **1** | `[timeout]` |
+| `timeout-1` | 1 | 0 | `229fa89` | **1** | `[timeout]` |
+| `timeout-string` | 1 | 0 | `8711df1` | **1** | `[timeout]` |
+| `timeout-bool` | 1 | 0 | `f0ce2ab` | **1** | `[timeout]` |
+| `timeout-deleted` | 1 | 0 | `2893c60` | **1** | `[timeout]` |
+| `maintenance-deleted` | 1 | 0 | `85b0e73` | **1** | `[drift]` |
+| `changelog-job-deleted` | 1 | 0 | `9a7ba65` | **1** | `[drift]` |
+| `workflows-job-deleted` | 1 | 0 | `ab2abf7` | **1** | `[drift]` |
+| `tag-pinned-action` | 1 | 0 | `b7167d5` | **1** | `[pin]` |
+| `sha-comment-dropped` | 1 | 0 | `d5f3ad6` | **1** | `[pin]` |
+| `sha-moved` | 1 | 0 | `565f36e` | **1** | `[release]` |
+| `pypa-rolled-back` | 1 | 0 | `59df6a3` | **1** | `[release]` |
+| `composite-tag-pinned` | 1 | 0 | `162da9a` | **1** | `[pin]` |
+| `uses-quoted-key` | 1 | 0 | `324809f` | **1** | `[pin]` |
+| `needs-as-list` | 0 | 0 | `6160bb0` | 0 | — |
+| `timeout-below-p100` | 0 | 0 | `77c0825` | 0 | — |
+| `concurrency-added` | 0 | 0 | `85906a0` | 0 | — |
+| `guard-self-disabled` | 0 | 0 | `e520571` | 0 | — |
+| `guard-self-disabled-nonconstant` | 0 | 0 | `b87295d` | 0 | — |
+| `guard-step-gutted` | 0 | 0 | `af579fd` | 0 | — |
 
 43 rows, 37 expected to fail, 6 expected green; every helper exit 0, every hash
 distinct, every expected failure reported by the expected check, every expected

--- a/scripts/_mutate_workflow.sh
+++ b/scripts/_mutate_workflow.sh
@@ -151,27 +151,71 @@ path.write_text("".join(lines[:start] + lines[end:]))
 PY
 }
 
-# replace_after FILE MARKER OLD NEW -- MARKER must occur exactly once; OLD must
-# occur exactly once AFTER it. For an edit whose target line is byte-identical
-# in several jobs (setup-node in `test` and `install-smoke`), where the job
-# header is the only unique context.
-replace_after() {
-	MUT_FILE="$1" MUT_MARKER="$2" MUT_OLD="$3" MUT_NEW="$4" python3 - <<'PY'
+# replace_re FILE PATTERN REPL -- PATTERN (Python re, MULTILINE) must match
+# exactly once; REPL may use \1 backrefs. For anchors that contain a pinned
+# `uses:` line: the SHA and release comment change on every Dependabot bump,
+# so a literal anchor would refuse (and silently strand the mutant) on the
+# first legitimate update. Match the FORM of the pin, never its value.
+replace_re() {
+	MUT_FILE="$1" MUT_PATTERN="$2" MUT_REPL="$3" python3 - <<'PY'
 import os
 import pathlib
+import re
+import sys
+
+path = pathlib.Path(os.environ["MUT_FILE"])
+text = path.read_text()
+pattern = re.compile(os.environ["MUT_PATTERN"], re.MULTILINE)
+found = len(pattern.findall(text))
+if found != 1:
+    sys.exit(f"regex anchor matched {found} times (expected exactly 1) in {path}:\n{pattern.pattern!r}")
+path.write_text(pattern.sub(os.environ["MUT_REPL"], text, count=1))
+PY
+}
+
+# replace_after_re FILE MARKER PATTERN REPL -- MARKER (literal) exactly once;
+# PATTERN exactly once after it.
+replace_after_re() {
+	MUT_FILE="$1" MUT_MARKER="$2" MUT_PATTERN="$3" MUT_REPL="$4" python3 - <<'PY'
+import os
+import pathlib
+import re
 import sys
 
 path = pathlib.Path(os.environ["MUT_FILE"])
 text = path.read_text()
 marker = os.environ["MUT_MARKER"]
-old = os.environ["MUT_OLD"]
-new = os.environ["MUT_NEW"]
+pattern = re.compile(os.environ["MUT_PATTERN"], re.MULTILINE)
 if text.count(marker) != 1:
     sys.exit(f"marker matched {text.count(marker)} times (expected exactly 1) in {path}:\n{marker!r}")
 head, tail = text.split(marker, 1)
-if tail.count(old) != 1:
-    sys.exit(f"anchor matched {tail.count(old)} times after marker (expected exactly 1) in {path}:\n{old!r}")
-path.write_text(head + marker + tail.replace(old, new, 1))
+found = len(pattern.findall(tail))
+if found != 1:
+    sys.exit(f"regex anchor matched {found} times after marker (expected exactly 1) in {path}:\n{pattern.pattern!r}")
+path.write_text(head + marker + pattern.sub(os.environ["MUT_REPL"], tail, count=1))
+PY
+}
+
+# flip_last_hex FILE PATTERN -- PATTERN (exactly once) must end in a capture
+# group holding a hex SHA; its last digit is changed. Form-valid, wrong commit.
+flip_last_hex() {
+	MUT_FILE="$1" MUT_PATTERN="$2" python3 - <<'PY'
+import os
+import pathlib
+import re
+import sys
+
+path = pathlib.Path(os.environ["MUT_FILE"])
+text = path.read_text()
+pattern = re.compile(os.environ["MUT_PATTERN"], re.MULTILINE)
+matches = list(pattern.finditer(text))
+if len(matches) != 1:
+    sys.exit(f"regex anchor matched {len(matches)} times (expected exactly 1) in {path}:\n{pattern.pattern!r}")
+m = matches[0]
+sha = m.group(1)
+flipped = sha[:-1] + ("4" if sha[-1] != "4" else "5")
+start, end = m.span(1)
+path.write_text(text[:start] + flipped + text[end:])
 PY
 }
 
@@ -256,12 +300,8 @@ continue-on-error-job)
 '
 	;;
 continue-on-error-step)
-	replace "$RELEASE" '      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
-' '      - name: Publish to PyPI
-        continue-on-error: true
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
-'
+	replace_re "$RELEASE" '^(      - name: Publish to PyPI\n)(        uses: pypa/gh-action-pypi-publish@[0-9a-f]{40} # \S+\n)' \
+		'\1        continue-on-error: true\n\2'
 	;;
 if-on-publish-job)
 	replace "$RELEASE" '  publish:
@@ -272,12 +312,8 @@ if-on-publish-job)
 '
 	;;
 if-on-publish-step)
-	replace "$RELEASE" '      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
-' '      - name: Publish to PyPI
-        if: ${{ github.actor != '"'"'nobody'"'"' }}
-        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
-'
+	replace_re "$RELEASE" '^(      - name: Publish to PyPI\n)(        uses: pypa/gh-action-pypi-publish@[0-9a-f]{40} # \S+\n)' \
+		'\1        if: ${{ github.actor != '"'"'nobody'"'"' }}\n\2'
 	;;
 if-on-build-job)
 	replace "$RELEASE" '  build:
@@ -316,8 +352,8 @@ YAML
 forked-action)
 	# Keeps the SHA form and the comment, so the pin invariant passes and only
 	# the exact EXPECTED_USES allowlist can see the owner change.
-	replace "$RELEASE" 'uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2' \
-		'uses: attacker-fork/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2'
+	replace_re "$RELEASE" 'uses: pypa/gh-action-pypi-publish@([0-9a-f]{40} # \S+)' \
+		'uses: attacker-fork/gh-action-pypi-publish@\1'
 	;;
 permissions-job-widened)
 	replace "$RELEASE" '      id-token: write  # Required for trusted publishing
@@ -407,30 +443,26 @@ guard-self-disabled-nonconstant)
 '
 	;;
 tag-pinned-action)
-	replace_after "$TEST_WF" '  install-smoke:
-' '      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-' '      - uses: actions/setup-node@v7
-'
+	replace_after_re "$TEST_WF" '  install-smoke:
+' '- uses: actions/setup-node@[0-9a-f]{40} # \S+' '- uses: actions/setup-node@v7'
 	;;
 sha-comment-dropped)
-	replace "$RELEASE" 'uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1' \
-		'uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a'
+	replace_re "$RELEASE" '(uses: actions/upload-artifact@[0-9a-f]{40}) # \S+' '\1'
 	;;
 sha-moved)
-	replace "$RELEASE" 'uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2' \
-		'uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba34 # v1.14.2'
+	flip_last_hex "$RELEASE" 'uses: pypa/gh-action-pypi-publish@([0-9a-f]{40}) # \S+'
 	;;
 pypa-rolled-back)
-	replace "$RELEASE" 'uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2' \
+	# The rollback TARGET is deliberately literal: v1.9.0's real commit, below
+	# the GHSA-vxmw-7h4f-hqxh floor. The anchor is not.
+	replace_re "$RELEASE" 'uses: pypa/gh-action-pypi-publish@[0-9a-f]{40} # \S+' \
 		'uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0 # v1.9.0'
 	;;
 composite-tag-pinned)
-	replace "$COMPOSITE" 'uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0' \
-		'uses: actions/setup-node@v4'
+	replace_re "$COMPOSITE" 'uses: actions/setup-node@[0-9a-f]{40} # \S+' 'uses: actions/setup-node@v4'
 	;;
 uses-quoted-key)
-	replace "$COMPOSITE" '- uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0' \
-		'- "uses": actions/setup-node@v4'
+	replace_re "$COMPOSITE" '- uses: actions/setup-node@[0-9a-f]{40} # \S+' '- "uses": actions/setup-node@v4'
 	;;
 guard-step-gutted)
 	replace "$TEST_WF" \

--- a/tests/test_workflow_guards.py
+++ b/tests/test_workflow_guards.py
@@ -153,28 +153,32 @@ DRIFT_MUTANTS = (
 )
 
 # Mutants of the FORM of a pin, caught by `all_uses_are_sha_pinned` on raw
-# text. Each is the same edit the shell helper makes, applied to a copy.
+# text. Each is the same edit the shell helper makes, applied to a copy:
+# (file, regex locating the CURRENT pinned line, replacement). Regex, not a
+# literal: the SHA and comment change on every Dependabot bump, and a literal
+# anchor made the first such bump (#219) fail this suite.
+_PIN_RE = r"@[0-9a-f]{40} # \S+"
 PIN_MUTANTS: dict[str, tuple[Path, str, str]] = {
     "tag-pinned-action": (
         TEST_YML,
-        "- uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0",
+        "- uses: actions/setup-node" + _PIN_RE,
         "- uses: actions/setup-node@v7",
     ),
     "sha-comment-dropped": (
         RELEASE_YML,
-        "uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1",
-        "uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+        r"(uses: actions/upload-artifact@[0-9a-f]{40}) # \S+",
+        r"\1",
     ),
     "composite-tag-pinned": (
         REPO_ROOT / ".github" / "actions" / "pipeline-bootstrap-setup" / "action.yml",
-        "uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0",
+        "uses: actions/setup-node" + _PIN_RE,
         "uses: actions/setup-node@v4",
     ),
     # Valid YAML GitHub runs; invisible to the line scan. Only the
     # parsed-inventory cross-check sees it.
     "uses-quoted-key": (
         REPO_ROOT / ".github" / "actions" / "pipeline-bootstrap-setup" / "action.yml",
-        "- uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0",
+        "- uses: actions/setup-node" + _PIN_RE,
         '- "uses": actions/setup-node@v4',
     ),
 }
@@ -422,10 +426,14 @@ class TestShaPinning:
 
     @pytest.mark.parametrize("mutant", sorted(PIN_MUTANTS))
     def test_mutant_is_rejected(self, mutant: str, tmp_path: Path) -> None:
-        source, old, new = PIN_MUTANTS[mutant]
+        source, pattern, repl = PIN_MUTANTS[mutant]
         text = source.read_text()
-        assert text.count(old) >= 1, f"{mutant}: anchor gone from {source.name}"
-        copy_path = _write(tmp_path, source.name, text.replace(old, new))
+        mutated, count = cw.re.subn(pattern, repl, text, count=1)
+        # tag-pinned-action's line is byte-identical in two jobs; the helper
+        # scopes it under `install-smoke:`. Here any one occurrence will do,
+        # but the pattern must still FIND the pin.
+        assert count == 1, f"{mutant}: pin pattern not found in {source.name}"
+        copy_path = _write(tmp_path, source.name, mutated)
         reasons = cw.all_uses_are_sha_pinned([copy_path])
         assert reasons and all(r.startswith("[pin]") for r in reasons), reasons
 
@@ -1054,6 +1062,29 @@ class TestMutationHelperContract:
         # coverage that does not exist.
         rows = {row[0]: row for row in self._rows()}
         assert rows[mutant][1] == "0"
+
+    @pytest.mark.parametrize(
+        ("source", "allowed"),
+        [
+            # The one deliberate literal: the v1.9.0 rollback TARGET.
+            (MUTATE_SH, {"ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0"}),
+            # Same target, plus the synthetic fixture SHA and the all-zeros
+            # placeholder the CI-wiring tests use.
+            (
+                Path(__file__),
+                {"ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0", _SHA, "0" * 40},
+            ),
+        ],
+    )
+    def test_no_pin_anchor_hardcodes_a_real_sha(
+        self, source: Path, allowed: set[str]
+    ) -> None:
+        # #219: the first Dependabot bump of the composite's pin changed the
+        # line two mutants and two tests anchored on by literal, and CI went
+        # red on a correct one-line update. Anchors match the FORM of a pin
+        # (`@<40 hex> # <release>`); only a mutation's *target* may be literal.
+        found = set(cw.re.findall(r"\b[0-9a-f]{40}\b", source.read_text()))
+        assert found <= allowed, sorted(found - allowed)
 
     def test_an_unknown_mutant_name_is_refused(self) -> None:
         result = subprocess.run(


### PR DESCRIPTION
See Consiliency/pmcp#217; unblocks Dependabot PR #219.

#219 — Dependabot's first bump of the composite action's pin (`setup-node` v4.4.0 → v7.0.0, produced by the directory entry #218 added) — failed `test (3.10)`: `composite-tag-pinned` and `uses-quoted-key` in `tests/test_workflow_guards.py`, and the same two mutants plus seven other anchors in `scripts/_mutate_workflow.sh`, hardcoded the literal `@49933ea… # v4.4.0`. Every legitimate pin update would have gone red the same way.

- `scripts/_mutate_workflow.sh`: `replace_re`, `replace_after_re`, `flip_last_hex` — anchors match the **form** of a pin (`@<40 hex> # <release>`), still exactly-once and fail-loud. The only 40-hex literal left is the deliberate v1.9.0 rollback *target*. `replace_after` (literal) removed as dead.
- `tests/test_workflow_guards.py`: `PIN_MUTANTS` locate the current pin by regex; new contract test `test_no_pin_anchor_hardcodes_a_real_sha` fails on today's `main` (helper has 9 literal anchors) and passes here.
- `.consiliency/evidence/mutation-217.md`: matrix re-run on this branch, all 43 rows as expected.

Note (unchanged, by design): `EXPECTED_USES` in `check_workflows.py` still names exact commits for `release.yml`, so a Dependabot bump of any of its five actions fails the `workflows` job until that constant is updated in the same PR — the "spell it twice" rule from #189. With patch-level SHA bumps that will now happen more often than with major-tag bumps.

Local: `tests/test_workflow_guards.py` 194 passed; ruff clean; `check_workflows.py` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NR2LKqZgn7CXVH2816gaa

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790843826&installation_model_id=427051&pr_number=222&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F222&signature=aa9fd4174d0bfa1100b2b8033e5a6f423be598cb17f29cfb32cbbaecfffaf098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->