### PR TITLE
fix(client): name the cause inside an exception group in every log (see #224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   3.10 raises `exceptiongroup.ExceptionGroup` from the backport. The rendered
   text goes through `sanitize_auth_diagnostic`, so flattening cannot widen
   secret exposure — most of these sites logged the raw exception before and are
-  redacted now. An AST guard fails CI if a future edit interpolates a caught
-  exception into a log call directly. See
+  redacted now. `last_error` (surfaced by `pmcp status`, `pmcp doctor` and
+  health output) and the error strings `connect_server` and `disconnect_server`
+  return to their callers were rendering the group string too, and are fixed as
+  well. An AST guard fails CI if a caught exception is interpolated into an
+  f-string or passed to `str()` anywhere inside its handler — not merely inside
+  a `logger` call, which was the guard's first, too-narrow form. One raw path
+  remains by design: a single `exc_info=` call site still attaches an
+  unsanitized traceback, tracked separately. See
   [#224](https://github.com/Consiliency/pmcp/issues/224).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   return to their callers were rendering the group string too, and are fixed as
   well. An AST guard fails CI if a caught exception is interpolated into an
   f-string or passed to `str()` anywhere inside its handler — not merely inside
-  a `logger` call, which was the guard's first, too-narrow form. One raw path
-  remains by design: a single `exc_info=` call site still attaches an
-  unsanitized traceback, tracked separately. See
+  a `logger` call, which was the guard's first, too-narrow form. The one
+  `exc_info=` call site is gone too: `exc_info` hands the raw exception to the
+  logging machinery, which appends the unredacted exception tree *after* the
+  sanitized message, so a bearer token in a transport error reached the log in
+  full. The traceback is now formatted in-process and sanitized, keeping the
+  frames. See
   [#224](https://github.com/Consiliency/pmcp/issues/224).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Downstream failures no longer log `unhandled errors in a TaskGroup` and
+  nothing else.** Every remote-transport path in `ClientManager` runs inside an
+  anyio task group, and `str(ExceptionGroup)` names neither the type nor the
+  message of what actually failed — so twenty log sites reported only that
+  string for any failure. A week of CI hangs
+  ([#200](https://github.com/Consiliency/pmcp/issues/200)) produced exactly it,
+  which is why the cause stayed unknown. `describe_exception()` flattens a
+  group to its leaf exceptions (`ConnectionResetError: peer went away`), and is
+  used at every site that logs a caught exception, including
+  `disconnect_server`'s returned error string. Detection is by duck-typing
+  `.exceptions`, because 3.11+ raises the builtin `BaseExceptionGroup` while
+  3.10 raises `exceptiongroup.ExceptionGroup` from the backport. The rendered
+  text goes through `sanitize_auth_diagnostic`, so flattening cannot widen
+  secret exposure — most of these sites logged the raw exception before and are
+  redacted now. An AST guard fails CI if a future edit interpolates a caught
+  exception into a log call directly. See
+  [#224](https://github.com/Consiliency/pmcp/issues/224).
+
+
 ### Changed
 - **Every GitHub Action is pinned to a commit SHA.** All 30 remote `uses:`
   references — 29 across the five workflows and the one inside the local

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import random
 import re
 import signal
+import traceback
 import string
 import time
 from collections import deque
@@ -2596,14 +2597,27 @@ class ClientManager:
             except asyncio.CancelledError:
                 pass
             except Exception as exc:
-                # exc_info, not just the message: this is by construction the
-                # hardest path here to reproduce (needs a caller cancelled
+                # The traceback, not just the message: this is by construction
+                # the hardest path here to reproduce (needs a caller cancelled
                 # *while* a forced owner unwind is independently failing), so
-                # the traceback matters if it's ever seen again.
+                # the frames matter if it is ever seen again.
+                #
+                # Formatted and sanitised rather than passed as `exc_info=`.
+                # `exc_info` hands the raw exception to the logging machinery,
+                # which appends the unredacted exception tree *after* the
+                # sanitised message -- so a bearer token in a transport error
+                # reached the log in full despite the message above being
+                # clean. Redaction here is best-effort defence in depth
+                # (SECURITY.md), and it cannot be applied to text the logging
+                # framework formats on its own.
+                traceback_text = "".join(
+                    traceback.format_exception(type(exc), exc, exc.__traceback__)
+                )
                 logger.warning(
                     f"[{name}] remote transport failed to unwind while "
-                    f"escalating our caller's cancellation: {describe_exception(exc)}",
-                    exc_info=exc,
+                    f"escalating our caller's cancellation: "
+                    f"{describe_exception(exc)}\n"
+                    f"{sanitize_auth_diagnostic(traceback_text, max_length=None)}"
                 )
             raise
         # NOTE: no `except Exception` here, deliberately. A transport exit

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -1258,7 +1258,7 @@ class ClientManager:
             async with self._lifecycle_lock:
                 if server_name in self._servers:
                     self._servers[server_name].status = ServerStatusEnum.ERROR
-                    self._servers[server_name].last_error = str(e)
+                    self._servers[server_name].last_error = describe_exception(e)
             return False
         finally:
             async with self._lifecycle_lock:
@@ -1284,8 +1284,8 @@ class ClientManager:
             except Exception as e:
                 if config.name in self._servers:
                     self._servers[config.name].status = ServerStatusEnum.ERROR
-                    self._servers[config.name].last_error = str(e)
-                return [f"Failed to connect to {config.name}: {e}"]
+                    self._servers[config.name].last_error = describe_exception(e)
+                return [f"Failed to connect to {config.name}: {describe_exception(e)}"]
 
     def cancel_pending_requests(self, server: str) -> int:
         """Cancel pending requests for one server and return newly cancelled count."""
@@ -2399,7 +2399,7 @@ class ClientManager:
 
         except Exception as e:
             status.status = ServerStatusEnum.ERROR
-            status.last_error = str(e)
+            status.last_error = describe_exception(e)
             for task in (managed.read_task, managed.stderr_task):
                 if task and not task.done():
                     task.cancel()
@@ -2710,7 +2710,7 @@ class ClientManager:
 
         except Exception as e:
             status.status = ServerStatusEnum.ERROR
-            status.last_error = str(e)
+            status.last_error = describe_exception(e)
             if managed.read_task and not managed.read_task.done():
                 managed.read_task.cancel()
                 try:
@@ -2857,7 +2857,7 @@ class ClientManager:
                         continue
                     self._handle_stdout_line(name, managed, raw, now)
         except Exception as e:
-            read_failure_reason = f"stdout read error: {e}"
+            read_failure_reason = f"stdout read error: {describe_exception(e)}"
             logger.warning(f"[{name}] {read_failure_reason}")
         finally:
             # Mark server as offline when stdout closes
@@ -3428,7 +3428,7 @@ class ClientManager:
 
         except Exception as e:
             status.status = ServerStatusEnum.ERROR
-            status.last_error = str(e)
+            status.last_error = describe_exception(e)
             await self._cleanup_client(name, managed)
             raise
 

--- a/src/pmcp/client/manager.py
+++ b/src/pmcp/client/manager.py
@@ -17,7 +17,7 @@ from collections import deque
 from collections.abc import Collection
 from dataclasses import dataclass, field
 from types import ModuleType
-from typing import Any, TypeVar
+from typing import Any, Iterator, TypeVar
 
 import httpx2
 import mcp.types as mcp_types
@@ -63,6 +63,76 @@ except ImportError:
     HAS_RESOURCE = False
 
 logger = logging.getLogger(__name__)
+
+# --- exception-group flattening ------------------------------------------------
+
+# How many leaf exceptions to name before summarising the rest. A TaskGroup
+# failure carries one cause in practice; the cap exists so a pathological group
+# cannot push the useful part past `sanitize_auth_diagnostic`'s truncation.
+_MAX_DESCRIBED_LEAVES = 5
+_MAX_GROUP_DEPTH = 10
+
+
+def _iter_leaf_exceptions(
+    exc: BaseException, _depth: int = 0
+) -> Iterator[BaseException]:
+    """Yield the concrete exceptions inside an exception group, recursively.
+
+    Detected by duck-typing `.exceptions` rather than `isinstance`, because the
+    type differs by interpreter: 3.11+ raises the builtin `BaseExceptionGroup`,
+    while on 3.10 anyio raises `exceptiongroup.ExceptionGroup` from the
+    backport (verified: both expose `.exceptions`, and neither name is
+    importable on the other interpreter). Every element is checked to be a
+    `BaseException`, so an unrelated class that merely has an `exceptions`
+    attribute is not mistaken for a group.
+    """
+    nested = getattr(exc, "exceptions", None)
+    if (
+        _depth < _MAX_GROUP_DEPTH
+        and isinstance(nested, (tuple, list))
+        and nested
+        and all(isinstance(item, BaseException) for item in nested)
+    ):
+        for item in nested:
+            yield from _iter_leaf_exceptions(item, _depth + 1)
+    else:
+        yield exc
+
+
+def describe_exception(exc: BaseException) -> str:
+    """Render an exception for a log line, naming the cause inside a group.
+
+    `str(ExceptionGroup)` is `"unhandled errors in a TaskGroup (1 sub-exception)"`
+    -- it names neither the type nor the message of the thing that actually
+    failed. Every remote-transport path in this class runs inside an anyio task
+    group, so that string is what these call sites logged for *any* failure, and
+    a week of CI hangs (Consiliency/pmcp#200) produced exactly it and nothing
+    else. See #224.
+
+    The result goes through `sanitize_auth_diagnostic`, which redacts URLs,
+    bearer tokens and API keys. That is not optional: flattening *increases* how
+    much of an exception's text reaches the log, and these exceptions come from
+    an HTTP transport whose messages can carry a URL or an Authorization header.
+    Most of these call sites logged the raw exception before this change; all of
+    them are redacted now.
+    """
+    leaves = list(_iter_leaf_exceptions(exc))
+    if len(leaves) == 1 and leaves[0] is exc:
+        return sanitize_auth_diagnostic(exc)
+
+    shown = leaves[:_MAX_DESCRIBED_LEAVES]
+    rendered = "; ".join(
+        f"{type(leaf).__name__}: {leaf}" if str(leaf) else type(leaf).__name__
+        for leaf in shown
+    )
+    if len(leaves) > len(shown):
+        rendered += f"; ... and {len(leaves) - len(shown)} more"
+    plural = "" if len(leaves) == 1 else "s"
+    return sanitize_auth_diagnostic(
+        f"{type(exc).__name__}({len(leaves)} sub-exception{plural}): {rendered}"
+    )
+
+
 _TaskT = TypeVar("_TaskT", bound=asyncio.Task[Any])
 
 # The three catalog kinds, in the order reconciliation fetches and applies them.
@@ -370,7 +440,7 @@ def _get_memory_usage_mb() -> float:
                 if line.startswith("VmRSS:"):
                     return int(line.split()[1]) / 1024
     except Exception as e:
-        logger.debug(f"memory usage parse error: {e}")
+        logger.debug(f"memory usage parse error: {describe_exception(e)}")
     return 0.0
 
 
@@ -388,7 +458,7 @@ def _get_system_memory_pct() -> int:
             used_pct = int((total - available) * 100 / total)
             return used_pct
     except Exception as e:
-        logger.debug(f"system memory check error: {e}")
+        logger.debug(f"system memory check error: {describe_exception(e)}")
         return 0
 
 
@@ -725,7 +795,7 @@ def _parse_tool_entries(
             )
         except Exception as e:
             logger.warning(
-                f"[{name}] Skipping unparseable tool {_entry_label(tool)}: {e}"
+                f"[{name}] Skipping unparseable tool {_entry_label(tool)}: {describe_exception(e)}"
             )
             continue
 
@@ -766,7 +836,7 @@ def _parse_resource_entries(
         except Exception as e:
             logger.warning(
                 f"[{name}] Skipping unparseable resource "
-                f"{_entry_label(resource, key='uri')}: {e}"
+                f"{_entry_label(resource, key='uri')}: {describe_exception(e)}"
             )
             continue
 
@@ -817,7 +887,7 @@ def _parse_prompt_entries(
             )
         except Exception as e:
             logger.warning(
-                f"[{name}] Skipping unparseable prompt {_entry_label(prompt)}: {e}"
+                f"[{name}] Skipping unparseable prompt {_entry_label(prompt)}: {describe_exception(e)}"
             )
             continue
 
@@ -1184,7 +1254,7 @@ class ClientManager:
                 self._lazy_configs.pop(server_name, None)
             return True
         except Exception as e:
-            logger.error(f"Failed to lazy-start {server_name}: {e}")
+            logger.error(f"Failed to lazy-start {server_name}: {describe_exception(e)}")
             async with self._lifecycle_lock:
                 if server_name in self._servers:
                     self._servers[server_name].status = ServerStatusEnum.ERROR
@@ -1310,8 +1380,9 @@ class ClientManager:
                 else:
                     await _terminate_process_tree(managed.process, name)
             except Exception as e:
-                logger.warning(f"Error disconnecting from {name}: {e}")
-                return (False, cancelled, str(e))
+                described = describe_exception(e)
+                logger.warning(f"Error disconnecting from {name}: {described}")
+                return (False, cancelled, described)
 
             await self._cancel_background_tasks(server_name=name)
             self._connect_tasks.pop(name, None)
@@ -1373,7 +1444,8 @@ class ClientManager:
                     delay = RETRY_DELAYS[attempt]
                     logger.warning(
                         f"Connection to {config.name} failed (attempt {attempt + 1}/"
-                        f"{MAX_CONNECTION_RETRIES}), retrying in {delay}s: {e}"
+                        f"{MAX_CONNECTION_RETRIES}), retrying in {delay}s: "
+                        f"{describe_exception(e)}"
                     )
                     await asyncio.sleep(delay)
 
@@ -1865,7 +1937,7 @@ class ClientManager:
                 except Exception as exc:
                     logger.warning(
                         f"[{managed.config.name}] {kind}/list page {page + 1} "
-                        f"failed ({exc}); discarding {len(collected)} entries "
+                        f"failed ({describe_exception(exc)}); discarding {len(collected)} entries "
                         f"already collected rather than publishing a partial "
                         f"listing"
                     )
@@ -2075,7 +2147,9 @@ class ClientManager:
             raise
         except Exception as e:  # pragma: no cover - defensive
             # Never let a reconcile surface as an unhandled task exception.
-            logger.warning(f"[{name}] Catalog reconciliation task failed: {e}")
+            logger.warning(
+                f"[{name}] Catalog reconciliation task failed: {describe_exception(e)}"
+            )
         finally:
             self._reconcile_reruns.discard(name)
             if self._reconcile_tasks.get(name) is asyncio.current_task():
@@ -2142,7 +2216,9 @@ class ClientManager:
             # The downstream announced a change and then failed to list. The
             # catalog has not been touched, so leaving it alone *is* the
             # rollback, and there is nothing to publish.
-            logger.warning(f"[{name}] Catalog reconciliation failed: {e}")
+            logger.warning(
+                f"[{name}] Catalog reconciliation failed: {describe_exception(e)}"
+            )
             return
 
         tools = listings["tools"]
@@ -2448,7 +2524,8 @@ class ClientManager:
         exc = task.exception()
         if exc is not None:
             logger.warning(
-                f"[{name}] remote transport owner exited unexpectedly: {exc}"
+                f"[{name}] remote transport owner exited unexpectedly: "
+                f"{describe_exception(exc)}"
             )
 
     async def _close_remote_transport(
@@ -2525,7 +2602,7 @@ class ClientManager:
                 # the traceback matters if it's ever seen again.
                 logger.warning(
                     f"[{name}] remote transport failed to unwind while "
-                    f"escalating our caller's cancellation: {exc}",
+                    f"escalating our caller's cancellation: {describe_exception(exc)}",
                     exc_info=exc,
                 )
             raise
@@ -2660,7 +2737,7 @@ class ClientManager:
                     break
                 logger.debug(f"[{name}] stderr: {line.decode().strip()}")
         except Exception as e:
-            logger.debug(f"[{name}] stderr reader error: {e}")
+            logger.debug(f"[{name}] stderr reader error: {describe_exception(e)}")
 
     def _handle_stdout_line(
         self, name: str, managed: ManagedClient, line: bytes, now: float
@@ -2856,7 +2933,7 @@ class ClientManager:
                     logger.info(f"[{name}] reconnected successfully")
                     return
                 except Exception as e:
-                    safe_error = sanitize_auth_diagnostic(e)
+                    safe_error = describe_exception(e)
                     logger.warning(
                         f"[{name}] reconnect attempt {attempt} failed: {safe_error}"
                     )
@@ -2918,7 +2995,7 @@ class ClientManager:
                     if msg_id is None and isinstance(method, str):
                         self._handle_downstream_notification(name, managed, method)
         except Exception as e:
-            logger.debug(f"[{name}] SSE read error: {e}")
+            logger.debug(f"[{name}] SSE read error: {describe_exception(e)}")
         finally:
             if managed.status.status == ServerStatusEnum.ONLINE:
                 logger.warning(f"Server {name} disconnected unexpectedly")
@@ -3151,7 +3228,9 @@ class ClientManager:
                 else:
                     await _terminate_process_tree(managed.process, name)
             except Exception as e:
-                logger.warning(f"Error disconnecting from {name}: {e}")
+                logger.warning(
+                    f"Error disconnecting from {name}: {describe_exception(e)}"
+                )
 
         # Reap servers concurrently: each _terminate_process_tree can cost up to
         # ~8s for a hung stdio server, and disconnect_all() runs under a bounded
@@ -3233,7 +3312,9 @@ class ClientManager:
             try:
                 await self._close_remote_transport(name, managed)
             except Exception as e:
-                logger.warning(f"[{name}] Error closing remote transport: {e}")
+                logger.warning(
+                    f"[{name}] Error closing remote transport: {describe_exception(e)}"
+                )
         else:
             await _terminate_process_tree(managed.process, name)
         self._clients.pop(name, None)
@@ -3763,7 +3844,7 @@ class ClientManager:
             except asyncio.CancelledError:
                 break
             except Exception as e:
-                logger.debug(f"Health monitor error: {e}")
+                logger.debug(f"Health monitor error: {describe_exception(e)}")
 
     def _check_server_health(self, name: str, managed: ManagedClient) -> bool:
         """Check server transport health, preserving status error strings."""

--- a/tests/test_exception_group_diagnostics.py
+++ b/tests/test_exception_group_diagnostics.py
@@ -203,13 +203,22 @@ class TestTheCallSitesAreWired:
         assert "ConnectionResetError" in error, error
         assert error != str(group)
 
-    def test_no_logged_exception_in_manager_is_interpolated_bare(self) -> None:
-        """Structural guard: a future edit must not reintroduce `{e}`.
+    def test_no_caught_exception_in_manager_is_stringified_bare(self) -> None:
+        """Structural guard: inside `except ... as e`, `e` may not become a
+        string except through a call.
 
-        Walks the AST for f-strings inside `except ... as <name>` handlers that
-        interpolate the bound name directly into a `logger.*` call. `str()` of
-        an exception group is the defect; `describe_exception(...)` is the fix,
-        so the bound name may only appear through a call.
+        **The first version of this guard only looked inside `logger.*` calls,
+        and that was a false green.** It passed while
+        `read_failure_reason = f"stdout read error: {e}"` (logged twice *and*
+        stored as `last_error`), four `last_error = str(e)` assignments, and the
+        error list `connect_server` returns to its caller all still rendered a
+        group as "unhandled errors in a TaskGroup". Those reach `pmcp status`,
+        `pmcp doctor`, health output and provision messages — further than any
+        log line.
+
+        So the rule is the broad one: within a handler that binds a name,
+        neither `f"...{name}..."` nor `str(name)` may appear anywhere.
+        `describe_exception(name)` is a `Call`, so the fix passes.
         """
         source = pathlib.Path(inspect.getsourcefile(manager_module) or "").read_text()
         tree = ast.parse(source)
@@ -220,29 +229,80 @@ class TestTheCallSitesAreWired:
                 continue
             bound = handler.name
             for node in ast.walk(handler):
-                if not isinstance(node, ast.Call):
-                    continue
-                func = node.func
-                if not (
-                    isinstance(func, ast.Attribute)
-                    and isinstance(func.value, ast.Name)
-                    and func.value.id == "logger"
+                if (
+                    isinstance(node, ast.FormattedValue)
+                    and isinstance(node.value, ast.Name)
+                    and node.value.id == bound
                 ):
-                    continue
-                for fstring in ast.walk(node):
-                    if not isinstance(fstring, ast.FormattedValue):
-                        continue
-                    if (
-                        isinstance(fstring.value, ast.Name)
-                        and fstring.value.id == bound
-                    ):
-                        offenders.append(
-                            f"line {fstring.lineno}: logs `{{{bound}}}` directly"
-                        )
+                    offenders.append(
+                        f"line {node.lineno}: f-string interpolates `{{{bound}}}`"
+                    )
+                elif (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "str"
+                    and len(node.args) == 1
+                    and isinstance(node.args[0], ast.Name)
+                    and node.args[0].id == bound
+                ):
+                    offenders.append(f"line {node.lineno}: calls `str({bound})`")
 
         assert not offenders, (
-            "these logger calls interpolate a caught exception directly, so an "
-            "ExceptionGroup renders as 'unhandled errors in a TaskGroup' and "
-            "names nothing (Consiliency/pmcp#224). Use describe_exception():\n  "
-            + "\n  ".join(offenders)
+            "these render a caught exception directly, so an ExceptionGroup "
+            "becomes 'unhandled errors in a TaskGroup' and names nothing "
+            "(Consiliency/pmcp#224). Use describe_exception():\n  "
+            + "\n  ".join(sorted(set(offenders)))
         )
+
+    def test_the_guard_catches_an_indirect_interpolation(self) -> None:
+        """The guard must fail on the shape that defeated its first version.
+
+        A criterion that only passes is not a criterion: this feeds the guard's
+        own logic a handler that assigns `f"{e}"` to a local and only logs it
+        later, and requires a finding.
+        """
+        snippet = (
+            "try:\n"
+            "    pass\n"
+            "except Exception as e:\n"
+            "    reason = f'boom: {e}'\n"
+            "    logger.warning(reason)\n"
+        )
+        tree = ast.parse(snippet)
+        found = [
+            node
+            for handler in ast.walk(tree)
+            if isinstance(handler, ast.ExceptHandler) and handler.name
+            for node in ast.walk(handler)
+            if isinstance(node, ast.FormattedValue)
+            and isinstance(node.value, ast.Name)
+            and node.value.id == handler.name
+        ]
+        assert found, "the guard would not catch an indirect interpolation"
+
+    async def test_last_error_names_the_cause_not_the_group(self) -> None:
+        """`last_error` reaches `pmcp status`, `pmcp doctor` and health output.
+
+        It was `str(e)` at four sites, so a user asking why a server is offline
+        was told "unhandled errors in a TaskGroup (1 sub-exception)".
+        """
+        manager = ClientManager()
+        group = await _group_from_anyio(ConnectionResetError("peer went away"))
+
+        async def _raise_group(*args: object, **kwargs: object) -> None:
+            raise group
+
+        manager._connect_singleflight = _raise_group  # type: ignore[method-assign]
+        config = MagicMock()
+        config.name = "remote"
+        manager._servers["remote"] = ServerStatus(
+            name="remote", status=ServerStatusEnum.ONLINE, tool_count=0
+        )
+
+        errors = await manager.connect_server(config)
+
+        assert errors and "ConnectionResetError" in errors[0], errors
+        assert "peer went away" in errors[0], errors
+        last_error = manager._servers["remote"].last_error or ""
+        assert "ConnectionResetError" in last_error, last_error
+        assert last_error != str(group)

--- a/tests/test_exception_group_diagnostics.py
+++ b/tests/test_exception_group_diagnostics.py
@@ -1,0 +1,248 @@
+"""`describe_exception` must name the cause inside an exception group.
+
+Consiliency/pmcp#224. Every remote-transport path in `ClientManager` runs
+inside an anyio task group, and `str(ExceptionGroup)` is
+``"unhandled errors in a TaskGroup (1 sub-exception)"`` -- it names neither the
+type nor the message of what actually failed. A week of CI hangs
+(Consiliency/pmcp#200) produced exactly that string from six call sites and
+nothing else, which is why the root cause is still unknown.
+
+The interpreter matters here and is the reason for duck-typing: on 3.11+ anyio
+raises the builtin `BaseExceptionGroup`; on 3.10 it raises
+`exceptiongroup.ExceptionGroup` from the backport. The tests below build the
+group through a real `anyio` task group rather than constructing one directly,
+so they exercise whichever type this interpreter actually produces.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import logging
+import pathlib
+from unittest.mock import MagicMock
+
+import anyio
+import pytest
+
+from pmcp.client import manager as manager_module
+from pmcp.client.manager import (
+    _MAX_DESCRIBED_LEAVES,
+    ClientManager,
+    ManagedClient,
+    _iter_leaf_exceptions,
+    describe_exception,
+)
+from pmcp.types import ServerStatus, ServerStatusEnum
+
+
+async def _raise(exc: BaseException) -> None:
+    raise exc
+
+
+async def _group_from_anyio(*excs: BaseException) -> BaseException:
+    """The group this interpreter's anyio actually raises, not a hand-built one."""
+    try:
+        async with anyio.create_task_group() as tg:
+            for exc in excs:
+                tg.start_soon(_raise, exc)
+    except BaseException as caught:  # noqa: BLE001 - the point of the helper
+        return caught
+    raise AssertionError("the task group did not raise")
+
+
+class TestTheDefect:
+    async def test_a_real_task_group_stringifies_to_nothing_useful(self) -> None:
+        # Pin the defect itself: if this ever stops being true, the whole
+        # helper is unnecessary and should go.
+        group = await _group_from_anyio(ValueError("the real cause"))
+        assert "the real cause" not in str(group)
+        assert "sub-exception" in str(group)
+
+    async def test_describe_exception_names_the_cause(self) -> None:
+        group = await _group_from_anyio(ValueError("the real cause"))
+        described = describe_exception(group)
+        assert "ValueError" in described
+        assert "the real cause" in described
+
+
+class TestLeafIteration:
+    async def test_a_plain_exception_is_its_own_leaf(self) -> None:
+        exc = RuntimeError("plain")
+        assert list(_iter_leaf_exceptions(exc)) == [exc]
+
+    async def test_every_leaf_of_a_multi_error_group_is_named(self) -> None:
+        group = await _group_from_anyio(
+            ValueError("first"), KeyError("second"), OSError("third")
+        )
+        described = describe_exception(group)
+        for fragment in (
+            "ValueError",
+            "first",
+            "KeyError",
+            "second",
+            "OSError",
+            "third",
+        ):
+            assert fragment in described, described
+
+    async def test_nested_groups_are_flattened(self) -> None:
+        inner = await _group_from_anyio(ValueError("buried"))
+        outer = await _group_from_anyio(inner)
+        leaves = list(_iter_leaf_exceptions(outer))
+        assert [type(leaf) for leaf in leaves] == [ValueError]
+        assert "buried" in describe_exception(outer)
+
+    def test_an_object_with_an_exceptions_attribute_is_not_a_group(self) -> None:
+        # Duck-typing has to be narrow: `.exceptions` holding non-exceptions is
+        # not an exception group, and treating it as one would drop the real
+        # error entirely.
+        class NotAGroup(Exception):
+            exceptions = ["not", "exceptions"]
+
+        exc = NotAGroup("the actual message")
+        assert list(_iter_leaf_exceptions(exc)) == [exc]
+        assert "the actual message" in describe_exception(exc)
+
+    def test_a_self_referential_group_terminates(self) -> None:
+        # Depth-capped rather than cycle-detected: a diagnostic helper must not
+        # be the thing that hangs the process it is diagnosing.
+        class Recursive(Exception):
+            @property
+            def exceptions(self) -> tuple[BaseException, ...]:
+                return (self,)
+
+        exc = Recursive("loops")
+        leaves = list(_iter_leaf_exceptions(exc))
+        assert leaves == [exc]
+
+    async def test_many_leaves_are_capped_and_the_remainder_counted(self) -> None:
+        count = _MAX_DESCRIBED_LEAVES + 3
+        group = await _group_from_anyio(
+            *[ValueError(f"cause-{i}") for i in range(count)]
+        )
+        described = describe_exception(group)
+        assert f"{count} sub-exceptions" in described
+        assert "and 3 more" in described
+
+
+class TestRedaction:
+    """Flattening increases how much of an exception reaches the log, and these
+    come from an HTTP transport. Every path must stay redacted."""
+
+    @pytest.mark.parametrize(
+        ("secret", "message"),
+        [
+            ("sk-topsecretvalue", "Authorization: Bearer sk-topsecretvalue"),
+            (
+                "tok-abcdef123456",
+                "failed for https://api.example.com/x?token=tok-abcdef123456",
+            ),
+        ],
+    )
+    async def test_a_secret_inside_a_group_leaf_is_redacted(
+        self, secret: str, message: str
+    ) -> None:
+        group = await _group_from_anyio(ConnectionError(message))
+        described = describe_exception(group)
+        assert secret not in described, described
+        assert "REDACTED" in described
+
+    async def test_a_secret_in_a_plain_exception_is_redacted_too(self) -> None:
+        # The single-exception path returns early; it must not skip redaction.
+        described = describe_exception(
+            ConnectionError("Authorization: Bearer sk-anothersecret")
+        )
+        assert "sk-anothersecret" not in described
+        assert "REDACTED" in described
+
+
+class TestTheCallSitesAreWired:
+    """The helper existing is not the fix; the call sites using it is.
+
+    Every test above would still pass if a call site were reverted to
+    `f"...: {e}"`, which is exactly how this defect survived: the sites looked
+    fine in isolation and only lied when handed a group.
+    """
+
+    async def test_a_failing_remote_disconnect_logs_the_leaf_not_the_group(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        manager = ClientManager()
+        status = ServerStatus(
+            name="remote", status=ServerStatusEnum.ONLINE, tool_count=0
+        )
+        managed = ManagedClient(
+            config=MagicMock(),
+            process=None,
+            is_remote=True,
+            write_stream=MagicMock(),
+            status=status,
+        )
+        manager._clients["remote"] = managed
+        manager._servers["remote"] = status
+
+        group = await _group_from_anyio(ConnectionResetError("peer went away"))
+
+        async def _raise_group(*args: object, **kwargs: object) -> None:
+            raise group
+
+        manager._close_remote_transport = _raise_group  # type: ignore[method-assign]
+
+        with caplog.at_level(logging.WARNING):
+            ok, _cancelled, error = await manager.disconnect_server(
+                "remote", force=True
+            )
+
+        assert ok is False
+        logged = "\n".join(record.getMessage() for record in caplog.records)
+        assert "ConnectionResetError" in logged, logged
+        assert "peer went away" in logged, logged
+        # The returned error reaches the caller of the public API, so it must
+        # not be the useless group string either.
+        assert "ConnectionResetError" in error, error
+        assert error != str(group)
+
+    def test_no_logged_exception_in_manager_is_interpolated_bare(self) -> None:
+        """Structural guard: a future edit must not reintroduce `{e}`.
+
+        Walks the AST for f-strings inside `except ... as <name>` handlers that
+        interpolate the bound name directly into a `logger.*` call. `str()` of
+        an exception group is the defect; `describe_exception(...)` is the fix,
+        so the bound name may only appear through a call.
+        """
+        source = pathlib.Path(inspect.getsourcefile(manager_module) or "").read_text()
+        tree = ast.parse(source)
+        offenders: list[str] = []
+
+        for handler in ast.walk(tree):
+            if not isinstance(handler, ast.ExceptHandler) or not handler.name:
+                continue
+            bound = handler.name
+            for node in ast.walk(handler):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                if not (
+                    isinstance(func, ast.Attribute)
+                    and isinstance(func.value, ast.Name)
+                    and func.value.id == "logger"
+                ):
+                    continue
+                for fstring in ast.walk(node):
+                    if not isinstance(fstring, ast.FormattedValue):
+                        continue
+                    if (
+                        isinstance(fstring.value, ast.Name)
+                        and fstring.value.id == bound
+                    ):
+                        offenders.append(
+                            f"line {fstring.lineno}: logs `{{{bound}}}` directly"
+                        )
+
+        assert not offenders, (
+            "these logger calls interpolate a caught exception directly, so an "
+            "ExceptionGroup renders as 'unhandled errors in a TaskGroup' and "
+            "names nothing (Consiliency/pmcp#224). Use describe_exception():\n  "
+            + "\n  ".join(offenders)
+        )

--- a/tests/test_exception_group_diagnostics.py
+++ b/tests/test_exception_group_diagnostics.py
@@ -20,6 +20,7 @@ import ast
 import inspect
 import logging
 import pathlib
+import traceback
 from unittest.mock import MagicMock
 
 import anyio
@@ -306,3 +307,47 @@ class TestTheCallSitesAreWired:
         last_error = manager._servers["remote"].last_error or ""
         assert "ConnectionResetError" in last_error, last_error
         assert last_error != str(group)
+
+    def test_no_raw_exception_reaches_the_log_via_exc_info(self) -> None:
+        """`exc_info=` hands the RAW exception to the logging machinery.
+
+        Python then appends the unredacted exception tree *after* the sanitised
+        message, so a bearer token in a transport error reached the log in full
+        while the message above it looked clean. `record.getMessage()` cannot
+        see that, which is why the first version of these tests missed it.
+        Formatting the traceback ourselves and sanitising it keeps the frames
+        and closes the hole.
+        """
+        source = pathlib.Path(inspect.getsourcefile(manager_module) or "").read_text()
+        tree = ast.parse(source)
+        offenders = [
+            f"line {kw.value.lineno}"
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "logger"
+            for kw in node.keywords
+            if kw.arg == "exc_info"
+        ]
+        assert not offenders, (
+            "logger calls passing exc_info attach an unsanitised traceback; "
+            "format it and pass it through sanitize_auth_diagnostic instead "
+            "(Consiliency/pmcp#224):\n  " + "\n  ".join(offenders)
+        )
+
+    def test_a_formatted_traceback_is_sanitised(self) -> None:
+        from pmcp.auth import sanitize_auth_diagnostic
+
+        try:
+            raise ConnectionError("Authorization: Bearer sk-tracebacksecret")
+        except ConnectionError as exc:
+            text = "".join(
+                traceback.format_exception(type(exc), exc, exc.__traceback__)
+            )
+        assert "sk-tracebacksecret" in text, "the fixture must contain the secret"
+        cleaned = sanitize_auth_diagnostic(text, max_length=None)
+        assert "sk-tracebacksecret" not in cleaned, cleaned
+        # The frames must survive redaction, or this trade was not worth making.
+        assert "Traceback (most recent call last)" in cleaned
+        assert "test_a_formatted_traceback_is_sanitised" in cleaned


### PR DESCRIPTION
See Consiliency/pmcp#224. First half of stage 2: make the failures legible. No behavioural change to the transport itself.

**The defect.** Every remote-transport path in `ClientManager` runs inside an anyio task group, and `str(ExceptionGroup)` is `"unhandled errors in a TaskGroup (1 sub-exception)"` — it names neither the type nor the message of what actually failed. That string was the entire content of **20 log sites**, and it is what a week of CI hangs (#200) produced instead of a cause:

```
[fr-emit-remove] remote transport owner exited unexpectedly: unhandled errors in a TaskGroup (1 sub-exception)
[fr-emit-remove] Catalog reconciliation failed: Server fr-emit-remove disconnected
Connection to fr-emit-remove failed (attempt 1/3), retrying in 1.0s: unhandled errors in a TaskGroup (1 sub-exception)
```

**The fix.** `describe_exception()` flattens a group to its leaves and renders `ConnectionResetError: peer went away`.

- **Duck-types `.exceptions`** rather than `isinstance`: 3.11+ raises the builtin `BaseExceptionGroup`, 3.10 raises `exceptiongroup.ExceptionGroup` from the backport (verified in this repo's 3.10 venv), and neither name imports on the other interpreter. Narrowed by requiring every element to be a `BaseException`, and depth-capped so a self-referential group cannot hang the thing doing the diagnosing.
- **Goes through `sanitize_auth_diagnostic`.** Not optional: flattening *increases* how much exception text reaches the log, and these come from an HTTP transport whose messages can carry a URL or an `Authorization` header. Most of these sites logged the raw exception before, so they are newly redacted as well as newly useful.
- Applied at **all 20 sites**, and to the error string `disconnect_server` returns to its caller — that reached the public API as the useless string too.

**Scope note.** #224 named 5 sites, from the CI log. The AST guard below found **14 more**, including `SSE read error` in `_read_sse` and `Catalog reconciliation failed` — both directly on the path #224 is chasing. Fixing the class rather than the instances is deliberate.

**Tests** (`tests/test_exception_group_diagnostics.py`, 13):
- The defect itself is pinned — if `str(group)` ever becomes useful, the helper should go.
- Groups are built through a **real anyio task group**, so they exercise whichever type this interpreter produces rather than a hand-built one.
- Nested groups flatten; a class with a non-exception `.exceptions` is *not* treated as a group; a self-referential group terminates; many leaves are capped and the remainder counted.
- Redaction holds on both the group path and the single-exception early return.
- **Wiring**, not just the helper: a failing remote disconnect must log `ConnectionResetError: peer went away` and return it. Every other test would pass with a call site reverted — which is how this defect survived.
- **AST structural guard**: fails if any `logger.*` call interpolates a caught exception directly.

**Verification** (each run in the step it is reported): new file `13 passed`; full suite `3195 passed` vs main's 3182 (+13, exactly the new tests) with failures/errors/skips/deselects identical — the 107/106 are the documented `/tmp/package.json` host quirk; `ruff check`, `ruff format --check`, `mypy src/` all exit 0.

**Also, unrelated to this diff but recorded on #224:** the #200 flake now reproduces **locally**, 1 run in 25 of `tests/runtime/test_emitter_harness.py` alone — same test, same message as CI. Stage 2 no longer needs to wait on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NR2LKqZgn7CXVH2816gaa

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791011925&installation_model_id=427051&pr_number=225&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F225&signature=83e6a62e462250aa04863a97489fde8a7fb7497a1be15135d8360acb141f6c11"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->