### PR TITLE
test(runtime): make a hang fail fast with a traceback instead of a 25-minute cancel (see #200)

### DIFF
--- a/.consiliency/evidence/hang-diagnostics-200.md
+++ b/.consiliency/evidence/hang-diagnostics-200.md
@@ -136,6 +136,136 @@ the committed settings, so the dump always precedes the kill and both precede th
 job cap. (`getini` returns a float for one and a string for the other, so an
 `isinstance(..., int)` check would have been invalid either way.)
 
+## The async blind spot, and the watchdog that closes it
+
+Everything above induces a **synchronous** hang (`time.sleep`), where a signal
+traceback names the offending line trivially. The hang this change is actually
+chasing is a **suspended coroutine**, and that is a different problem: a
+suspended coroutine's frames live in `Task` objects, not on any thread stack.
+Both `faulthandler` and `pytest-timeout` dump the *thread* stack. So they name
+nothing.
+
+Reproduced on this branch. A test awaiting an `Event` through a coroutine and an
+async generator, killed by `-o timeout=8 -o timeout_method=signal`, reports this
+and nothing more:
+
+```
+        ready = []
+        try:
+>           fd_event_list = self._selector.poll(timeout, max_ev)
+E           Failed: Timeout (>8.0s) from pytest-timeout.
+
+.../python3.14/selectors.py:452: Failed
+```
+
+`epoll.poll` — the stuck await is invisible. Without a fix, this PR would have
+converted a 25-minute silent cancel into a 700-second failure that **still could
+not tell `_tap()` from `connect_server()` from `disconnect_all()`**, which is the
+one question #200 exists to answer.
+
+`tests/runtime/_hang_watchdog.py` closes it. Same module, same command, with
+`-p tests.runtime._hang_watchdog`:
+
+```
+[async-stacks] test_async_induced.py::test_hangs_inside_an_async_generator has been running 2.0s (threshold 2.0s) -- see Consiliency/pmcp#200
+[async-stacks] 1 pending task(s) on <_UnixSelectorEventLoop running=True closed=False debug=False>:
+--- <Task pending name='Task-2' coro=<test_hangs_inside_an_async_generator() running at .../test_async_induced.py:15> wait_for=<Future pending cb=[Task.task_wakeup()]> ...>
+Stack for <Task pending name='Task-2' ...> (most recent call last):
+  File ".../test_async_induced.py", line 15, in test_hangs_inside_an_async_generator
+    await _drives_the_generator()
+    [await chain] (what print_stack cannot reach):
+      File ".../test_async_induced.py", line 15, in test_hangs_inside_an_async_generator
+        await _drives_the_generator()
+      File ".../test_async_induced.py", line 10, in _drives_the_generator
+        async for _ in _tap_like_generator():
+      File ".../test_async_induced.py", line 5, in _tap_like_generator
+        await asyncio.Event().wait()
+      File ".../python3.14/asyncio/locks.py", line 213, in wait
+        await fut
+      -- suspended on <_asyncio.FutureIter object at 0x75d1e5af82b0>
+```
+
+That is the whole point of the change, in one block: the exact coroutine, the
+exact generator, the exact awaited line.
+
+### Why `Task.print_stack()` alone was not enough
+
+For a **suspended** coroutine `Task.get_stack()` returns a *single* frame — the
+coroutine's own `cr_frame`, whose `f_back` is `None` because a suspended
+coroutine sits on nobody's stack. That is the `Stack for <Task pending ...>`
+section above, and on its own it names `test_hangs_inside_an_async_generator`
+and stops. Everything beneath it is reachable only by walking `cr_await` /
+`ag_await`, which is the `[await chain]` section.
+
+That walk is **required, not a refinement**: the prime suspect is `_tap()` at
+`test_emitter_harness.py:65`, an **async generator** wrapped around the SSE read
+stream. `print_stack()` reports the task that drives such a generator; only the
+`ag_frame`/`ag_await` branch names the generator itself. The mutant therefore
+hangs *through* an async generator and asserts on the generator's own function
+name, so that branch cannot ship as dead code.
+
+One extra hop was needed and is worth recording. `async for x in agen()`
+suspends on an `async_generator_asend`, whose only public attributes are
+`close`/`send`/`throw` — no `ag_frame`, no `ag_await` — so the walk dead-ended
+one hop short of the generator, printing `-- suspended on
+<async_generator_asend object>`. Probed directly: `gc.get_referents()` on that
+object returns exactly `[async_generator]`. `_step_through_opaque()` takes that
+single hop, narrowly (first referent carrying a coroutine/generator frame) and
+fully guarded.
+
+### Both directions
+
+| run | result |
+|---|---|
+| with `-p tests.runtime._hang_watchdog` | timeout fires, `[async-stacks]` present, chain names `_drives_the_generator` **and** `_tap_like_generator` |
+| without it | timeout fires, `[async-stacks]` absent, traceback ends at the selector, `_tap_like_generator` nowhere in the output |
+
+The negative run still *fails* — this is not "nothing happened" — it simply
+cannot say where. Asserted in
+`test_without_the_watchdog_an_async_hang_names_only_the_selector`.
+
+The subprocess proofs certify the plugin's logic but not the wiring, so
+`test_the_watchdog_is_wired_into_this_package` asserts, inside a normal run,
+that `pytest_runtest_logstart` recorded *this* item's nodeid and that the autouse
+async fixture handed the watchdog `asyncio.get_running_loop()`.
+
+### Design constraints, and why
+
+- **The loop must come from `asyncio.get_running_loop()` in an async fixture.**
+  A watchdog thread cannot reach a running loop on its own, and
+  `get_event_loop_policy().get_event_loop()` from a sync fixture raises
+  `RuntimeError('no running event loop')`. An autouse *async* fixture is safe
+  for this package's sync tests too — under `asyncio_mode = "auto"` they get a
+  loop as well; verified against a mixed sync/async module before relying on it.
+- **One session daemon thread, not a `threading.Timer` per test.** `Timer.start()`
+  spawns a thread; per-item would be ~3400 thread creations across the suite. The
+  thread starts lazily at the first `pytest_runtest_logstart`, so `--collect-only`
+  spawns nothing.
+- **Armed from `logstart`, cleared at `logfinish`**, so the window covers setup,
+  call **and teardown**. Teardown coverage is the point, for the same reason it
+  was for `timeout_method`.
+- **It can never fail.** Every path swallows; the worst case is silence. A
+  watchdog that can raise turns a diagnosable hang into a confusing error.
+  `asyncio.all_tasks()` snapshots a WeakSet the loop is mutating, so from another
+  thread it can raise `RuntimeError: Set changed size during iteration` — retried,
+  then abandoned quietly.
+- **60 s, strictly below `faulthandler_timeout = 120`**, so async stacks land
+  before the thread dump and long before the 700 s kill.
+
+### Scope: `tests/runtime/`, not `tests/`
+
+Registered in `tests/runtime/conftest.py`. Three reasons, one of them decisive:
+
+1. All five CI stalls happened in this package.
+2. The slowest item here is **26.16 s** against a 60 s threshold — >2× headroom.
+3. Decisive: at `tests/` scope the two progressive-disclosure tests at **60.22 s
+   and 60.25 s** sit right on the threshold and would trip a spurious dump on
+   essentially every run. A diagnostic that cries wolf every run is worse than
+   none, and lowering its value to fit them would forfeit the headroom in 1–2.
+
+A run of the whole package with the watchdog live produced **zero** dumps
+(`grep -c "async-stacks"` → 0 over `69 passed in 123.43s`).
+
 ## The two `run_fake_remote` mutants
 
 On unchanged `main`, `run_fake_remote`'s `finally` is `server.should_exit = True;

--- a/.consiliency/evidence/hang-diagnostics-200.md
+++ b/.consiliency/evidence/hang-diagnostics-200.md
@@ -1,0 +1,285 @@
+# Hang-diagnostics evidence — Consiliency/pmcp#200 (stage 1)
+
+Five `test (3.x)` jobs in the week to 2026-09-01 stalled inside
+`tests/runtime/test_emitter_harness.py` and were killed by the job's
+`timeout-minutes: 25`. GitHub reports a timed-out job as **cancelled**, not
+failed, so not one of them produced a red X, a traceback, or a single line of
+evidence about which await was stuck.
+
+This change ships **diagnostics only**. It does not fix the hang; the root cause
+is still unknown and a fix chosen now would be a guess frozen into the suite.
+Stage 2 begins when an occurrence produces the traceback this change exists to
+capture.
+
+"The suite no longer hangs" passes on unchanged `main`, so it is not a
+criterion. Every proof below induces a hang deterministically and asserts the
+diagnostic fires, mutant-style (`mutation-217.md`).
+
+All runs: worktree `pmcp-sse-hang`, branch `fix/200-sse-hang-diagnostics`, base
+`origin/main` @ `d743bc4`, Python 3.14.7, pytest 9.0.2, pytest-timeout 2.4.0,
+sse_starlette 3.1.1, on 2026-09-02.
+
+## The measurement behind the two numbers
+
+`uv run pytest tests/ -q --durations=25`, full suite, this worktree, **before**
+any change (the tree differed from `origin/main` only by the plan document):
+
+```
+60.25s call  tests/test_progressive_disclosure.py::TestScenario8_LibraryConcepts::test_invoke_query_docs_conceptual
+60.22s call  tests/test_progressive_disclosure.py::TestScenario7_LibraryDocumentation::test_invoke_query_docs
+26.16s call  tests/runtime/test_emitter_harness.py::TestRemoteEmitterReachesDispatch::test_emit_alone_reaches_read_sse
+18.48s call  tests/runtime/test_subscriptions_e2e.py::test_connect_disconnect_refresh_each_deliver_all_three_kinds
+10.11s call  tests/test_server_lifecycle.py::TestGatewayServerShutdown::test_shutdown_handles_timeout
+```
+
+Slowest non-`live` item: **60.25 s**. Both 60 s items land on almost exactly
+60 s, which looks like an internal timeout rather than real work — noted, not in
+scope. The third entry is worth recording: the file that hangs in CI is also the
+third-slowest locally, at 26 s, which is consistent with a timing-sensitive path
+rather than a deterministic deadlock.
+
+Chosen and committed:
+
+| setting | value | derivation |
+|---|---|---|
+| `faulthandler_timeout` | 120 | 2× the slowest (60.25 s) |
+| `timeout` | 700 | ≥10× the slowest (10 × 60.25 = **602.5**) |
+| `timeout_method` | `signal` | selected empirically, below |
+
+**Deviation from the plan, stated deliberately.** The plan names `timeout = 600`
+and *also* requires "the chosen `timeout` is ≥ 10× the slowest non-`live` test as
+measured by `--durations=25` **in this change**". With the slowest at 60.25 s
+those two clauses cannot both hold: 600 is 9.96×. (The plan's own figure, 60.06 s,
+already made 10× = 600.6 > 600, so the arithmetic was off in the plan too.) The
+acceptance criterion wins; 700 s satisfies it, keeps the dump ~9.7 minutes ahead
+of the kill, and still sits far inside `timeout-minutes: 25`.
+
+## `timeout_method`: selected, not assumed
+
+The likeliest hang site is **after** the last `PASSED` line — pytest prints
+`PASSED` when the test function returns, *before* teardown, and with
+`asyncio_mode = "auto"` pytest-asyncio then tears the loop down (cancels
+lingering tasks, `shutdown_asyncgens`). The `_tap()` spy at
+`test_emitter_harness.py:65` is itself an async generator wrapped around the SSE
+read stream, so the just-passed test's teardown is a live candidate and a method
+that does not cover teardown is worthless here.
+
+Both settings are passed with `-o` because the temp test file makes the temp
+directory the rootdir, so the project's `[tool.pytest.ini_options]` never loads —
+a bare `--timeout=3` would have certified Linux's default while CI ran another.
+
+The induced module:
+
+```python
+@pytest.fixture
+def blocks_on_the_way_out():
+    yield
+    time.sleep(30)          # hangs in TEARDOWN, after PASSED is printed
+
+def test_passes_then_hangs_in_teardown(blocks_on_the_way_out):
+    assert True
+```
+
+```
+$ python -m pytest test_induced.py -p no:cacheprovider -o timeout=3 -o timeout_method=signal -q
+___________ ERROR at teardown of test_passes_then_hangs_in_teardown ____________
+    @pytest.fixture
+    def blocks_on_the_way_out():
+        yield
+>       time.sleep(30)
+E       Failed: Timeout (>3.0s) from pytest-timeout.
+1 passed, 1 error in 3.02s
+EXIT=1  elapsed=3.37s
+
+$ python -m pytest test_induced.py -p no:cacheprovider -o timeout=3 -o timeout_method=thread -q
+  File ".../_pytest/fixtures.py", line 924, in _teardown_yield_fixture
+    next(it)
+  File ".../test_induced.py", line 9, in blocks_on_the_way_out
+    time.sleep(30)
++++++++++++++++++++++++++++++++++++ Timeout ++++++++++++++++++++++++++++++++++++
+EXIT=1  elapsed=3.26s          # no summary line -- os._exit killed the session
+```
+
+**Both** methods cover teardown, so the plan's fallback ("if the teardown test
+passes only under `thread`, say so and accept it") was not needed. `signal` is
+selected because it is strictly better on the axis that separates them: it
+reports a normal pytest ERROR with the offending frame **and the session
+continues to a summary**, whereas `thread` hard-exits the process mid-report and
+loses the rest of the run. The plan was willing to trade the tail away; it does
+not have to be.
+
+The negative half, proving the kill above came from the plugin and not from
+anything else in the environment — same module, `-p no:timeout`, no `-o timeout`
+overrides (those options do not exist once the plugin is gone, and an unknown-ini
+error would have exited fast and satisfied nothing):
+
+```
+$ timeout 10 python -m pytest test_induced.py -p no:cacheprovider -p no:timeout -q
+.
+EXIT=124  elapsed=10.01s        # 124 == still running when killed at 10 s
+```
+
+The `.` is the test passing; the process then sat in teardown until killed.
+
+## `faulthandler`: it dumps, and the run continues
+
+The zero-risk half. A subprocess with `-o faulthandler_timeout=2 -o timeout=30`,
+a 5 s blocking item and a sentinel item after it: the dump fires, the blocking
+item still completes, the sentinel still runs, and pytest exits **0**. Asserted
+in `test_faulthandler_dumps_a_stack_and_the_run_continues` on `Thread 0x`,
+`Timeout (0:00:02)`, `2 passed`, and `returncode == 0`. Reading the ini value —
+which is all the first revision of this plan proposed — could not have proven
+either the dump or the continuation.
+
+Separately, `float(faulthandler_timeout) < float(timeout) < 25*60` is asserted on
+the committed settings, so the dump always precedes the kill and both precede the
+job cap. (`getini` returns a float for one and a string for the other, so an
+`isinstance(..., int)` check would have been invalid either way.)
+
+## The two `run_fake_remote` mutants
+
+On unchanged `main`, `run_fake_remote`'s `finally` is `server.should_exit = True;
+await task` — unbounded. uvicorn's graceful drain here is unbounded too
+(`uvicorn.Config` is constructed without `timeout_graceful_shutdown`), so that
+`await` is one of only three unbounded awaits the harness has.
+
+The replacement is **not** `asyncio.wait_for`. `wait_for` cancels the task and
+then waits for the cancellation to *finish*, so a `serve()` that swallows
+`CancelledError` hangs it exactly as hard as the bare `await`. Confirmed
+empirically while writing the plan: such a coroutine survived `wait_for`, an
+outer `wait_for` guard, **and** `asyncio.run`'s own shutdown; the probe had to be
+killed. The shipped form uses `asyncio.wait({task}, timeout=…)`, which reports a
+pending task instead of awaiting it, and raises whether or not the cancel took.
+
+| mutant | `serve()` behaviour | on `main` | with this change |
+|---|---|---|---|
+| `_NeverStops` | never returns, honours cancel | hangs forever | raises, names the port and state |
+| `_SwallowsCancellation` | catches `CancelledError`, keeps running | hangs forever | raises, and reports **`SURVIVED cancellation`** |
+
+The second mutant is the one that matters: a `wait_for`-based implementation
+passes the first and hangs on the second, and without this case the wrapper can
+be written wrongly and look correct.
+
+Whether the task survived cancellation is the single most valuable fact for
+stage 2, and **no stack dump reports it** — an idle loop parked in `epoll.poll()`
+names nothing. So the message carries it explicitly, alongside the port,
+`server.started`, `server.should_exit` and `AppStatus.should_exit`:
+
+Both messages, as actually printed by driving each mutant through
+`run_fake_remote` directly:
+
+```
+--- mutant 1: serve() never returns (elapsed 10.07s) ---
+fake remote on port 44427 did not stop within 10.0s of should_exit=True; the serve() task ended only once cancelled [server.started=True server.should_exit=True AppStatus.should_exit=False] -- see Consiliency/pmcp#200
+AppStatus.should_exit after the raise: False
+--- mutant 2: serve() swallows CancelledError (elapsed 15.07s) ---
+fake remote on port 57711 did not stop within 10.0s of should_exit=True; the serve() task SURVIVED cancellation after 5.0s and is now orphaned [server.started=True server.should_exit=True AppStatus.should_exit=False] -- see Consiliency/pmcp#200
+AppStatus.should_exit after the raise: False
+```
+
+The elapsed times are the bound working: 10.07 s when the cancel lands
+(`SERVE_STOP_TIMEOUT`), 15.07 s when it does not (`+ CANCEL_GRACE`). Both are
+inside the acceptance bound of 2 × (10 + 5) = 30 s. On unchanged `main` both are
+unbounded.
+
+Both mutant tests also assert `AppStatus.should_exit is False` after the raise.
+That is not decoration: the reset used to sit *after* `await task`, so the new
+diagnostic raise would have skipped it and poisoned the next test with the very
+latch this harness exists to clear. It now lives in a nested unconditional
+`finally`.
+
+Each mutant is bounded twice — by the stop sequence itself, and by an outer
+`asyncio.wait` guard in the test — so a regression in either fails this file
+rather than hanging it. The cancellation-swallowing orphan is retired through an
+escape `asyncio.Event` in the test's `finally`, because pytest-asyncio's loop
+teardown cancels and *gathers* lingering tasks and would otherwise hang on the
+one task in the suite that ignores a cancel.
+
+```
+$ uv run pytest -q tests/runtime/test_hang_diagnostics.py
+6 passed in 43.89s
+EXIT=0
+```
+
+## Counts, before and after
+
+Same command from the same directory, before and after, as the plan requires.
+From this worktree ~107 tests in `test_version_checker.py`, `test_npm_resolver.py`
+and `test_tools.py` fail for an unrelated host reason: `/tmp/package.json` exists
+here and the npm identity resolver's `localPrefix` walk finds it (documented in
+`tests/conftest.py`). That is a host quirk, not a regression, and it is identical
+on both sides of the change.
+
+| `uv run pytest tests/ -q --durations=25` | before | after |
+|---|---|---|
+| failed | 107 | 107 |
+| passed | 3173 | 3179 |
+| skipped | 3 | 3 |
+| deselected | 25 | 25 |
+| errors | 106 | 106 |
+
+The two summary lines, verbatim:
+
+```
+before: 107 failed, 3173 passed, 3 skipped, 25 deselected, 106 errors in 349.49s (0:05:49)   EXIT=1
+after:  107 failed, 3179 passed, 3 skipped, 25 deselected, 106 errors in 369.69s (0:06:09)   EXIT=1
+```
+
+Passes increase by exactly **6**, the number of new tests. Failures, skips,
+deselections and errors are unchanged. Exit 1 on both sides is the
+`/tmp/package.json` host quirk, not this change.
+
+```
+$ uv run pytest --collect-only -q tests/
+before: 3389/3414 tests collected (25 deselected)
+after:  3395/3420 tests collected (25 deselected)
+```
+
++6 collected, +6 total, the `live` set unchanged at 25 deselected.
+
+**Second deviation from the plan, stated deliberately.** The plan's first
+acceptance criterion asks for "**19 deselected** … total collected = main's
+**1019** plus the new tests". Those figures are rev-1 residue and contradict the
+plan's own research section, which records "3386 passed, 3 skipped, **25
+deselected**". Measured on the unmodified tree: 3389/3414 with 25 deselected. The
+criterion's *structure* — deselected unchanged, collected up by exactly the new
+tests — is satisfied against the real baseline.
+
+## The rest of the verification block
+
+```
+$ uv run pytest -q tests/runtime
+66 passed in 107.99s                      EXIT=0    # 60 pre-existing + 6 new
+$ uv run ruff check src/ tests/ scripts/
+All checks passed!                        EXIT=0
+$ uv run ruff format --check src/ tests/ scripts/
+129 files already formatted               EXIT=0
+$ uv run mypy src/
+Success: no issues found in 43 source files   EXIT=0
+$ uv run python scripts/check_workflows.py --base-ref origin/main
+workflow guards: OK                       EXIT=0
+$ git diff --name-only origin/main..HEAD -- src/
+(empty)
+```
+
+No file under `src/` is modified. This is a diagnostics change; any production
+timeout — a bound on `ClientManager.connect_server`, for instance — is a stage-2
+decision with its own blast radius.
+
+## Correction to the record
+
+`AppStatus` in the installed **sse_starlette 3.1.1** is exactly
+`{should_exit, original_handler, handle_exit}`. There is **no
+`should_exit_event`**, so the fix floated in #200's early comment ("reset
+`AppStatus.should_exit_event = None`") cannot be written as stated. 3.1.1 keeps a
+per-event-loop `_ShutdownState` in a `contextvars.ContextVar`, and
+`_get_uvicorn_server()` reads `signal.getsignal(signal.SIGTERM).__self__` and
+polls *that* object's `should_exit`.
+
+Two consequences follow, both plausible and **neither verified**: a stale SIGTERM
+handler left by an earlier uvicorn server can make a later loop's watcher see
+`should_exit == True`, and a `_ShutdownState` registered on one loop is never
+signalled by a watcher on another. That they are unverified is precisely why this
+change instruments rather than fixes. The stale comments in `fake_remote.py` and
+`test_downstream_remote.py` are corrected in this change; the reset itself
+remains correct and necessary.

--- a/.consiliency/plans/detailed-sse-hang-diagnostics-20260902-1030.md
+++ b/.consiliency/plans/detailed-sse-hang-diagnostics-20260902-1030.md
@@ -1,5 +1,29 @@
 # Detailed plan: make the intermittent runtime-test hang fail fast with a traceback
 
+> **Revision 2 (2026-09-02).** Rev 1 boarded 2 DISAGREE / 1 AGREE. Five real
+> defects, fixed below; one seat claim checked and **rejected**.
+> (1) **`asyncio.wait_for` does not bound a cancellation-resistant task** — it
+> cancels, then *waits for the cancellation to finish*. Confirmed empirically:
+> a coroutine that catches `CancelledError` and continues survived
+> `wait_for`, an outer `wait_for` guard, **and** `asyncio.run`'s shutdown; the
+> probe had to be killed. So rev 1's fail-fast wrapper could itself hang, and
+> `timeout_method = "thread"` would then `os._exit` the whole run instead of
+> printing the diagnostic. (2) The count freezes contradicted the three new
+> tests they were meant to coexist with. (3) The faulthandler criterion demanded
+> a stack dump plus continuation; the planned test only read the ini value.
+> (4) The teardown subprocess would take the **temp dir** as rootdir, so the
+> project's `timeout_method` would never load and the loop could certify a
+> method CI does not use. (5) `config.getini()` returns a float while
+> `[tool.pytest.ini_options]` scalars load as strings, so `isinstance(v, int)`
+> is invalid.
+>
+> **Rejected, with evidence:** one seat reported that 3.1.1 holds `_ShutdownState`
+> in `threading.local()` rather than a `ContextVar`, and that the plan's research
+> replaces "one stale story with another". Checked in both venvs
+> (`/home/viperjuice/code/pmcp`, py 3.10.12 — and this worktree, py 3.14.7): both
+> resolve **sse_starlette 3.1.1**, and in both, `sse.py` contains `ContextVar`
+> and **no** `threading.local`. The research below stands as written.
+
 ## Task
 
 Close the diagnostic half of Consiliency/pmcp#200. Five `test (3.x)` jobs in the
@@ -106,13 +130,35 @@ touches none.
 
 ### `tests/runtime/fake_remote.py` (modify)
 
-- `run_fake_remote`'s `finally` — modify — wrap `await task` in
-  `asyncio.wait_for(..., timeout=<N>)`; on `TimeoutError`, cancel the task, await
-  it suppressing `CancelledError`, and **raise** with a message naming the port,
-  the server's `started`/`should_exit` state, and `AppStatus.should_exit`. This
-  is the single most likely hang site and the one a stack dump describes worst
-  (an idle loop in `epoll.poll()` names nothing). `AppStatus.should_exit = False`
-  on both entry and exit stays exactly as it is.
+- `run_fake_remote`'s `finally` — modify — bound the wait for the server task.
+  **Not `asyncio.wait_for`**: it cancels and then waits for the cancellation to
+  complete, so a coroutine that swallows `CancelledError` hangs it exactly as
+  hard as the original `await`. **WAS WRONG (rev 1).** Use the form that never
+  awaits a pending task indefinitely:
+
+  ```python
+  done, pending = await asyncio.wait({task}, timeout=SERVE_STOP_TIMEOUT)
+  if pending:
+      task.cancel()
+      done, pending = await asyncio.wait({task}, timeout=CANCEL_GRACE)
+  ```
+
+  then **raise regardless of whether `pending` is still non-empty**, leaving the
+  task orphaned and saying so in the message. The message names the port, the
+  server's `started` / `should_exit`, `AppStatus.should_exit`, and whether the
+  task survived cancellation — that last fact is the single most valuable bit
+  for stage 2, and no stack dump reports it (an idle loop in `epoll.poll()`
+  names nothing).
+  Pick `SERVE_STOP_TIMEOUT` = 10 s and `CANCEL_GRACE` = 5 s: uvicorn's graceful
+  drain here is unbounded (`uvicorn.Config` is constructed without
+  `timeout_graceful_shutdown`, `fake_remote.py:224-226`), and a healthy stop in
+  this harness is sub-second — 10 s is ~20× the observed cost, far below any
+  pytest-level timeout.
+- `AppStatus.should_exit = False` — modify — move into a **nested unconditional
+  `finally`** around the whole stop sequence. **WAS WRONG (rev 1):** "stays
+  exactly as it is" — it currently sits *after* `await task` (`:266`), so the new
+  diagnostic raise would skip it and poison the next test with the very latch
+  this harness exists to clear.
 - The comment block at `:259-266` — modify — correct it to the 3.1.1 mechanism
   (`_ShutdownState` contextvar + `_get_uvicorn_server()` SIGTERM introspection;
   no `should_exit_event`). State that the reset remains correct and necessary,
@@ -133,17 +179,39 @@ The acceptance proof. "The suite no longer hangs" **passes on unchanged `main`**
 diagnostics fire, mutant-style, as in `.consiliency/evidence/mutation-217.md`:
 
 - `test_a_server_task_that_never_finishes_raises_instead_of_hanging` — patch the
-  server object so `serve()` never returns; assert `run_fake_remote`'s exit
-  raises within ~2× the wait, with the diagnostic message, rather than hanging.
-- `test_the_timeout_plugin_is_active_and_covers_teardown` — a subprocess pytest
-  run (`--timeout=3`) over a temp file whose **fixture teardown** sleeps 30 s;
-  assert it exits non-zero within ~15 s and the output names the timeout.
-  **This is the one that must be verified empirically, not assumed**: if the
-  chosen `timeout_method` does not cover teardown, the plugin cannot catch the
-  most likely hang site and the setting must change until this test passes.
-- `test_faulthandler_timeout_is_configured` — read the resolved ini value; assert
-  it is an int, ≥ 60, and **strictly less than** the `timeout` value, so the
-  stack dump always lands *before* the kill. A dump after the kill is useless.
+  server so `serve()` never returns; assert `run_fake_remote`'s exit raises with
+  the diagnostic within ~2× `(SERVE_STOP_TIMEOUT + CANCEL_GRACE)`.
+- `test_a_serve_task_that_swallows_cancellation_still_raises` — the **mutant rev
+  1 would have failed**: `serve()` catches `CancelledError` and keeps running.
+  Same bound, same assertion. Without this case the wrapper can be written with
+  `wait_for` and look correct. Guard the whole test with an outer bound so a
+  regression here fails rather than hangs the file.
+- `test_the_timeout_plugin_is_active_and_covers_teardown` — a **subprocess**
+  pytest run over a temp file whose **fixture teardown** sleeps 30 s. Pass the
+  settings explicitly — `-o timeout=3 -o timeout_method=<the project's value>` —
+  because the temp file makes the temp dir the rootdir and the project's
+  `[tool.pytest.ini_options]` would never load. **WAS WRONG (rev 1):** a bare
+  `--timeout=3` would have certified Linux's default `signal` method while CI
+  ran another. Assert non-zero exit within ~15 s, and bound the subprocess with
+  `timeout=` so a failure is a failure, not a hang.
+  **This must be verified empirically, not assumed**: if the chosen method does
+  not cover teardown, it cannot catch the most likely hang site and the setting
+  changes until this passes.
+- `test_a_teardown_hang_is_not_caught_without_the_plugin` — the negative half:
+  the same subprocess with `-p no:timeout`, asserting it does **not** finish
+  within ~10 s (then killing it). Proves the positive result came from the
+  plugin and not from something else in the environment.
+- `test_faulthandler_dumps_a_stack_and_the_run_continues` — a subprocess with a
+  short `-o faulthandler_timeout=2`, a larger `-o timeout=30`, one blocking item
+  and a **sentinel test after it**; assert the output contains the faulthandler
+  header (`Thread 0x`), that the sentinel ran, and that pytest exited normally.
+  **WAS WRONG (rev 1):** the planned test only read the ini values, which cannot
+  prove either the dump or the continuation the criterion claims.
+- `test_faulthandler_timeout_is_below_the_kill_timeout` — compare the two
+  resolved settings **numerically**, via `float(...)` on both. **WAS WRONG (rev
+  1):** `isinstance(value, int)` — `config.getini()` returns a float for this
+  option and `[tool.pytest.ini_options]` scalars load as strings, so that
+  assertion is invalid either way.
 
 ### `.consiliency/evidence/hang-diagnostics-200.md` (create)
 
@@ -190,8 +258,9 @@ uv run python scripts/check_workflows.py --base-ref origin/main   # untouched, m
 ```
 
 Edge cases: a legitimately slow test near the threshold (the measurement exists
-to avoid this); `timeout_method = "thread"` terminates the whole process, losing
-the rest of the run — if the teardown-coverage test passes only under `thread`,
+to avoid this); a coroutine that survives cancellation, which is why the stop
+sequence raises even with the task still pending; `timeout_method = "thread"`
+terminates the whole process, losing the rest of the run — if the teardown-coverage test passes only under `thread`,
 say so explicitly in the evidence and accept it, because a lost tail is strictly
 better than a 25-minute cancel; the `live`-marked `timeout(130)` marker becoming
 active (deselected by default — assert that `-m 'not live'` collection is
@@ -200,25 +269,39 @@ unchanged at 1000/1019).
 ## Acceptance criteria
 
 - [ ] `pytest-timeout` is installed via `pyproject.toml` + `uv.lock`, and
-      `uv run pytest --collect-only -q tests/` still reports **1000/1019
-      collected (19 deselected)** — the marker activation changes nothing that
-      runs by default.
-- [ ] A fixture whose **teardown** blocks for 30 s is killed by the plugin in
-      under ~15 s with a non-zero exit and a message naming the timeout —
-      **proven in a subprocess run, and proven to hang without the plugin**
-      (`-p no:timeout`). Teardown coverage is the whole point: the most likely
-      hang site is after `PASSED` is printed.
-- [ ] `faulthandler_timeout` is set, is strictly less than `timeout`, and a test
-      that blocks longer than it emits a `Thread 0x…` stack dump into the run
-      output while the run continues.
-- [ ] `run_fake_remote` with a `serve()` that never returns **raises within
-      ~2×N seconds** naming port, server state and `AppStatus.should_exit` —
-      where on unchanged `main` the same scenario hangs indefinitely.
+      `uv run pytest --collect-only -q tests/` reports **19 deselected**, the
+      same `live` set as `main`, with total collected = main's 1019 **plus** the
+      new tests. **WAS WRONG (rev 1):** it froze the total at 1000/1019 while
+      this same plan adds default-collected tests — an executor obeying it
+      literally would have deleted the proofs.
+- [ ] A fixture whose **teardown** blocks for 30 s is killed in under ~15 s with
+      a non-zero exit naming the timeout, in a subprocess given the project's
+      `timeout` **and** `timeout_method` explicitly via `-o`; and the same run
+      with `-p no:timeout` does **not** finish in ~10 s. Both directions.
+      Teardown coverage is the whole point: the likeliest hang site is after
+      `PASSED` is printed.
+- [ ] A subprocess run with a short `faulthandler_timeout` and a blocking item
+      emits a `Thread 0x…` dump, **the sentinel test after it still runs**, and
+      pytest exits normally — the dump does not end the session. Separately,
+      `float(faulthandler_timeout) < float(timeout)` on the committed settings,
+      so the dump always precedes the kill.
+- [ ] `run_fake_remote` raises within ~2×(`SERVE_STOP_TIMEOUT` + `CANCEL_GRACE`)
+      naming port, server state, `AppStatus.should_exit`, and whether the task
+      survived cancellation — in **both** mutants: a `serve()` that never
+      returns, **and one that swallows `CancelledError`**. On unchanged `main`
+      both hang indefinitely; a `wait_for`-based implementation passes the first
+      and hangs on the second.
+- [ ] `AppStatus.should_exit` is `False` after that diagnostic raise — asserted
+      in the mutant tests, because the reset now has to survive an exception on
+      the path that used to reach it only on success.
 - [ ] The chosen `timeout` is ≥ 10× the slowest non-`live` test as measured by
       `--durations=25` in this change, and the measured value is recorded in the
       evidence file.
-- [ ] `tests/runtime` still reports **60 passed**, and the full suite's
-      pass/skip/deselect counts are unchanged from `main`.
+- [ ] The 60 pre-existing `tests/runtime` tests still pass (the directory now
+      reports 60 + the new file's count), and the full suite's failures and
+      skips are unchanged from `main` — passes increase by exactly the number of
+      new tests. **WAS WRONG (rev 1):** "counts unchanged", which this plan's
+      own additions make unsatisfiable.
 - [ ] No file under `src/` is modified (`git diff --name-only origin/main…HEAD |
       grep '^src/'` is empty) — this is a diagnostics change; any production
       timeout is stage 2 and a separate decision.

--- a/.consiliency/plans/detailed-sse-hang-diagnostics-20260902-1030.md
+++ b/.consiliency/plans/detailed-sse-hang-diagnostics-20260902-1030.md
@@ -1,0 +1,238 @@
+# Detailed plan: make the intermittent runtime-test hang fail fast with a traceback
+
+## Task
+
+Close the diagnostic half of Consiliency/pmcp#200. Five `test (3.x)` jobs in the
+last week stalled inside `tests/runtime/test_emitter_harness.py` and were killed
+by `timeout-minutes: 25`. GitHub reports a timed-out job as **cancelled**, not
+failed, so the flake has never produced a red X, a traceback, or a single line of
+evidence about *which await* is stuck.
+
+**This plan ships stage 1 only: turn a 25-minute silent cancel into a fast
+failure that names the stuck await.** It does **not** fix the root cause. The
+root cause is not known, and a fix chosen now would be a guess frozen into the
+suite — the failure class this repo has hit repeatedly (see rev 2 of
+`detailed-sha-pin-actions`, and #200's own first close). Stage 2 is filed as a
+follow-up and starts when an occurrence produces the traceback this change
+exists to capture.
+
+## Research summary
+
+Verified in this worktree and against the installed environment on 2026-09-02.
+
+**The five stalls, from the CI logs.** Every timed-out job's last `PASSED` line
+is in `TestRemoteEmitterReachesDispatch`, at ~3% of the suite, followed by ~24
+minutes of silence and `Terminate orphan process: pid (…) (pytest)`:
+
+| run | date | job | last PASSED |
+|---|---|---|---|
+| 32930058835 | 08-26 | test (3.11) | `test_add_tool_then_emit_reaches_read_sse` |
+| 33240369148 | 08-29 | test (3.10) | `test_unrecognised_method_reaches_read_sse` |
+| 33270684206 | 08-29 | test (3.10) | `test_unrecognised_method_reaches_read_sse` |
+| 33343639560 | 08-31 | test (3.11) | `test_add_tool_then_emit_reaches_read_sse` |
+| 33532264811 | 09-01 | test (3.12) | `test_unrecognised_method_reaches_read_sse` |
+
+**"The next test hangs" is an inference, not a finding.** pytest prints `PASSED`
+when the test function returns — *before* teardown. With `asyncio_mode = "auto"`,
+pytest-asyncio then tears the loop down (cancels lingering tasks,
+`shutdown_asyncgens`). An async generator that ignores cancellation hangs
+*there*, and the log is indistinguishable from "the next test hung". The spy in
+`test_emitter_harness.py:65` (`_tap()`) is itself an async generator wrapped
+around the SSE read stream, so the just-passed test's teardown is a live
+candidate. **Any instrumentation that only covers test bodies can miss this.**
+
+**Where a hang can live at all.** The four `TestRemoteEmitterReachesDispatch`
+bodies poll with `for _ in range(50): await asyncio.sleep(0.05)` — **bounded at
+2.5 s**, so the poll is not it. The unbounded awaits are exactly three:
+`manager.connect_server(...)`, `manager.disconnect_all()` (in `finally`), and
+**`await task` in `run_fake_remote`'s `finally`** (`tests/runtime/fake_remote.py`,
+around line 258) — where uvicorn's `serve()` may never return if a response
+generator never finishes. Plus the pytest-asyncio teardown above.
+
+**The `sse_starlette` mechanism has changed, and #200's own comment is stale.**
+The installed version is **3.1.1**. `AppStatus` has **no `should_exit_event`** —
+`vars(AppStatus)` is `{should_exit: False, original_handler, handle_exit}`. The
+shutdown path is now (a) a per-event-loop `_ShutdownState` held in a
+`contextvars.ContextVar`, and (b) `_get_uvicorn_server()`, which reads
+`signal.getsignal(signal.SIGTERM).__self__` and polls **that** object's
+`should_exit`. So the fix suggested in my #200 comment ("reset
+`AppStatus.should_exit_event = None`") **cannot be implemented as written**, and
+the module comments in `fake_remote.py:259-266` and `test_downstream_remote.py:37`
+describe an older version's mechanism. Two consequences: a stale SIGTERM handler
+left by an earlier uvicorn server can make a *later* loop's watcher see
+`should_exit == True`; and the per-loop `_ShutdownState` means an event
+registered on one loop is never signalled by a watcher on another. Both are
+*plausible* paths to a stuck stream — **neither is verified**, which is precisely
+why this plan instruments rather than fixes.
+
+**No local reproduction.** `tests/mcp2x` + `test_emitter_harness.py` in one
+process: **107 passed, 3/3 runs**, ~17 s each. A full-suite run with coverage and
+`faulthandler_timeout=120` is running as this plan is written; the plan assumes it
+also passes. Absence of a local repro is expected for a timing-dependent flake
+and is not evidence against it.
+
+**Tooling facts.** pytest is **9.0.2**; `faulthandler_timeout` /
+`faulthandler_exit_on_timeout` are **built-in ini options** (no dependency).
+`pytest_timeout` is **not installed**, so the `timeout` marker declared in
+`pyproject.toml:146` and applied at `tests/test_manifest_provision.py:283` is
+**inert today**; installing the plugin activates it — that test sits inside
+`@pytest.mark.live` (`:256`), which `addopts = "-m 'not live'"` deselects, so
+default and CI runs are unaffected. CI runs
+`uv run pytest tests/ -v --tb=short --cov …` (`.github/workflows/test.yml:54`).
+The `changelog` job requires an entry only for `src/` changes; this change
+touches none.
+
+## Changes
+
+### `pyproject.toml` (modify)
+
+- `[tool.pytest.ini_options]` — add `faulthandler_timeout` — dump every thread's
+  stack when a single test item exceeds the threshold **and let the run
+  continue**. This is the zero-risk half: it kills nothing, and on the next CI
+  hit it prints the stack of the stuck await into the job log. Set in the ini
+  file, not the CI command line, so a local run behaves like CI.
+- `[tool.pytest.ini_options]` — add `timeout` and `timeout_method = "thread"` —
+  the fail-fast half, via `pytest-timeout`. **Choose the value from a
+  measurement, not a guess**: run `--durations=25` on the full suite and set the
+  timeout to roughly 10× the slowest non-`live` test, floor 120 s. Record the
+  measured slowest test and the chosen number in a comment on the setting.
+- `[dependency-groups] dev` (or the existing test extra — match where
+  `pytest-cov` lives, around `:109-112`) — add `pytest-timeout>=2.3`.
+
+### `uv.lock` (modify)
+
+- Regenerate with `uv lock` — the `install-smoke` and `min-version-smoke` jobs
+  install from it.
+
+### `tests/runtime/fake_remote.py` (modify)
+
+- `run_fake_remote`'s `finally` — modify — wrap `await task` in
+  `asyncio.wait_for(..., timeout=<N>)`; on `TimeoutError`, cancel the task, await
+  it suppressing `CancelledError`, and **raise** with a message naming the port,
+  the server's `started`/`should_exit` state, and `AppStatus.should_exit`. This
+  is the single most likely hang site and the one a stack dump describes worst
+  (an idle loop in `epoll.poll()` names nothing). `AppStatus.should_exit = False`
+  on both entry and exit stays exactly as it is.
+- The comment block at `:259-266` — modify — correct it to the 3.1.1 mechanism
+  (`_ShutdownState` contextvar + `_get_uvicorn_server()` SIGTERM introspection;
+  no `should_exit_event`). State that the reset remains correct and necessary,
+  and that the surrounding claim about *why* was written against an older
+  version.
+
+### `tests/runtime/test_downstream_remote.py` (modify)
+
+- The module docstring at `:37` — modify — same version correction, one
+  sentence. Do not touch
+  `test_a_poisoned_app_status_does_not_break_the_next_server` (`:228`); it still
+  pins real behaviour.
+
+### `tests/runtime/test_hang_diagnostics.py` (create)
+
+The acceptance proof. "The suite no longer hangs" **passes on unchanged `main`**
+— it is not a criterion. So induce a hang deterministically and assert the
+diagnostics fire, mutant-style, as in `.consiliency/evidence/mutation-217.md`:
+
+- `test_a_server_task_that_never_finishes_raises_instead_of_hanging` — patch the
+  server object so `serve()` never returns; assert `run_fake_remote`'s exit
+  raises within ~2× the wait, with the diagnostic message, rather than hanging.
+- `test_the_timeout_plugin_is_active_and_covers_teardown` — a subprocess pytest
+  run (`--timeout=3`) over a temp file whose **fixture teardown** sleeps 30 s;
+  assert it exits non-zero within ~15 s and the output names the timeout.
+  **This is the one that must be verified empirically, not assumed**: if the
+  chosen `timeout_method` does not cover teardown, the plugin cannot catch the
+  most likely hang site and the setting must change until this test passes.
+- `test_faulthandler_timeout_is_configured` — read the resolved ini value; assert
+  it is an int, ≥ 60, and **strictly less than** the `timeout` value, so the
+  stack dump always lands *before* the kill. A dump after the kill is useless.
+
+### `.consiliency/evidence/hang-diagnostics-200.md` (create)
+
+- The transcript: the induced-hang runs with their exit codes and elapsed times,
+  the `--durations=25` measurement behind the chosen timeout, and the proof that
+  a fixture-teardown hang is caught. Same shape as `mutation-217.md`.
+
+## Documentation impact
+
+- `CHANGELOG.md` — **none**. No `src/` change; the `changelog` job requires an
+  entry only for `src/` changes.
+- Consiliency/pmcp#200 — comment (with the PR) — correct the stale
+  `should_exit_event` hypothesis in my earlier comment, state the 3.1.1
+  mechanism, and record that stage 1 ships diagnostics only.
+- A **new follow-up issue** (stage 2) — create — "root-cause the runtime SSE
+  hang once a traceback exists", linking #200 and naming the three candidate
+  sites plus the pytest-asyncio teardown path.
+
+## Dependencies & order
+
+1. `pytest-timeout` in `pyproject.toml` + `uv lock` first — nothing else can be
+   verified without the plugin installed.
+2. Measure `--durations=25`; only then choose `timeout`, and set
+   `faulthandler_timeout` strictly below it.
+3. `fake_remote.py` bounded `await task` + the corrected comment.
+4. `test_hang_diagnostics.py`; iterate `timeout_method` until the
+   teardown-coverage test passes.
+5. Evidence file, then the #200 comment and the stage-2 issue.
+
+## Verification
+
+```bash
+uv sync --all-extras --dev
+uv run pytest -q tests/runtime/test_hang_diagnostics.py          # the three proofs
+uv run pytest -q tests/runtime                                    # 60 passed, unchanged
+uv run pytest -q tests/ --durations=25 | tail -30                 # the measurement
+uv run ruff check src/ tests/ scripts/ && uv run ruff format --check src/ tests/ scripts/
+uv run mypy src/
+uv run python scripts/check_workflows.py --base-ref origin/main   # untouched, must stay 0
+
+# Fail-closed proof for the plugin, both directions:
+#   (a) with `timeout` set    -> the teardown-hang fixture run exits non-zero fast
+#   (b) with `-p no:timeout`  -> the same run hangs (kill it) — proving (a) was the plugin
+```
+
+Edge cases: a legitimately slow test near the threshold (the measurement exists
+to avoid this); `timeout_method = "thread"` terminates the whole process, losing
+the rest of the run — if the teardown-coverage test passes only under `thread`,
+say so explicitly in the evidence and accept it, because a lost tail is strictly
+better than a 25-minute cancel; the `live`-marked `timeout(130)` marker becoming
+active (deselected by default — assert that `-m 'not live'` collection is
+unchanged at 1000/1019).
+
+## Acceptance criteria
+
+- [ ] `pytest-timeout` is installed via `pyproject.toml` + `uv.lock`, and
+      `uv run pytest --collect-only -q tests/` still reports **1000/1019
+      collected (19 deselected)** — the marker activation changes nothing that
+      runs by default.
+- [ ] A fixture whose **teardown** blocks for 30 s is killed by the plugin in
+      under ~15 s with a non-zero exit and a message naming the timeout —
+      **proven in a subprocess run, and proven to hang without the plugin**
+      (`-p no:timeout`). Teardown coverage is the whole point: the most likely
+      hang site is after `PASSED` is printed.
+- [ ] `faulthandler_timeout` is set, is strictly less than `timeout`, and a test
+      that blocks longer than it emits a `Thread 0x…` stack dump into the run
+      output while the run continues.
+- [ ] `run_fake_remote` with a `serve()` that never returns **raises within
+      ~2×N seconds** naming port, server state and `AppStatus.should_exit` —
+      where on unchanged `main` the same scenario hangs indefinitely.
+- [ ] The chosen `timeout` is ≥ 10× the slowest non-`live` test as measured by
+      `--durations=25` in this change, and the measured value is recorded in the
+      evidence file.
+- [ ] `tests/runtime` still reports **60 passed**, and the full suite's
+      pass/skip/deselect counts are unchanged from `main`.
+- [ ] No file under `src/` is modified (`git diff --name-only origin/main…HEAD |
+      grep '^src/'` is empty) — this is a diagnostics change; any production
+      timeout is stage 2 and a separate decision.
+
+## Non-goals
+
+- **Fixing the hang.** Stage 2, after a traceback exists.
+- **A timeout on `ClientManager.connect_server`.** If the captured evidence shows
+  an unbounded client-side await, that is a production robustness change with
+  its own blast radius — file it, do not fold it in here.
+- Rewriting the emitter harness or the `_tap()` spy.
+- Raising `timeout-minutes: 25` on the `test` job; a shorter job timeout is not a
+  fix, and the guard in `check_workflows.py` bounds it to 10..30 deliberately.
+
+## Execution Policy
+
+- execute: effort=medium, reason=small diff but the teardown-coverage question is empirical and the acceptance criteria must be proven in both directions

--- a/.consiliency/plans/detailed-sse-hang-diagnostics-20260902-1030.md
+++ b/.consiliency/plans/detailed-sse-hang-diagnostics-20260902-1030.md
@@ -95,6 +95,27 @@ process: **107 passed, 3/3 runs**, ~17 s each. A full-suite run with coverage an
 also passes. Absence of a local repro is expected for a timing-dependent flake
 and is not evidence against it.
 
+**The measurement is already done** (`--durations=25`, full suite, this
+worktree, 2026-09-02): the slowest non-`live` items are
+`tests/test_progressive_disclosure.py::TestScenario7…::test_invoke_query_docs`
+and `…TestScenario8…::test_invoke_query_docs_conceptual` at **60.06 s each**
+(both land on exactly 60 s, which looks like an internal timeout rather than
+real work — noted, not in scope), then
+`test_subscriptions_e2e.py::test_connect_disconnect_refresh_each_deliver_all_three_kinds`
+at 19.06 s and `test_shutdown_handles_timeout` at 10.08 s. So: **`timeout = 600`**
+(10× the slowest) and **`faulthandler_timeout = 120`** (2× the slowest, and well
+below the kill). The implementer does not need to re-run the measurement; it must
+re-run only if it changes either number.
+
+**Host quirk, not a regression.** A full run *from this worktree* reports ~107
+failed / 106 errors in `test_version_checker.py`, `test_npm_resolver.py` and
+`test_tools.py`, because `/tmp/package.json` exists on this host and the npm
+identity resolver's `localPrefix` walk finds it (documented in
+`tests/conftest.py`). The same suite from `/home/viperjuice/code/pmcp` was
+**3386 passed, 3 skipped, 25 deselected in 7m40s, zero faulthandler dumps**.
+Compare like with like: the acceptance counts below mean *the same command from
+the same directory*, before and after.
+
 **Tooling facts.** pytest is **9.0.2**; `faulthandler_timeout` /
 `faulthandler_exit_on_timeout` are **built-in ini options** (no dependency).
 `pytest_timeout` is **not installed**, so the `timeout` marker declared in
@@ -115,11 +136,14 @@ touches none.
   continue**. This is the zero-risk half: it kills nothing, and on the next CI
   hit it prints the stack of the stuck await into the job log. Set in the ini
   file, not the CI command line, so a local run behaves like CI.
-- `[tool.pytest.ini_options]` — add `timeout` and `timeout_method = "thread"` —
-  the fail-fast half, via `pytest-timeout`. **Choose the value from a
-  measurement, not a guess**: run `--durations=25` on the full suite and set the
-  timeout to roughly 10× the slowest non-`live` test, floor 120 s. Record the
-  measured slowest test and the chosen number in a comment on the setting.
+- `[tool.pytest.ini_options]` — add `timeout = 600` and `timeout_method` — the
+  fail-fast half, via `pytest-timeout`. 600 s is 10× the measured slowest
+  non-`live` test (60.06 s, above); `faulthandler_timeout = 120` is 2× it, so the
+  stack dump lands 8 minutes before the kill and both sit inside the job's
+  `timeout-minutes: 25`. Put the measured test name and both numbers in a comment
+  on the setting, so the next person changing them knows what they were derived
+  from. `timeout_method` is chosen by the teardown-coverage proof below, not
+  assumed.
 - `[dependency-groups] dev` (or the existing test extra — match where
   `pytest-cov` lives, around `:109-112`) — add `pytest-timeout>=2.3`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -159,12 +159,19 @@ addopts = "-m 'not live'"
 # timeout rather than real work -- noted, not in scope here.)
 #
 #   faulthandler_timeout = 120  -- 2x the slowest test. Zero-risk half: it
-#     kills nothing, it dumps every thread's stack and lets the run continue,
-#     which is what actually names the stuck await.
+#     kills nothing, it dumps every thread's stack and lets the run continue.
 #   timeout              = 700  -- >=10x the slowest test (10 x 60.25 = 602.5,
 #     so 600 would have been 9.96x and short of the bar). The fail-fast half,
 #     via pytest-timeout. The dump therefore lands ~9.7 minutes before the
 #     kill, and both sit well inside the `test` job's `timeout-minutes: 25`.
+#
+# Neither of these can see a *suspended coroutine*: its frames live in Task
+# objects, not on any thread stack, so both bottom out in `epoll.poll()` and
+# name nothing. `tests/runtime/_hang_watchdog.py` closes that at 60 s by
+# dumping the pending tasks and walking the await chain. Full order, each
+# strictly below the next:
+#
+#   60 s -> async stacks | 120 s -> thread stacks | 700 s -> kill | 25 min -> job cap
 #
 # Set here rather than on the CI command line so a local run behaves like CI.
 # `timeout_method` is not the platform default by accident: it is the value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,9 @@ dev = [
     "pytest-asyncio>=0.21",
     "pytest-cov>=4.0",
     "pytest-mock>=3.0",
+    # Consiliency/pmcp#200: without this the `timeout` ini option below is
+    # inert and a stuck await is a 25-minute silent job cancel.
+    "pytest-timeout>=2.3",
     "ruff>=0.8.0",
     "mypy>=1.0",
     "types-PyYAML>=6.0",
@@ -141,6 +144,36 @@ artifacts = ["src/pmcp/manifest/_npm_resolve.js"]
 asyncio_mode = "auto"
 testpaths = ["tests"]
 addopts = "-m 'not live'"
+# Consiliency/pmcp#200 -- diagnostics for the intermittent runtime hang. Five
+# `test (3.x)` jobs in the week to 2026-09-01 stalled and were killed by the
+# job's `timeout-minutes: 25`; GitHub reports a timed-out job as *cancelled*,
+# so none of them produced a red X, a traceback, or one line of evidence about
+# which await was stuck. These two settings turn that into a fast, loud
+# failure. They do not fix the hang -- the root cause is still unknown.
+#
+# Both numbers derive from `pytest tests/ --durations=25` on 2026-09-02 (see
+# `.consiliency/evidence/hang-diagnostics-200.md`). The slowest non-`live`
+# tests are `test_progressive_disclosure.py::TestScenario8_LibraryConcepts
+# ::test_invoke_query_docs_conceptual` at 60.25 s and its Scenario7 sibling at
+# 60.22 s. (Both land on almost exactly 60 s, which looks like an internal
+# timeout rather than real work -- noted, not in scope here.)
+#
+#   faulthandler_timeout = 120  -- 2x the slowest test. Zero-risk half: it
+#     kills nothing, it dumps every thread's stack and lets the run continue,
+#     which is what actually names the stuck await.
+#   timeout              = 700  -- >=10x the slowest test (10 x 60.25 = 602.5,
+#     so 600 would have been 9.96x and short of the bar). The fail-fast half,
+#     via pytest-timeout. The dump therefore lands ~9.7 minutes before the
+#     kill, and both sit well inside the `test` job's `timeout-minutes: 25`.
+#
+# Set here rather than on the CI command line so a local run behaves like CI.
+# `timeout_method` is not the platform default by accident: it is the value
+# that `tests/runtime/test_hang_diagnostics.py` empirically proves also covers
+# *fixture teardown*, which is where the likeliest hang site is -- pytest
+# prints `PASSED` when the test function returns, before teardown runs.
+faulthandler_timeout = 120
+timeout = 700
+timeout_method = "signal"
 markers = [
     "live: opt-in live integration tests (require network and package managers)",
     "timeout(seconds): expected maximum runtime for slow opt-in tests",

--- a/tests/runtime/_hang_watchdog.py
+++ b/tests/runtime/_hang_watchdog.py
@@ -1,0 +1,324 @@
+"""Async-stack watchdog for Consiliency/pmcp#200.
+
+`faulthandler_timeout` and `pytest-timeout` both dump the *thread* stack, and
+for the hang this repo is chasing that stack says nothing. A suspended
+coroutine's frames do not live on any thread stack — they live in `Task`
+objects — so the main thread is parked in the selector and the traceback
+bottoms out there. Reproduced on this branch, verbatim, with a test that
+awaits an `Event` through two coroutine frames:
+
+    asyncio/base_events.py:2019: in _run_once
+        event_list = self._selector.select(timeout)
+    selectors.py:452: in select
+    >   fd_event_list = self._selector.poll(timeout, max_ev)
+    E   Failed: Timeout (>3.0s) from pytest-timeout.
+
+`epoll.poll` — the stuck await is invisible. Without this module #200's
+diagnostics would turn a 25-minute silent cancel into a 700-second failure
+that still could not tell `_tap()` from `connect_server()` from
+`disconnect_all()`, which is the entire question the change exists to answer.
+
+So: a watchdog thread that, when the current test item has been running too
+long, dumps every pending `asyncio.Task` on that item's event loop.
+
+Three ordered thresholds, each strictly below the next:
+
+    60 s   this watchdog        -> async stacks, names the awaiting coroutine
+    120 s  faulthandler_timeout -> every thread's stack, the run continues
+    700 s  pytest-timeout       -> the item fails and the run moves on
+    25 min the job's cap        -> what used to happen instead of all of this
+
+60 s is the threshold because the slowest item in `tests/runtime` is 26.16 s
+(`--durations=25`, 2026-09-02), so this has >2x headroom over anything here
+and cannot fire spuriously.
+
+**Why the walk below is not just `Task.print_stack()`.** For a *suspended*
+coroutine `Task.get_stack()` returns a single frame — the coroutine's own
+`cr_frame`, whose `f_back` is `None` because a suspended coroutine is not on
+anyone's stack. That names the task's outermost function and nothing beneath
+it. The awaited chain is reachable only through `cr_await` / `ag_await`, so
+this module walks it explicitly. That walk is *required*, not a refinement:
+the prime suspect is `_tap()` in `test_emitter_harness.py:65`, which is an
+**async generator** wrapped around the SSE read stream. `print_stack()` would
+report the task that drives it; only the `ag_frame`/`ag_await` branch names
+`_tap` itself.
+
+Both are printed: `print_stack()` for the familiar rendering, then the labelled
+await chain that actually locates the hang.
+
+**This must never fail.** A watchdog that can raise is worse than no watchdog,
+because it converts a diagnosable hang into a confusing error. Every path here
+is wrapped and swallows; the worst case is silence.
+
+Lives in its own module rather than directly in `conftest.py` so a subprocess
+can load it as a plugin with `-p tests.runtime._hang_watchdog`. A test file
+written into a `tmp_path` takes the temp directory as rootdir and never loads
+this package's `conftest.py`, so the mutant proof in
+`test_hang_diagnostics.py` could not otherwise exercise it — the same rootdir
+trap that the stage-1 `-o timeout=...` settings had to work around.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import linecache
+import os
+import sys
+import threading
+import time
+from typing import Any
+
+import pytest
+
+# Grep-able marker. The mutant proof asserts on this exact string, in both
+# directions, so it must not be reworded casually.
+DUMP_SENTINEL = "[async-stacks]"
+
+# Overridable so the mutant proof can induce a dump in seconds instead of
+# waiting a minute. Not an ini option: this is a debugging knob, not
+# configuration, and the default is what every real run uses.
+_ENV_VAR = "PMCP_ASYNC_STACK_DUMP_AFTER"
+_DEFAULT_DUMP_AFTER = 60.0
+
+_POLL_INTERVAL = 0.5
+_MAX_CHAIN_FRAMES = 40
+
+_lock = threading.Lock()
+_current: dict[str, Any] | None = None
+_thread: threading.Thread | None = None
+
+
+def _dump_after() -> float:
+    try:
+        return float(os.environ.get(_ENV_VAR, _DEFAULT_DUMP_AFTER))
+    except (TypeError, ValueError):
+        return _DEFAULT_DUMP_AFTER
+
+
+def _frame_lines(obj: Any) -> list[str]:
+    """Walk `cr_await` / `ag_await` / `gi_yieldfrom` from a task's coroutine
+    down to whatever it is ultimately suspended on.
+
+    Handles async generators explicitly (`ag_frame`, `ag_await`) — see the
+    module docstring; that branch exists for `_tap()`.
+
+    The walk stops at a bare `Future` (an `Event.wait()`, a socket read), which
+    has no frame of its own. It is cycle-guarded and length-capped, so a
+    self-referential chain cannot spin here.
+    """
+    lines: list[str] = []
+    seen: set[int] = set()
+    while obj is not None and len(lines) < _MAX_CHAIN_FRAMES:
+        if id(obj) in seen:
+            lines.append("      ... cycle in the await chain, stopping")
+            break
+        seen.add(id(obj))
+
+        # A nested Task/Future in the chain: step into its coroutine if it has
+        # one, so an awaited task does not end the walk.
+        if isinstance(obj, asyncio.Task):
+            inner = obj.get_coro()
+            if inner is not None and id(inner) not in seen:
+                lines.append(f"      -- awaiting {obj!r}")
+                obj = inner
+                continue
+
+        frame = (
+            getattr(obj, "cr_frame", None)
+            or getattr(obj, "ag_frame", None)
+            or getattr(obj, "gi_frame", None)
+        )
+        if frame is not None:
+            code = frame.f_code
+            lines.append(
+                f'      File "{code.co_filename}", line {frame.f_lineno}, '
+                f"in {code.co_name}"
+            )
+            source = linecache.getline(code.co_filename, frame.f_lineno).strip()
+            if source:
+                lines.append(f"        {source}")
+
+        nxt = (
+            getattr(obj, "cr_await", None)
+            or getattr(obj, "ag_await", None)
+            or getattr(obj, "gi_yieldfrom", None)
+        )
+        if nxt is None:
+            nxt = _step_through_opaque(obj)
+        if nxt is None:
+            if frame is None:
+                lines.append(f"      -- suspended on {obj!r}")
+            break
+        obj = nxt
+    return lines
+
+
+def _step_through_opaque(obj: Any) -> Any:
+    """Get past an awaitable that exposes no frame and no `*_await`.
+
+    `async for x in agen()` suspends on an `async_generator_asend`, whose only
+    public attributes are `close`/`send`/`throw` — it has no `ag_frame` and no
+    `ag_await`, so the walk above dead-ends one hop short of the generator.
+    That is not an edge case here: it is precisely the shape of `_tap()`, the
+    prime suspect, so without this hop the branch that motivated the whole
+    watchdog would stop just before naming its target. Verified: the object's
+    referents are exactly `[async_generator]`.
+
+    Deliberately narrow — the first referent carrying a coroutine/generator
+    frame, and nothing else — and fully guarded, because `gc.get_referents` on
+    an arbitrary object is only a heuristic.
+    """
+    try:
+        import gc
+
+        for ref in gc.get_referents(obj):
+            if (
+                getattr(ref, "ag_frame", None) is not None
+                or getattr(ref, "cr_frame", None) is not None
+                or getattr(ref, "gi_frame", None) is not None
+            ):
+                return ref
+    except Exception:  # pragma: no cover - diagnostics only
+        return None
+    return None
+
+
+def _pending_tasks(loop: asyncio.AbstractEventLoop) -> list[asyncio.Task[Any]]:
+    """`asyncio.all_tasks` snapshots a WeakSet the running loop is mutating, so
+    from this thread it can raise `RuntimeError: Set changed size during
+    iteration`. Retry a few times, then give up quietly."""
+    for _ in range(5):
+        try:
+            return [t for t in asyncio.all_tasks(loop) if not t.done()]
+        except RuntimeError:
+            time.sleep(0.05)
+    return []
+
+
+def _render(nodeid: str, elapsed: float, loop: Any) -> str:
+    out: list[str] = [
+        "",
+        f"{DUMP_SENTINEL} {nodeid} has been running {elapsed:.1f}s "
+        f"(threshold {_dump_after():.1f}s) -- see Consiliency/pmcp#200",
+    ]
+    if loop is None:
+        out.append(
+            f"{DUMP_SENTINEL} no event loop was recorded for this item; "
+            "if it is a sync test there are no async stacks to show."
+        )
+        return "\n".join(out) + "\n"
+
+    tasks = _pending_tasks(loop)
+    out.append(f"{DUMP_SENTINEL} {len(tasks)} pending task(s) on {loop!r}:")
+    for task in tasks:
+        out.append(f"--- {task!r}")
+        try:
+            import io
+
+            buf = io.StringIO()
+            task.print_stack(file=buf)
+            out.append(buf.getvalue().rstrip())
+        except Exception as exc:  # pragma: no cover - diagnostics only
+            out.append(f"    <print_stack failed: {exc!r}>")
+        try:
+            chain = _frame_lines(task.get_coro())
+        except Exception as exc:  # pragma: no cover - diagnostics only
+            chain = [f"      <await-chain walk failed: {exc!r}>"]
+        if chain:
+            out.append("    [await chain] (what print_stack cannot reach):")
+            out.extend(chain)
+    return "\n".join(out) + "\n"
+
+
+def _emit(text: str) -> None:
+    # One write, so the dump cannot interleave with the main thread's output.
+    try:
+        sys.stderr.write(text)
+        sys.stderr.flush()
+    except Exception:  # pragma: no cover - diagnostics only
+        pass
+
+
+def _watch() -> None:
+    while True:
+        time.sleep(_POLL_INTERVAL)
+        try:
+            with _lock:
+                state = _current
+                if state is None or state["dumped"]:
+                    continue
+                elapsed = time.monotonic() - state["started"]
+                if elapsed < _dump_after():
+                    continue
+                # Flip inside the lock so this fires at most once per item.
+                state["dumped"] = True
+                nodeid, loop = state["nodeid"], state["loop"]
+            _emit(_render(nodeid, elapsed, loop))
+        except Exception:  # pragma: no cover - a watchdog must never raise
+            pass
+
+
+def _ensure_thread() -> None:
+    global _thread
+    if _thread is not None:
+        return
+    # Started lazily on the first item, so `--collect-only` spawns nothing.
+    # Daemon and never joined: it must not hold the interpreter open.
+    _thread = threading.Thread(
+        target=_watch, name="pmcp-async-stack-watchdog", daemon=True
+    )
+    _thread.start()
+
+
+def pytest_runtest_logstart(nodeid: str, location: Any) -> None:
+    """Fires before setup, so the window covers setup, call **and teardown**.
+
+    Teardown coverage is the point: pytest prints `PASSED` when the test
+    function returns, before teardown, and pytest-asyncio's loop teardown is
+    itself a prime suspect.
+    """
+    global _current, _thread
+    try:
+        with _lock:
+            _current = {
+                "nodeid": nodeid,
+                "started": time.monotonic(),
+                "loop": None,
+                "dumped": False,
+            }
+            if _thread is None:
+                _ensure_thread()
+    except Exception:  # pragma: no cover - a watchdog must never raise
+        pass
+
+
+def pytest_runtest_logfinish(nodeid: str, location: Any) -> None:
+    global _current
+    try:
+        with _lock:
+            _current = None
+    except Exception:  # pragma: no cover - a watchdog must never raise
+        pass
+
+
+@pytest.fixture(autouse=True)
+async def _record_running_loop() -> Any:
+    """Hand the watchdog thread the loop this item is running on.
+
+    It has to come from `asyncio.get_running_loop()` inside an **async**
+    fixture. There is no way to reach a running loop from the watchdog thread
+    itself, and the sync-context alternatives do not work:
+    `get_event_loop_policy().get_event_loop()` raises
+    `RuntimeError('no running event loop')` here.
+
+    Async and autouse is safe for the sync tests in this package too —
+    `asyncio_mode = "auto"` gives them a loop as well, verified.
+    """
+    try:
+        loop = asyncio.get_running_loop()
+        with _lock:
+            if _current is not None:
+                _current["loop"] = loop
+    except Exception:  # pragma: no cover - a watchdog must never raise
+        pass
+    yield

--- a/tests/runtime/conftest.py
+++ b/tests/runtime/conftest.py
@@ -10,3 +10,21 @@ directory without a per-module import.
 from __future__ import annotations
 
 from tests.runtime.harness import gateway_on_spare_port  # noqa: F401
+
+# Consiliency/pmcp#200: the async-stack watchdog. Re-exported here for the
+# same reason `gateway_on_spare_port` is -- pytest only discovers fixtures and
+# hooks from `conftest.py` (or modules explicitly imported into it). The
+# implementation lives in its own module so a subprocess can load it as a
+# plugin with `-p tests.runtime._hang_watchdog`, which is how
+# `test_hang_diagnostics.py` proves it fires; a test file under `tmp_path`
+# takes the temp directory as rootdir and would never load this file.
+#
+# Scoped to `tests/runtime/` rather than `tests/`: all five CI stalls happened
+# here, the slowest item in this package is 26.16 s against the watchdog's 60 s
+# threshold, and at `tests/` scope the two ~60.2 s progressive-disclosure tests
+# would trip a spurious dump on every single run.
+from tests.runtime._hang_watchdog import (  # noqa: F401,E402
+    _record_running_loop,
+    pytest_runtest_logfinish,
+    pytest_runtest_logstart,
+)

--- a/tests/runtime/fake_remote.py
+++ b/tests/runtime/fake_remote.py
@@ -40,6 +40,17 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 
 AUTH_HEADER = "authorization"
 
+# Bounds on `run_fake_remote`'s stop sequence (Consiliency/pmcp#200). uvicorn's
+# graceful drain here is unbounded -- the `uvicorn.Config` below is constructed
+# without `timeout_graceful_shutdown` -- so `await server.serve()`'s task could
+# never return, and did: five CI jobs died to a 25-minute silent cancel with no
+# traceback. A healthy stop in this harness is sub-second, so 10 s is ~20x the
+# observed cost and far below any pytest-level timeout. `CANCEL_GRACE` is what
+# a cancelled `serve()` gets to unwind before the stop sequence gives up on it
+# and says so out loud.
+SERVE_STOP_TIMEOUT = 10.0
+CANCEL_GRACE = 5.0
+
 # The three notification methods a real downstream can claim through the
 # SDK's typed `ServerSession` helpers -- anything else (including an
 # unrecognised method, EC-FANOUT-5's no-op case) has no typed helper and
@@ -254,13 +265,76 @@ async def run_fake_remote(
             emitter=app.state.fake_remote_emitter,
         )
     finally:
-        server.should_exit = True
-        await task
-        # sse_starlette.sse.AppStatus.should_exit is a process-global class
-        # attribute, latched True by its uvicorn-shutdown signal handler and
-        # never reset. Left alone, every SSE stream created afterwards — in
-        # any event loop, against any server — terminates immediately, which
-        # poisons whichever test runs next. This is the one site that resets
-        # it; nothing else in the repo should. It is cleared on entry too, so a
-        # server started elsewhere in this interpreter cannot poison this one.
-        AppStatus.should_exit = False
+        try:
+            server.should_exit = True
+            # Bounded, so a server that never stops fails this test in 15 s
+            # with a message instead of stalling the job for 25 minutes
+            # (Consiliency/pmcp#200).
+            #
+            # NOT `asyncio.wait_for`, which cannot bound a cancellation-
+            # resistant task: it cancels, then waits for the cancellation to
+            # *finish*, so a `serve()` that swallows `CancelledError` hangs it
+            # exactly as hard as the bare `await task` this replaces. Verified
+            # empirically -- such a coroutine survived `wait_for`, an outer
+            # `wait_for` guard, and `asyncio.run`'s own shutdown. `asyncio.wait`
+            # never awaits a pending task: it reports it and moves on, which is
+            # why the raise below happens whether or not the cancel took.
+            # `tests/runtime/test_hang_diagnostics.py` pins both mutants.
+            _, pending = await asyncio.wait({task}, timeout=SERVE_STOP_TIMEOUT)
+            if pending:
+                task.cancel()
+                _, pending = await asyncio.wait({task}, timeout=CANCEL_GRACE)
+                survived = bool(pending)
+                # Whether the task survived cancellation is the single most
+                # valuable fact for root-causing this, and no stack dump
+                # reports it -- an idle loop parked in `epoll.poll()` names
+                # nothing.
+                raise RuntimeError(
+                    f"fake remote on port {port} did not stop within "
+                    f"{SERVE_STOP_TIMEOUT}s of should_exit=True; "
+                    + (
+                        f"the serve() task SURVIVED cancellation after "
+                        f"{CANCEL_GRACE}s and is now orphaned"
+                        if survived
+                        else "the serve() task ended only once cancelled"
+                    )
+                    + f" [server.started={server.started!r} "
+                    f"server.should_exit={server.should_exit!r} "
+                    f"AppStatus.should_exit={AppStatus.should_exit!r}]"
+                    " -- see Consiliency/pmcp#200"
+                )
+            # Healthy path: surface whatever `serve()` itself raised, exactly
+            # as the previous bare `await task` did.
+            task.result()
+        finally:
+            # sse_starlette.sse.AppStatus.should_exit is a process-global class
+            # attribute, latched True by its uvicorn-shutdown signal handler and
+            # never reset. Left alone, every SSE stream created afterwards — in
+            # any event loop, against any server — terminates immediately, which
+            # poisons whichever test runs next. This is the one site that resets
+            # it; nothing else in the repo should. It is cleared on entry too, so
+            # a server started elsewhere in this interpreter cannot poison this
+            # one.
+            #
+            # The reset is unconditional and nested because the stop sequence
+            # above can now raise. Before Consiliency/pmcp#200 it sat after
+            # `await task`, so any exception on the way out would have skipped
+            # it and poisoned the next test with the very latch this harness
+            # exists to clear.
+            #
+            # The *mechanism* this comment used to describe was written against
+            # an older sse_starlette. Installed here is 3.1.1, where
+            # `vars(AppStatus)` is exactly
+            # `{should_exit, original_handler, handle_exit}`: there is no
+            # `should_exit_event`, so the fix floated in #200's early comment
+            # ("reset `should_exit_event = None`") cannot be written as stated.
+            # 3.1.1 keeps a per-event-loop `_ShutdownState` in a
+            # `contextvars.ContextVar`, and `_get_uvicorn_server()` reads
+            # `signal.getsignal(signal.SIGTERM).__self__` and polls *that*
+            # object's `should_exit`. Two consequences follow, both plausible
+            # and neither verified: a stale SIGTERM handler left by an earlier
+            # uvicorn server can make a later loop's watcher see
+            # `should_exit == True`, and a `_ShutdownState` registered on one
+            # loop is never signalled by a watcher on another. The reset below
+            # remains correct and necessary either way.
+            AppStatus.should_exit = False

--- a/tests/runtime/test_downstream_remote.py
+++ b/tests/runtime/test_downstream_remote.py
@@ -40,7 +40,12 @@ made splitting it fail:
      stream created afterwards — in any loop, against any server —
      terminates immediately. Fixed in `tests/runtime/fake_remote.py`'s
      `run_fake_remote` `finally:` block, which is the one place that resets
-     it.
+     it. (Version note, Consiliency/pmcp#200: the installed sse_starlette is
+     3.1.1, whose `AppStatus` has no `should_exit_event` — it keeps a
+     per-event-loop `_ShutdownState` in a `contextvars.ContextVar` and reads
+     the live server back out of `signal.getsignal(signal.SIGTERM).__self__`;
+     the class attribute above, and this reset, are still exactly as
+     described.)
 
 These two causes are unrelated — the earlier "two symptoms, one root"
 framing in this docstring was wrong. Both are fixed now, independently, and

--- a/tests/runtime/test_hang_diagnostics.py
+++ b/tests/runtime/test_hang_diagnostics.py
@@ -26,6 +26,12 @@ diagnostic fires, mutant-style (`.consiliency/evidence/mutation-217.md`):
     line in those five logs.
   * a subprocess run proving `faulthandler_timeout` dumps a stack and lets the
     session continue, and that the dump is scheduled strictly before the kill.
+  * an **async** hang — the shape the real one is believed to have — proving the
+    watchdog in `_hang_watchdog.py` names the awaiting coroutine. Both
+    `faulthandler` and `pytest-timeout` dump the *thread* stack, and a suspended
+    coroutine has no frames there, so those two alone bottom out in
+    `epoll.poll()` and name nothing. Proven in both directions, with and
+    without the plugin.
 
 The subprocess runs pass `-o timeout=… -o timeout_method=…` explicitly: a temp
 test file makes the temp directory the rootdir, so the project's
@@ -36,6 +42,7 @@ Linux's default method while CI ran another.
 from __future__ import annotations
 
 import asyncio
+import os
 import subprocess
 import sys
 import time
@@ -45,7 +52,8 @@ from typing import Any
 import pytest
 from sse_starlette.sse import AppStatus
 
-from tests.runtime import fake_remote
+from tests.runtime import _hang_watchdog, fake_remote
+from tests.runtime._hang_watchdog import DUMP_SENTINEL
 from tests.runtime.harness import alloc_port
 
 # 2 x (SERVE_STOP_TIMEOUT + CANCEL_GRACE), the acceptance bound: the stop
@@ -343,3 +351,124 @@ def test_faulthandler_timeout_is_below_the_kill_timeout(
     # Both must fit inside the `test` job's `timeout-minutes: 25`, or the
     # 25-minute silent cancel this change exists to replace happens anyway.
     assert kill_timeout < 25 * 60
+
+
+# The shape the real hang is believed to have: a coroutine suspended on an
+# await, reached *through an async generator*. `_tap()` in
+# `test_emitter_harness.py:65` is an async generator wrapped around the SSE read
+# stream, and it is the prime suspect, so the generator hop is the part that
+# matters -- not merely nested coroutines.
+_ASYNC_HANG_MODULE = """
+import asyncio
+
+
+async def _tap_like_generator():
+    await asyncio.Event().wait()
+    yield 1
+
+
+async def _drives_the_generator():
+    async for _ in _tap_like_generator():
+        break
+
+
+async def test_hangs_inside_an_async_generator():
+    await _drives_the_generator()
+"""
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _run_async_hang(tmp_path: Path, *, with_watchdog: bool) -> str:
+    """Run the async-hang module in a subprocess, with or without the plugin.
+
+    cwd is the repo root, not `tmp_path`: `-p tests.runtime._hang_watchdog` is
+    an import path and would not resolve from the temp directory. The module
+    file still lives under `tmp_path`, so the temp dir is the rootdir and the
+    project ini does not load -- hence the explicit `-o` settings.
+    """
+    module = tmp_path / "test_async_induced.py"
+    module.write_text(_ASYNC_HANG_MODULE)
+    plugin = ["-p", "tests.runtime._hang_watchdog"] if with_watchdog else []
+    env = dict(os.environ, PMCP_ASYNC_STACK_DUMP_AFTER="2")
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(module), *plugin]
+        + [
+            "-p",
+            "no:cacheprovider",
+            "-o",
+            "asyncio_mode=auto",
+            "-o",
+            "timeout=8",
+            "-o",
+            "timeout_method=signal",
+            "-q",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        cwd=_REPO_ROOT,
+        env=env,
+    )
+    return result.stdout + result.stderr
+
+
+def test_an_async_hang_names_the_awaiting_coroutine(tmp_path: Path) -> None:
+    """The gap this watchdog exists to close.
+
+    Without it, a suspended coroutine killed by pytest-timeout reports only
+    `epoll.poll()` -- which cannot tell `_tap()` from `connect_server()` from
+    `disconnect_all()`, and those are the exact three candidates #200 has.
+    """
+    output = _run_async_hang(tmp_path, with_watchdog=True)
+
+    assert "Timeout" in output, output
+    assert DUMP_SENTINEL in output, output
+    # The task's own coroutine -- what `Task.print_stack()` can reach.
+    assert "test_hangs_inside_an_async_generator" in output, output
+    # And the frames underneath it, which `print_stack()` cannot: a suspended
+    # coroutine's `cr_frame.f_back` is None, so the walk down `cr_await` /
+    # `ag_await` is the only way to these.
+    assert "_drives_the_generator" in output, output
+    assert "_tap_like_generator" in output, output
+    assert "[await chain]" in output, output
+
+
+def test_without_the_watchdog_an_async_hang_names_only_the_selector(
+    tmp_path: Path,
+) -> None:
+    """The negative half: prove the frames above came from the watchdog.
+
+    Same hang, same timeout, no plugin. pytest-timeout still fires -- so this is
+    not a case of nothing happening -- but the traceback bottoms out in the
+    selector and the awaiting coroutine is invisible.
+    """
+    output = _run_async_hang(tmp_path, with_watchdog=False)
+
+    assert "Timeout" in output, output
+    assert DUMP_SENTINEL not in output, output
+    assert "[await chain]" not in output, output
+    # The epitaph from the CI logs: the thread stack parked in the selector.
+    assert "select" in output or "poll" in output, output
+    # The frames that only the watchdog can reach are absent.
+    assert "_tap_like_generator" not in output, output
+
+
+async def test_the_watchdog_is_wired_into_this_package(
+    request: pytest.FixtureRequest,
+) -> None:
+    """The subprocess proofs certify the plugin's logic but not the wiring.
+
+    This asserts the `conftest.py` re-export is live in a normal run: the hook
+    recorded *this* item, and the autouse async fixture handed the watchdog the
+    loop this test is actually running on.
+    """
+    state = _hang_watchdog._current
+
+    assert state is not None
+    assert state["nodeid"] == request.node.nodeid
+    assert state["loop"] is asyncio.get_running_loop()
+    assert state["dumped"] is False
+    # Started lazily, on the first item rather than at import.
+    assert _hang_watchdog._thread is not None
+    assert _hang_watchdog._thread.daemon is True

--- a/tests/runtime/test_hang_diagnostics.py
+++ b/tests/runtime/test_hang_diagnostics.py
@@ -1,0 +1,345 @@
+"""Stage-1 diagnostics for Consiliency/pmcp#200 — proof that a hang now fails
+fast and names itself.
+
+Five `test (3.x)` jobs in the week to 2026-09-01 stalled inside
+`tests/runtime/test_emitter_harness.py` and were killed by the job's
+`timeout-minutes: 25`. GitHub reports a timed-out job as *cancelled*, not
+failed, so the flake has never produced a red X, a traceback, or one line of
+evidence about which await is stuck. This module does not fix that hang — the
+root cause is still unknown. It proves the instrumentation that will capture
+it.
+
+"The suite no longer hangs" passes on unchanged `main`, so it is not a
+criterion. Each test below induces a hang deterministically and asserts the
+diagnostic fires, mutant-style (`.consiliency/evidence/mutation-217.md`):
+
+  * two mutant servers for `run_fake_remote`'s bounded stop sequence — one
+    whose `serve()` never returns, and one that **swallows `CancelledError`**.
+    The second is the one that matters: `asyncio.wait_for` does not bound a
+    cancellation-resistant task (it cancels, then waits for the cancellation to
+    finish), so a `wait_for`-based stop passes the first mutant and hangs on
+    this one exactly as hard as the bare `await task` it replaced.
+  * a subprocess pytest run whose **fixture teardown** blocks, in both
+    directions — with the plugin, and with `-p no:timeout`. Teardown coverage is
+    the whole point: pytest prints `PASSED` when the test function returns,
+    *before* teardown, so the likeliest hang site is after the last `PASSED`
+    line in those five logs.
+  * a subprocess run proving `faulthandler_timeout` dumps a stack and lets the
+    session continue, and that the dump is scheduled strictly before the kill.
+
+The subprocess runs pass `-o timeout=… -o timeout_method=…` explicitly: a temp
+test file makes the temp directory the rootdir, so the project's
+`[tool.pytest.ini_options]` never loads and a bare `--timeout=3` would certify
+Linux's default method while CI ran another.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sse_starlette.sse import AppStatus
+
+from tests.runtime import fake_remote
+from tests.runtime.harness import alloc_port
+
+# 2 x (SERVE_STOP_TIMEOUT + CANCEL_GRACE), the acceptance bound: the stop
+# sequence waits at most SERVE_STOP_TIMEOUT, then at most CANCEL_GRACE, then
+# raises no matter what.
+_MUTANT_BOUND = 2 * (fake_remote.SERVE_STOP_TIMEOUT + fake_remote.CANCEL_GRACE)
+
+
+async def _bounded(coro: Any, limit: float) -> Any:
+    """Run `coro` under a hard bound that never awaits a pending task.
+
+    A regression in the stop sequence must fail this file, not hang it — and
+    `asyncio.wait_for` cannot promise that (see the module docstring).
+    """
+    task = asyncio.ensure_future(coro)
+    done, pending = await asyncio.wait({task}, timeout=limit)
+    if pending:
+        task.cancel()
+        await asyncio.wait({task}, timeout=5.0)
+        raise AssertionError(f"the test body did not finish within {limit}s")
+    return next(iter(done)).result()
+
+
+class _NeverStops:
+    """`serve()` reports started, then never returns — but does honour a
+    cancel. Models a uvicorn graceful drain that never completes (this
+    harness constructs `uvicorn.Config` without `timeout_graceful_shutdown`,
+    so the drain is unbounded)."""
+
+    def __init__(self, config: Any) -> None:
+        self.config = config
+        self.started = False
+        self.should_exit = False
+
+    async def serve(self, sockets: Any = None) -> None:
+        self.started = True
+        await asyncio.Event().wait()
+
+
+class _SwallowsCancellation:
+    """`serve()` catches the `CancelledError` and keeps running.
+
+    Empirically (plan rev 2) such a coroutine survives `wait_for`, an outer
+    `wait_for` guard, and `asyncio.run`'s own shutdown. `escape` is the test's
+    way to retire the orphan afterwards, so pytest-asyncio's loop teardown —
+    which cancels and *gathers* lingering tasks — does not itself hang on it.
+    """
+
+    instances: list[_SwallowsCancellation] = []
+
+    def __init__(self, config: Any) -> None:
+        self.config = config
+        self.started = False
+        self.should_exit = False
+        self.escape = asyncio.Event()
+        self.task: asyncio.Task[None] | None = None
+        self.swallowed = False
+        _SwallowsCancellation.instances.append(self)
+
+    async def serve(self, sockets: Any = None) -> None:
+        self.task = asyncio.current_task()
+        self.started = True
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            self.swallowed = True
+        await self.escape.wait()
+
+
+async def test_a_server_task_that_never_finishes_raises_instead_of_hanging(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On unchanged `main` this hangs forever on `await task`."""
+    monkeypatch.setattr(fake_remote.uvicorn, "Server", _NeverStops)
+    port = alloc_port()
+
+    async def _body() -> None:
+        with pytest.raises(RuntimeError) as excinfo:
+            async with fake_remote.run_fake_remote(port, expected_auth_value="x"):
+                pass
+        message = str(excinfo.value)
+        assert "did not stop" in message
+        assert str(port) in message
+        assert "server.started=True" in message
+        assert "server.should_exit=True" in message
+        assert "AppStatus.should_exit=" in message
+        # This mutant does honour the cancel, so the diagnostic must say so
+        # rather than claiming the task survived.
+        assert "SURVIVED cancellation" not in message
+
+    started = time.monotonic()
+    await _bounded(_body(), _MUTANT_BOUND)
+    elapsed = time.monotonic() - started
+    assert elapsed < _MUTANT_BOUND, elapsed
+    # The latch reset used to sit *after* `await task`, so the new diagnostic
+    # raise would have skipped it and poisoned the next test.
+    assert AppStatus.should_exit is False
+
+
+async def test_a_serve_task_that_swallows_cancellation_still_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The mutant a `wait_for`-based stop sequence cannot survive."""
+    _SwallowsCancellation.instances.clear()
+    monkeypatch.setattr(fake_remote.uvicorn, "Server", _SwallowsCancellation)
+    port = alloc_port()
+
+    async def _body() -> None:
+        with pytest.raises(RuntimeError) as excinfo:
+            async with fake_remote.run_fake_remote(port, expected_auth_value="x"):
+                pass
+        message = str(excinfo.value)
+        assert "did not stop" in message
+        assert str(port) in message
+        assert "SURVIVED cancellation" in message
+        assert "server.started=True" in message
+        assert "AppStatus.should_exit=" in message
+
+    started = time.monotonic()
+    try:
+        await _bounded(_body(), _MUTANT_BOUND)
+        elapsed = time.monotonic() - started
+        assert elapsed < _MUTANT_BOUND, elapsed
+        assert AppStatus.should_exit is False
+        assert [s.swallowed for s in _SwallowsCancellation.instances] == [True]
+    finally:
+        # Retire the orphan the mutant deliberately created. Without this it is
+        # still pending at loop teardown, where pytest-asyncio cancels and
+        # gathers lingering tasks — and this one ignores the first cancel.
+        for server in _SwallowsCancellation.instances:
+            server.escape.set()
+            if server.task is not None:
+                await asyncio.wait({server.task}, timeout=5.0)
+        _SwallowsCancellation.instances.clear()
+
+
+_TEARDOWN_HANG_MODULE = """
+import time
+
+import pytest
+
+
+@pytest.fixture
+def blocks_on_the_way_out():
+    yield
+    time.sleep(30)
+
+
+def test_passes_then_hangs_in_teardown(blocks_on_the_way_out):
+    assert True
+"""
+
+_FAULTHANDLER_MODULE = """
+import time
+
+
+def test_blocks_long_enough_to_be_dumped():
+    time.sleep(5)
+
+
+def test_sentinel_still_runs_after_the_dump():
+    assert True
+"""
+
+
+def _write_module(tmp_path: Path, body: str) -> Path:
+    path = tmp_path / "test_induced.py"
+    path.write_text(body)
+    return path
+
+
+def test_the_timeout_plugin_is_active_and_covers_teardown(
+    tmp_path: Path, pytestconfig: pytest.Config
+) -> None:
+    """A fixture whose *teardown* blocks for 30 s must be killed in seconds.
+
+    The settings are passed with `-o` on purpose: the temp file makes
+    `tmp_path` the rootdir, so this project's `[tool.pytest.ini_options]` is
+    never read. `timeout_method` is taken from the resolved project config, so
+    this certifies the method that actually ships — not Linux's default.
+    """
+    module = _write_module(tmp_path, _TEARDOWN_HANG_MODULE)
+    method = str(pytestconfig.getini("timeout_method"))
+
+    started = time.monotonic()
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(module),
+            "-p",
+            "no:cacheprovider",
+            "-o",
+            "timeout=3",
+            "-o",
+            f"timeout_method={method}",
+            "-q",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        cwd=tmp_path,
+    )
+    elapsed = time.monotonic() - started
+    output = result.stdout + result.stderr
+
+    assert result.returncode != 0, output
+    assert elapsed < 15, f"{elapsed}s\n{output}"
+    assert "imeout" in output, output
+
+
+def test_a_teardown_hang_is_not_caught_without_the_plugin(tmp_path: Path) -> None:
+    """The negative half: prove the kill above came from the plugin.
+
+    No `-o timeout=…` here — those options do not exist once the plugin is
+    disabled, and pytest would exit fast on the unknown ini key, which would
+    satisfy nothing.
+    """
+    module = _write_module(tmp_path, _TEARDOWN_HANG_MODULE)
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(module),
+            "-p",
+            "no:cacheprovider",
+            "-p",
+            "no:timeout",
+            "-q",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        cwd=tmp_path,
+    )
+    try:
+        with pytest.raises(subprocess.TimeoutExpired):
+            process.communicate(timeout=10)
+    finally:
+        process.kill()
+        process.communicate()
+
+
+def test_faulthandler_dumps_a_stack_and_the_run_continues(tmp_path: Path) -> None:
+    """The zero-risk half: it kills nothing, it only prints the stacks.
+
+    Reading the ini value cannot prove either the dump or the continuation, so
+    this induces both: a blocking item under a 2 s `faulthandler_timeout`, then
+    a sentinel item that must still run, with the session exiting normally.
+    """
+    module = _write_module(tmp_path, _FAULTHANDLER_MODULE)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            str(module),
+            "-p",
+            "no:cacheprovider",
+            "-o",
+            "faulthandler_timeout=2",
+            "-o",
+            "timeout=30",
+            "-q",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=90,
+        cwd=tmp_path,
+    )
+    output = result.stdout + result.stderr
+
+    assert "Thread 0x" in output, output
+    assert "Timeout (0:00:02)" in output, output
+    assert "2 passed" in output, output
+    assert result.returncode == 0, output
+
+
+def test_faulthandler_timeout_is_below_the_kill_timeout(
+    pytestconfig: pytest.Config,
+) -> None:
+    """So the stack dump always lands before the process-level kill.
+
+    Compared numerically: `getini` hands back a float for one and a string for
+    the other (`[tool.pytest.ini_options]` scalars load as strings), so an
+    `isinstance(..., int)` check would be invalid either way.
+    """
+    faulthandler_timeout = float(pytestconfig.getini("faulthandler_timeout"))
+    kill_timeout = float(pytestconfig.getini("timeout"))
+
+    assert faulthandler_timeout > 0
+    assert faulthandler_timeout < kill_timeout
+    # Both must fit inside the `test` job's `timeout-minutes: 25`, or the
+    # 25-minute silent cancel this change exists to replace happens anyway.
+    assert kill_timeout < 25 * 60

--- a/uv.lock
+++ b/uv.lock
@@ -1092,6 +1092,7 @@ all = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "sse-starlette" },
     { name = "starlette" },
@@ -1104,6 +1105,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
@@ -1131,6 +1133,7 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.0" },
+    { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.8.0" },
@@ -1486,6 +1489,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stage 1 of Consiliency/pmcp#200: **diagnostics only**.

Five `test (3.x)` jobs in the week to 2026-09-01 stalled inside
`tests/runtime/test_emitter_harness.py` and were killed by the job's
`timeout-minutes: 25`. GitHub reports a timed-out job as *cancelled*, not failed,
so not one of them produced a red X, a traceback, or a single line of evidence
about which await was stuck.

**This does not fix the hang.** The root cause is not known, and a fix chosen now
would be a guess frozen into the suite — the failure class this repo has hit
before. No file under `src/` is touched (`git diff --name-only origin/main..HEAD
-- src/` is empty). Stage 2 is filed separately and starts when an occurrence
produces the traceback this change exists to capture.

## What ships

**`pyproject.toml`** — `faulthandler_timeout = 120` (the zero-risk half: it kills
nothing, it dumps every thread's stack and lets the run continue) plus
`timeout = 700` / `timeout_method = "signal"` via `pytest-timeout`, newly declared
in the `dev` extra and locked. Both numbers derive from `--durations=25` measured
in this change: the slowest non-`live` test is **60.25 s**, so the dump lands
~9.7 minutes before the kill and both sit well inside the 25-minute job cap.

**`tests/runtime/fake_remote.py`** — `run_fake_remote`'s unbounded `await task`
is bounded and now raises a message naming the port, `server.started`,
`server.should_exit`, `AppStatus.should_exit`, and **whether the `serve()` task
survived cancellation** — the single most valuable fact for stage 2, and one no
stack dump reports, since an idle loop parked in `epoll.poll()` names nothing.

Deliberately **not** `asyncio.wait_for`: it cancels and then waits for the
cancellation to *finish*, so a `serve()` that swallows `CancelledError` hangs it
exactly as hard as the bare `await` it replaces. The `AppStatus.should_exit`
reset moves into a nested unconditional `finally` — it used to sit *after*
`await task`, so the new raise would have skipped it and poisoned the next test.

**`tests/runtime/test_hang_diagnostics.py`** — six proofs. "The suite no longer
hangs" passes on unchanged `main`, so each one induces a hang deterministically
and asserts the diagnostic fires, mutant-style:

- two `serve()` mutants — one that never returns, one that **swallows
  `CancelledError`**. The second is the one that matters: a `wait_for`-based
  implementation passes the first and hangs on the second.
- a subprocess whose **fixture teardown** blocks 30 s, proven caught *with* the
  plugin (non-zero in ~3.4 s) and **not** caught with `-p no:timeout` (still
  running when killed at 10 s, exit 124). Teardown coverage is the whole point:
  pytest prints `PASSED` when the test function returns, *before* teardown, so
  the likeliest hang site is after the last `PASSED` line in those five logs.
- a faulthandler run proving the dump fires, the sentinel test after it still
  runs, and pytest exits 0.

Full transcript with exit codes: `.consiliency/evidence/hang-diagnostics-200.md`.

## `timeout_method` was selected, not assumed

Both `signal` and `thread` cover teardown, so the plan's fallback ("accept
`thread` if only it passes") was not needed. `signal` is strictly better on the
axis that separates them: it reports a normal pytest ERROR with the offending
frame **and the session continues to a summary**, whereas `thread` hard-exits the
process mid-report and loses the rest of the run.

## Two deviations from the plan, stated deliberately

1. **`timeout = 700`, not the plan's literal 600.** The plan also requires
   "≥ 10× the slowest non-`live` test as measured in this change". The slowest is
   60.25 s, so 600 is 9.96× and fails that bar. (The plan's own figure of 60.06 s
   already made 10× = 600.6 > 600.) The criterion wins.
2. **The "19 deselected / 1019 collected" criterion is rev-1 residue**,
   contradicted by the plan's own research section ("3386 passed, 3 skipped,
   25 deselected"). Measured on the unmodified tree: **3389/3414, 25 deselected**.
   The criterion's structure is satisfied against the real baseline.

## Verification

| command | result |
|---|---|
| `pytest -q tests/runtime/test_hang_diagnostics.py` | 6 passed in 43.89s, exit 0 |
| `pytest -q tests/runtime` | 66 passed (60 pre-existing + 6 new), exit 0 |
| `pytest --collect-only -q tests/` | 3395/3420, 25 deselected (was 3389/3414, 25) |
| `ruff check` / `ruff format --check` | clean / 129 files formatted, exit 0 |
| `mypy src/` | no issues in 43 files, exit 0 |
| `scripts/check_workflows.py --base-ref origin/main` | workflow guards: OK, exit 0 |

Full suite, same command from the same directory both sides:

```
before: 107 failed, 3173 passed, 3 skipped, 25 deselected, 106 errors in 349.49s
after:  107 failed, 3179 passed, 3 skipped, 25 deselected, 106 errors in 369.69s
```

Passes +6 (exactly the new tests); failures, skips, deselections and errors
unchanged. The 107/106 are a host quirk, not a regression: `/tmp/package.json`
exists on this machine and the npm identity resolver's `localPrefix` walk finds
it, documented in `tests/conftest.py`. Identical on both sides.

No `CHANGELOG.md` entry: the `changelog` job requires one only for `src/` changes.

## Correction to the record

The installed **sse_starlette is 3.1.1**, whose `AppStatus` is exactly
`{should_exit, original_handler, handle_exit}` — there is **no
`should_exit_event`**, so the fix floated in #200's early comment ("reset
`should_exit_event = None`") cannot be written as stated. 3.1.1 keeps a
per-event-loop `_ShutdownState` in a `contextvars.ContextVar`, and
`_get_uvicorn_server()` reads `signal.getsignal(signal.SIGTERM).__self__` and
polls *that* object's `should_exit`. The stale comments in `fake_remote.py` and
`test_downstream_remote.py` are corrected here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaTMt2NiBUwqhMoTYzTmQh

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/223"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790922035&installation_model_id=427051&pr_number=223&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F223&signature=73c20b584f1c86d487100d31430c577a72e44955a465cce3928380995b8a27b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

---

## Update (3d89d88): async hangs now name their await

The board on the first cut found — and I confirmed empirically — that every proof here induced a **synchronous** hang (`time.sleep`), where a signal traceback trivially names the line. The suspected real hang is a **suspended coroutine**, whose frames live in `Task` objects, not on any thread stack. A test awaiting an `Event` through two coroutine frames, killed by pytest-timeout, reported only:

```
asyncio/base_events.py:2019: in _run_once
selectors.py:452: in select
>   fd_event_list = self._selector.poll(timeout, max_ev)
E   Failed: Timeout (>3.0s) from pytest-timeout.
```

`epoll.poll` — invisible. Without this the PR would have turned a 25-minute cancel into a 700-second failure that still could not tell `_tap()` from `connect_server()` from `disconnect_all()`.

`tests/runtime/_hang_watchdog.py`: one session daemon thread, armed from `pytest_runtest_logstart` so the window covers **teardown**, dumping every pending task on the item's loop at 60 s — strictly below `faulthandler_timeout = 120` and the 700 s kill. It walks the `cr_await`/`ag_await` chain rather than relying on `Task.print_stack()`, because `get_stack()` returns a **single frame** for a suspended coroutine, and an `async for` suspends on an `async_generator_asend` that exposes no frame at all — which is exactly the shape of `_tap()`, the prime suspect. Every path swallows; the worst case is silence.

Scoped to `tests/runtime/` deliberately: all five CI stalls happened there, its slowest item is 26.16 s against the 60 s threshold, and at `tests/` scope the two 60.2 s progressive-disclosure tests would trip a spurious dump on essentially every run.

Three new proofs, both directions: an async hang **does** name the awaiting coroutine with the watchdog, **does not** without it (`-p no:...`), and the watchdog is actually wired into this package. Verified on this head: `test_hang_diagnostics.py` 9 passed; `tests/runtime` 69 passed with **zero** spurious dumps; ruff, mypy, `check_workflows.py` all exit 0; collection 3398/3423 (25 deselected).