### PR TITLE
fix(env): stop the project .env reaching downstream servers (see #229)

### DIFF
--- a/.consiliency/plans/detailed-env-leak-availability-check-20260906-0300.md
+++ b/.consiliency/plans/detailed-env-leak-availability-check-20260906-0300.md
@@ -1,4 +1,36 @@
-# Detailed plan: stop an availability *check* from loading the project `.env` into the gateway
+# Detailed plan: stop the project `.env` reaching downstream servers
+
+> **Revision 2 (2026-09-06).** Rev 1 boarded 1 AGREE / 1 PARTIALLY AGREE / 1
+> DISAGREE. Four defects, all verified against source; one is a **scope error
+> that would have shipped a fix which did not close the leak**.
+>
+> 1. **`cli.py:2699` is the primary leak path, and rev 1 declared it out of
+>    scope.** `main()` — the gateway entry point — calls bare `load_dotenv()`,
+>    which loads the project `.env` into `os.environ` at startup,
+>    unconditionally, before any availability check runs. Fixing only
+>    `_check_api_key_available` would have closed a side door, left the front
+>    door open, and then updated SECURITY.md to say the leak was closed. The
+>    centre of gravity moves accordingly (see Changes).
+> 2. **The resolver was never wired.** Rev 1 put the non-mutating resolver in
+>    `loader.py` but did not list the `handlers.py` call site that actually
+>    passes `os.environ.get` — so decision (A) would not have worked and
+>    `test_the_servers_own_credential_still_resolves` would have failed. Found
+>    independently by two seats.
+> 3. **`interpolate=False` is not equivalent to `load_dotenv`.** Measured:
+>    for `DERIVED=${BASE}/x`, `dotenv_values(..., interpolate=False)` yields the
+>    literal `${BASE}/x` while `load_dotenv` yields `abc/x`. Swapping one for the
+>    other silently changes values, which the "same boolean as main" criterion
+>    would not necessarily catch.
+> 4. **Removing the import breaks an existing test.** `tests/test_tools.py:3587`
+>    does `monkeypatch.setattr("pmcp.tools.handlers.load_dotenv", ...)`; deleting
+>    the import makes that raise `AttributeError`.
+>
+> Also carried in: `read_env_file` must be guarded against `OSError` /
+> `PermissionError` on an existing-but-unreadable file, and empty-value priority
+> differs between the two approaches (an empty higher-priority value blocks a
+> later file under `load_dotenv`'s no-override semantics, but not under
+> per-file dicts).
+
 
 ## Task
 
@@ -102,13 +134,41 @@ deliberate deprecation with a CHANGELOG note, not a side effect of a security fi
 
 ## Changes
 
+### `src/pmcp/env_store.py` (modify) — the load-bearing change
+
+**The leak is closed at the boundary that owns it.** The gateway legitimately
+loads `.env` for its own configuration (`cli.py:2699`); what must not happen is
+that those keys are inherited by third-party downstream servers. So
+`sanitized_subprocess_env` — which already exists to strip PMCP-managed keys and
+already documents this exact gap — also strips keys sourced from the **project
+`.env`**, except the server's own declared `env_var` (decision (A)).
+
+- `project_env_keys(project)` — add — `set(read_env_file(<project>/".env"))`,
+  `OSError`-guarded, returning an empty set when absent or unreadable.
+- `sanitized_subprocess_env` — modify — strip `managed_secret_keys(...)` **and**
+  `project_env_keys(...)`, then apply `own_env` (which still wins, so the
+  declared credential is restored for the server that declared it).
+- The docstring's "secrets the operator exported into the shell or a plain
+  `.env` are not sanitized here" — modify — a plain `.env` now **is** stripped;
+  shell-exported secrets still are not. Do not overclaim the second half.
+
 ### `src/pmcp/tools/handlers.py` (modify)
 
 - `_check_api_key_available` — modify — answer from `env_store.read_env_file(path)`
   instead of `load_dotenv(path)` + `os.environ.get`. Check `os.environ` first
   (unchanged fast path), then each file's parsed dict. **No process state is
   mutated.** Docstring states that the check is now side-effect free and why.
-- The `load_dotenv` import (`:21`) — delete — this is its only use in the module.
+- The `load_dotenv` import (`:21`) — **keep**, or update
+  `tests/test_tools.py:3587` in the same change. **WAS WRONG (rev 1):** "delete"
+  — that test monkeypatches `pmcp.tools.handlers.load_dotenv` and `setattr`
+  raises when the attribute is gone. Deleting it is fine *if* the test is updated
+  to patch the new seam; decide once, and state which.
+- The `_manifest_server_to_config(..., os.environ.get)` call site — modify — pass
+  the non-mutating resolver instead. **WAS WRONG (rev 1):** the resolver was
+  specified in `loader.py` and never wired here, so decision (A) would not have
+  worked.
+- `read_env_file` calls — wrap in `try/except OSError` — an existing-but-unreadable
+  `.env` must answer "no", not raise.
 
 ### `src/pmcp/config/loader.py` (modify)
 
@@ -197,7 +257,10 @@ whose value is empty (today falsy → "not available"; keep that).
 
 ## Non-goals
 
-- The three `load_dotenv` calls in `cli.py` — deliberate startup configuration.
+- **Removing** `cli.py`'s startup `load_dotenv()`. The gateway may keep reading
+  `.env` for its own configuration; what changes is that those keys no longer
+  reach downstream servers. **WAS WRONG (rev 1):** this was listed as simply out
+  of scope, which is what let the primary leak path survive the fix.
 - Sanitising shell-exported secrets. `sanitized_subprocess_env` inherits ambient
   environment by design; changing that is a separate decision with a much larger
   blast radius.

--- a/.consiliency/plans/detailed-env-leak-availability-check-20260906-0300.md
+++ b/.consiliency/plans/detailed-env-leak-availability-check-20260906-0300.md
@@ -1,0 +1,209 @@
+# Detailed plan: stop an availability *check* from loading the project `.env` into the gateway
+
+## Task
+
+Close Consiliency/pmcp#229 (review finding **S-02**, HIGH). `_check_api_key_available`
+calls `load_dotenv()` as a side effect of answering "is this key available?".
+`load_dotenv` mutates `os.environ` process-wide, so a *lookup* loads every key of
+the current directory's `.env` into the gateway — and from there into every
+downstream server PMCP spawns.
+
+## Research summary
+
+Verified against `origin/main` at `aa2de50`.
+
+**The defect** (`src/pmcp/tools/handlers.py:2926-2947`):
+
+```python
+def _check_api_key_available(self, env_var: str | None) -> bool:
+    if os.environ.get(env_var):
+        return True
+    for env_path in [Path.cwd()/".env", Path.cwd()/".env.pmcp",
+                     Path.home()/".config"/"pmcp"/"pmcp.env"]:
+        if env_path.exists():
+            load_dotenv(env_path)              # <-- mutates os.environ
+            if os.environ.get(env_var):
+                return True
+    return False
+```
+
+Note the shape: the function answers a **boolean question** and its only way of
+answering is to **change global process state**. Every key in the file is loaded,
+not just `env_var`. It is the sole `load_dotenv` in `handlers.py` (`:2942`); the
+three in `cli.py` (`:2699-2702`) are deliberate startup configuration and are
+**out of scope**.
+
+**The leak reaches spawned servers, and the code says so.** `env_store.sanitized_subprocess_env`
+(`src/pmcp/env_store.py:124`) builds a downstream server's environment from
+`os.environ.copy()` minus PMCP-managed keys, and its own docstring records the
+gap:
+
+> "this removes only PMCP-managed keys; secrets the operator exported into the
+> shell **or a plain `.env`** are not sanitized here."
+
+`managed_secret_keys` (`:107`) says the same: "**not** secrets that reached
+`os.environ` from the operator's shell or a plain `.env`". So keys this check
+loads are precisely the keys the sanitiser does not strip. End to end: a project
+`.env` containing an unrelated database URL or a third-party token is inherited
+by every MCP server the gateway starts.
+
+**The clean primitive already exists.** `env_store.read_env_file(path)`
+(`:45`) parses with `dotenv_values(path, interpolate=False)` and returns a
+`dict[str, str]` **without touching `os.environ`**. The fix is to answer the
+question from that dict.
+
+**Someone already knew.** `tests/test_tools.py:3586` carries the comment
+"Prevent `_check_api_key_available` from loading env vars out of pmcp files on
+disk" — the hazard was known well enough to work around in a test, but not
+closed at the source.
+
+**Callers** (only two): `_check_any_api_key_available` (`:2950`) and
+`is_auth_available=self._check_api_key_available` passed into
+`resolve_startup_configs` (`:2239`). Both want a boolean. Neither reads the
+side effect.
+
+**The load-bearing question, and it is real.** Credential *resolution* for a
+manifest server runs through `_manifest_server_to_config(server, env_lookup)`
+(`src/pmcp/config/loader.py:980`), and `handlers.py:200` records that it is
+called with **`os.environ.get`**. So today, a credential that lives **only** in a
+plain project `.env` reaches a server *because* the availability check loaded it
+first. Removing the mutation removes that path. Whether that path should exist
+is a **product decision**, not an implementation detail — see Decision below.
+
+## Decision required before implementation
+
+Three env files are consulted. They are not equivalent:
+
+| file | owner | today | after a naive fix |
+|---|---|---|---|
+| `~/.config/pmcp/pmcp.env` | PMCP (`pmcp secrets set`) | loaded | must still resolve |
+| `<cwd>/.env.pmcp` | PMCP, project scope | loaded | must still resolve |
+| `<cwd>/.env` | **the operator's project**, not PMCP | loaded **and leaked** | ? |
+
+The leak is the third row. The question is whether a plain `.env` stays a
+*credential source* for a server's own declared `env_var`:
+
+- **(A) Keep it, narrowly.** Resolve the specific `env_var` from `.env` and inject
+  it into that server's own env only. Preserves today's behaviour for anyone
+  keeping credentials in a project `.env`; closes the leak, because only the
+  named key moves and only into the server that declared it.
+- **(B) Drop it.** PMCP's own stores remain credential sources; a plain `.env`
+  becomes lookup-only for availability, never a source. Simpler and safer, but a
+  **behaviour change**: a server whose key lives only in `.env` stops receiving
+  it, and `gateway.provision` may start reporting a credential as missing where
+  it previously worked.
+
+**Recommendation: (A).** It closes the reported vulnerability without removing a
+working configuration path, and the narrowing — one named key, one server — is
+exactly the property S-02 says is missing. (B) is defensible but should be a
+deliberate deprecation with a CHANGELOG note, not a side effect of a security fix.
+
+**This plan is written for (A) and must be re-read if the operator picks (B).**
+
+## Changes
+
+### `src/pmcp/tools/handlers.py` (modify)
+
+- `_check_api_key_available` — modify — answer from `env_store.read_env_file(path)`
+  instead of `load_dotenv(path)` + `os.environ.get`. Check `os.environ` first
+  (unchanged fast path), then each file's parsed dict. **No process state is
+  mutated.** Docstring states that the check is now side-effect free and why.
+- The `load_dotenv` import (`:21`) — delete — this is its only use in the module.
+
+### `src/pmcp/config/loader.py` (modify)
+
+- A resolver that, given a server's declared `env_var`, returns its value from
+  `os.environ` and then from the three env files, **without mutation** — the
+  lookup `_manifest_server_to_config` is handed instead of bare `os.environ.get`.
+  Keep it a plain `Callable[[str], str | None]` so the existing seam is unchanged;
+  do **not** widen `_manifest_server_to_config`'s signature.
+
+### `tests/test_env_leak_229.py` (create)
+
+The proofs. Each must fail on unchanged `main`:
+
+- `test_the_availability_check_does_not_mutate_os_environ` — write a `.env` with a
+  sentinel key PMCP does not manage, ask about an **unrelated** variable, assert
+  the answer is correct **and** the sentinel is absent from `os.environ`. On
+  `main` the sentinel is present.
+- `test_a_project_env_secret_never_reaches_a_spawned_server` — the end-to-end one:
+  the same sentinel must not appear in `sanitized_subprocess_env()`. This is the
+  criterion that matches the reported impact; the previous test alone would pass
+  against an implementation that leaked by some other route.
+- `test_the_servers_own_credential_still_resolves` — decision (A)'s other half:
+  a server whose declared `env_var` lives only in `.env` still receives it.
+- `test_only_the_declared_key_is_injected` — the narrowing: a *second* key in the
+  same `.env` does not reach that server.
+- `test_pmcp_managed_stores_still_answer` — `.env.pmcp` and `~/.config/pmcp/pmcp.env`
+  still satisfy the availability check.
+- `test_no_load_dotenv_outside_cli` — structural guard, in the spirit of the
+  #224/#225 AST guards: `load_dotenv` may appear only in `cli.py`. Prevents the
+  side effect being reintroduced anywhere else.
+
+## Documentation impact
+
+- `SECURITY.md` — modify — the "Credential isolation is scoped, not
+  identity-complete" bullet, and the `sanitized_subprocess_env` gap it mirrors,
+  must stop describing a plain `.env` as unsanitised-and-inherited once that is no
+  longer true. Do not overclaim: shell-exported secrets are still inherited.
+- `CHANGELOG.md` — add — `### Security`, naming the leak and the behaviour after
+  the fix. `src/` changes, so the `changelog` CI job requires it.
+
+## Dependencies & order
+
+1. Settle the Decision. (A) and (B) produce different tests.
+2. `tests/test_env_leak_229.py` first, red against `main`.
+3. `_check_api_key_available` + import removal.
+4. The non-mutating resolver, only if (A).
+5. Docs.
+
+## Verification
+
+```bash
+uv run pytest -q tests/test_env_leak_229.py          # the six proofs
+uv run pytest -q tests/test_tools.py                  # the 2239/2950 callers
+uv run pytest -q tests/                               # full suite; compare to main
+uv run ruff check src/ tests/ scripts/ && uv run ruff format --check src/ tests/ scripts/
+uv run mypy src/
+grep -rn "load_dotenv" src/                           # expect: cli.py only
+```
+
+Host note: `/tmp/package.json` makes ~107 npm-identity tests fail here
+(`tests/conftest.py`); compare the same command from the same directory
+before and after, not against a clean-machine expectation.
+
+Edge cases: no `.env` present; `.env` unreadable (must not raise — an
+availability check that throws is worse than one that says "no"); the same key in
+two files (first hit wins, preserving today's documented priority order); a key
+whose value is empty (today falsy → "not available"; keep that).
+
+## Acceptance criteria
+
+- [ ] A sentinel key in `<cwd>/.env`, unrelated to the variable being asked about,
+      is **absent from `os.environ`** after the availability check — where on
+      unchanged `main` it is present.
+- [ ] That sentinel is **absent from `sanitized_subprocess_env()`**, i.e. it never
+      reaches a spawned server. This is the reported impact and the criterion that
+      matters most.
+- [ ] The availability check returns the **same boolean** as `main` for every
+      combination of {present, absent} × {`.env`, `.env.pmcp`, `pmcp.env`,
+      `os.environ`} — a fix that closes the leak by answering "no" more often is
+      not a fix.
+- [ ] Under decision (A): a server whose declared `env_var` exists only in `.env`
+      still receives it, **and** a second key in that same file does not.
+- [ ] `grep -rn "load_dotenv" src/` returns only `cli.py`, enforced by a test.
+- [ ] Full-suite failures/skips/deselects unchanged from `main`; passes increase by
+      exactly the new tests.
+
+## Non-goals
+
+- The three `load_dotenv` calls in `cli.py` — deliberate startup configuration.
+- Sanitising shell-exported secrets. `sanitized_subprocess_env` inherits ambient
+  environment by design; changing that is a separate decision with a much larger
+  blast radius.
+- The wider trust-boundary programme (#230). This fix stands alone and should not
+  wait for it.
+
+## Execution Policy
+
+- execute: effort=medium, reason=small diff but it changes credential-resolution behaviour and the tests must prove absence rather than presence

--- a/.consiliency/plans/detailed-env-leak-availability-check-20260906-0300.md
+++ b/.consiliency/plans/detailed-env-leak-availability-check-20260906-0300.md
@@ -1,280 +1,216 @@
 # Detailed plan: stop the project `.env` reaching downstream servers
 
-> **Revision 2 (2026-09-06).** Rev 1 boarded 1 AGREE / 1 PARTIALLY AGREE / 1
-> DISAGREE. Four defects, all verified against source; one is a **scope error
-> that would have shipped a fix which did not close the leak**.
+> **Revision 3 (2026-09-06).** Revs 1 and 2.1 boarded DISAGREE. Six defects
+> across them, all one class: **both revisions tried to re-derive what
+> `load_dotenv` had done — which keys it introduced, how it interpolated, how
+> empty values shadow — instead of simply recording it.** Rev 3 changes the
+> mechanism rather than patching the findings:
 >
-> 1. **`cli.py:2699` is the primary leak path, and rev 1 declared it out of
->    scope.** `main()` — the gateway entry point — calls bare `load_dotenv()`,
->    which loads the project `.env` into `os.environ` at startup,
->    unconditionally, before any availability check runs. Fixing only
->    `_check_api_key_available` would have closed a side door, left the front
->    door open, and then updated SECURITY.md to say the leak was closed. The
->    centre of gravity moves accordingly (see Changes).
-> 2. **The resolver was never wired.** Rev 1 put the non-mutating resolver in
->    `loader.py` but did not list the `handlers.py` call site that actually
->    passes `os.environ.get` — so decision (A) would not have worked and
->    `test_the_servers_own_credential_still_resolves` would have failed. Found
->    independently by two seats.
-> 3. **`interpolate=False` is not equivalent to `load_dotenv`.** Measured:
->    for `DERIVED=${BASE}/x`, `dotenv_values(..., interpolate=False)` yields the
->    literal `${BASE}/x` while `load_dotenv` yields `abc/x`. Swapping one for the
->    other silently changes values, which the "same boolean as main" criterion
->    would not necessarily catch.
-> 4. **Removing the import breaks an existing test.** `tests/test_tools.py:3587`
->    does `monkeypatch.setattr("pmcp.tools.handlers.load_dotenv", ...)`; deleting
->    the import makes that raise `AttributeError`.
+> - **rev 1** fixed `_check_api_key_available` and declared `cli.py` out of
+>   scope, leaving the primary leak path (`cli.py:2699`, the entry point) open.
+> - **rev 2.1** moved the fix to the subprocess boundary but stripped **by key
+>   name**, which would delete a shell-provided `PATH` that merely shares a name
+>   with a `.env` entry; and its end-to-end test could pass **without the
+>   sanitiser being touched at all**, because once the availability check stops
+>   mutating, the sentinel never enters `os.environ` for the test to find.
+> - Both left `interpolate=False` vs `load_dotenv` and empty-value shadowing
+>   unresolved, and rev 2.1's "Dependencies & order" never listed its own
+>   load-bearing `env_store` step.
 >
-> Also carried in: `read_env_file` must be guarded against `OSError` /
-> `PermissionError` on an existing-but-unreadable file, and empty-value priority
-> differs between the two approaches (an empty higher-priority value blocks a
-> later file under `load_dotenv`'s no-override semantics, but not under
-> per-file dicts).
-
+> **Rev 3 records provenance instead of reconstructing it.** No dotenv file is
+> re-parsed, no semantics are emulated, and `load_dotenv` keeps its exact current
+> behaviour everywhere it is called.
 
 ## Task
 
-Close Consiliency/pmcp#229 (review finding **S-02**, HIGH). `_check_api_key_available`
-calls `load_dotenv()` as a side effect of answering "is this key available?".
-`load_dotenv` mutates `os.environ` process-wide, so a *lookup* loads every key of
-the current directory's `.env` into the gateway — and from there into every
-downstream server PMCP spawns.
+Close Consiliency/pmcp#229 (review finding **S-02**, HIGH): keys from the
+operator's project `.env` are inherited by every downstream MCP server PMCP
+spawns.
 
 ## Research summary
 
 Verified against `origin/main` at `aa2de50`.
 
-**The defect** (`src/pmcp/tools/handlers.py:2926-2947`):
+**Two sites put `.env` into `os.environ`, not one.**
+
+1. `src/pmcp/cli.py:2699` — bare `load_dotenv()` in `main()`, which
+   `pyproject.toml:134` declares as the console-script entry
+   (`pmcp = "pmcp.cli:main"`). It loads `<cwd>/.env` unconditionally at startup,
+   before anything else. **This is the primary path**, and rev 1 wrongly called
+   it out of scope.
+2. `src/pmcp/tools/handlers.py:2942` — `load_dotenv(env_path)` inside
+   `_check_api_key_available`, which answers a **boolean question** by mutating
+   global process state, loading every key in the file rather than the one asked
+   about.
+
+**The inheritance is real and the code documents it.**
+`env_store.sanitized_subprocess_env` (`src/pmcp/env_store.py:124`) builds each
+server's environment from `os.environ.copy()` minus PMCP-managed keys, and its
+own docstring records the gap: *"this removes only PMCP-managed keys; secrets the
+operator exported into the shell **or a plain `.env`** are not sanitized here."*
+
+**It is the single choke point.** Every downstream environment goes through it:
+`client/manager.py:2343` (whose result is the only `env=` at `:2354`),
+`manifest/installer.py:542`, and `tools/handlers.py:5143` / `:5247`.
+
+**Why "strip by name" is wrong (rev 2.1's defect).** `load_dotenv` defaults to
+`override=False`, so a variable already in the environment is **not** replaced. A
+shell-exported `PATH` that also appears in `.env` was never sourced from that
+file — stripping it by name would remove the operator's `PATH` from every
+spawned server.
+
+**Why re-parsing is wrong.** `read_env_file` uses `dotenv_values(...,
+interpolate=False)`. Measured difference: for `DERIVED=${BASE}/x` it returns the
+literal `${BASE}/x` where `load_dotenv` yields `abc/x`. Empty values differ too:
+under `load_dotenv`'s no-override semantics an empty higher-priority value blocks
+a later file, which per-file dicts do not reproduce. Any fix that re-parses must
+emulate both, and emulation is exactly what keeps going wrong.
+
+## Design: record what was introduced, strip that
+
+One mechanism, applied wherever PMCP loads a dotenv file into its own process:
 
 ```python
-def _check_api_key_available(self, env_var: str | None) -> bool:
-    if os.environ.get(env_var):
-        return True
-    for env_path in [Path.cwd()/".env", Path.cwd()/".env.pmcp",
-                     Path.home()/".config"/"pmcp"/"pmcp.env"]:
-        if env_path.exists():
-            load_dotenv(env_path)              # <-- mutates os.environ
-            if os.environ.get(env_var):
-                return True
-    return False
+before = set(os.environ)
+load_dotenv(...)                      # unchanged semantics
+introduced = set(os.environ) - before # exactly the keys THIS load added
 ```
 
-Note the shape: the function answers a **boolean question** and its only way of
-answering is to **change global process state**. Every key in the file is loaded,
-not just `env_var`. It is the sole `load_dotenv` in `handlers.py` (`:2942`).
+`introduced` is precise by construction: a shell-provided `PATH` is in `before`,
+so it is never recorded and never stripped. Interpolation and empty-value
+shadowing need no emulation — whatever `load_dotenv` did is what gets recorded.
 
-**But it is not the only way the project `.env` enters `os.environ`, and not even
-the first.** `cli.py:2696-2702` — `main()`, the gateway entry point — calls bare
-`load_dotenv()` before anything else, which loads `<cwd>/.env` unconditionally at
-startup. **WAS WRONG (rev 1):** it called the `cli.py` calls "deliberate startup
-configuration and out of scope", which would have left the primary leak path
-open while the plan claimed the leak was closed. The startup load itself is
-legitimate — the gateway may read `.env` for its own configuration — so the fix
-belongs at the boundary where those keys must *stop*: the subprocess
-environment.
-
-**The leak reaches spawned servers, and the code says so.** `env_store.sanitized_subprocess_env`
-(`src/pmcp/env_store.py:124`) builds a downstream server's environment from
-`os.environ.copy()` minus PMCP-managed keys, and its own docstring records the
-gap:
-
-> "this removes only PMCP-managed keys; secrets the operator exported into the
-> shell **or a plain `.env`** are not sanitized here."
-
-`managed_secret_keys` (`:107`) says the same: "**not** secrets that reached
-`os.environ` from the operator's shell or a plain `.env`". So keys this check
-loads are precisely the keys the sanitiser does not strip. End to end: a project
-`.env` containing an unrelated database URL or a third-party token is inherited
-by every MCP server the gateway starts.
-
-**The clean primitive already exists.** `env_store.read_env_file(path)`
-(`:45`) parses with `dotenv_values(path, interpolate=False)` and returns a
-`dict[str, str]` **without touching `os.environ`**. The fix is to answer the
-question from that dict.
-
-**Someone already knew.** `tests/test_tools.py:3586` carries the comment
-"Prevent `_check_api_key_available` from loading env vars out of pmcp files on
-disk" — the hazard was known well enough to work around in a test, but not
-closed at the source.
-
-**Callers** (only two): `_check_any_api_key_available` (`:2950`) and
-`is_auth_available=self._check_api_key_available` passed into
-`resolve_startup_configs` (`:2239`). Both want a boolean. Neither reads the
-side effect.
-
-**The load-bearing question, and it is real.** Credential *resolution* for a
-manifest server runs through `_manifest_server_to_config(server, env_lookup)`
-(`src/pmcp/config/loader.py:980`), and `handlers.py:200` records that it is
-called with **`os.environ.get`**. So today, a credential that lives **only** in a
-plain project `.env` reaches a server *because* the availability check loaded it
-first. Removing the mutation removes that path. Whether that path should exist
-is a **product decision**, not an implementation detail — see Decision below.
-
-## Decision required before implementation
-
-Three env files are consulted. They are not equivalent:
-
-| file | owner | today | after a naive fix |
-|---|---|---|---|
-| `~/.config/pmcp/pmcp.env` | PMCP (`pmcp secrets set`) | loaded | must still resolve |
-| `<cwd>/.env.pmcp` | PMCP, project scope | loaded | must still resolve |
-| `<cwd>/.env` | **the operator's project**, not PMCP | loaded **and leaked** | ? |
-
-The leak is the third row. The question is whether a plain `.env` stays a
-*credential source* for a server's own declared `env_var`:
-
-- **(A) Keep it, narrowly.** Resolve the specific `env_var` from `.env` and inject
-  it into that server's own env only. Preserves today's behaviour for anyone
-  keeping credentials in a project `.env`; closes the leak, because only the
-  named key moves and only into the server that declared it.
-- **(B) Drop it.** PMCP's own stores remain credential sources; a plain `.env`
-  becomes lookup-only for availability, never a source. Simpler and safer, but a
-  **behaviour change**: a server whose key lives only in `.env` stops receiving
-  it, and `gateway.provision` may start reporting a credential as missing where
-  it previously worked.
-
-**Recommendation: (A).** It closes the reported vulnerability without removing a
-working configuration path, and the narrowing — one named key, one server — is
-exactly the property S-02 says is missing. (B) is defensible but should be a
-deliberate deprecation with a CHANGELOG note, not a side effect of a security fix.
-
-**This plan is written for (A) and must be re-read if the operator picks (B).**
+`sanitized_subprocess_env` then strips the recorded keys in addition to
+`managed_secret_keys`, and `own_env` is applied **after** the strip, so a
+server's own declared credential is restored (operator decision **(A)**: a plain
+`.env` may still supply a server's own `env_var` — that key only, that server
+only).
 
 ## Changes
 
-### `src/pmcp/env_store.py` (modify) — the load-bearing change
+### `src/pmcp/env_store.py` (modify)
 
-**The leak is closed at the boundary that owns it.** The gateway legitimately
-loads `.env` for its own configuration (`cli.py:2699`); what must not happen is
-that those keys are inherited by third-party downstream servers. So
-`sanitized_subprocess_env` — which already exists to strip PMCP-managed keys and
-already documents this exact gap — also strips keys sourced from the **project
-`.env`**, except the server's own declared `env_var` (decision (A)).
-
-- `project_env_keys(project)` — add — `set(read_env_file(<project>/".env"))`,
-  `OSError`-guarded, returning an empty set when absent or unreadable.
+- `record_dotenv_keys(keys: Iterable[str]) -> None` and
+  `dotenv_sourced_keys() -> frozenset[str]` — add — a module-level registry of
+  keys PMCP itself introduced from dotenv files. Additive and idempotent.
+  Document that it holds *provenance*, not file contents, and that an empty
+  registry (library use, `main()` never ran) is the correct default.
+- `reset_dotenv_keys()` — add — test-only seam, so the registry cannot leak
+  between tests. Name it so its purpose is unmistakable.
 - `sanitized_subprocess_env` — modify — strip `managed_secret_keys(...)` **and**
-  `project_env_keys(...)`, then apply `own_env` (which still wins, so the
-  declared credential is restored for the server that declared it).
-- The docstring's "secrets the operator exported into the shell or a plain
-  `.env` are not sanitized here" — modify — a plain `.env` now **is** stripped;
-  shell-exported secrets still are not. Do not overclaim the second half.
+  `dotenv_sourced_keys()`, then apply `own_env` (unchanged precedence, so the
+  declared credential still wins). Signature and existing callers unchanged.
+- The docstring's "or a plain `.env`" gap sentence — modify — a plain `.env` is
+  now stripped; shell-exported secrets still are not. Do not overclaim.
+
+### `src/pmcp/cli.py` (modify)
+
+- `main()` (`:2696-2702`) — modify — capture the before/after delta around the
+  **first** `load_dotenv()` (the plain `.env`) and pass it to
+  `record_dotenv_keys`. The two PMCP-store loads that follow need no recording:
+  `managed_secret_keys` already covers them. `load_dotenv` itself is unchanged —
+  the gateway still reads `.env` for its own configuration.
 
 ### `src/pmcp/tools/handlers.py` (modify)
 
-- `_check_api_key_available` — modify — answer from `env_store.read_env_file(path)`
-  instead of `load_dotenv(path)` + `os.environ.get`. Check `os.environ` first
-  (unchanged fast path), then each file's parsed dict. **No process state is
-  mutated.** Docstring states that the check is now side-effect free and why.
-- The `load_dotenv` import (`:21`) — **keep**, or update
-  `tests/test_tools.py:3587` in the same change. **WAS WRONG (rev 1):** "delete"
-  — that test monkeypatches `pmcp.tools.handlers.load_dotenv` and `setattr`
-  raises when the attribute is gone. Deleting it is fine *if* the test is updated
-  to patch the new seam; decide once, and state which.
-- The `_manifest_server_to_config(..., os.environ.get)` call site — modify — pass
-  the non-mutating resolver instead. **WAS WRONG (rev 1):** the resolver was
-  specified in `loader.py` and never wired here, so decision (A) would not have
-  worked.
-- `read_env_file` calls — wrap in `try/except OSError` — an existing-but-unreadable
-  `.env` must answer "no", not raise.
-
-### `src/pmcp/config/loader.py` (modify)
-
-- A resolver that, given a server's declared `env_var`, returns its value from
-  `os.environ` and then from the three env files, **without mutation** — the
-  lookup `_manifest_server_to_config` is handed instead of bare `os.environ.get`.
-  Keep it a plain `Callable[[str], str | None]` so the existing seam is unchanged;
-  do **not** widen `_manifest_server_to_config`'s signature.
+- `_check_api_key_available` (`:2926`) — modify — keep `load_dotenv` and its
+  exact semantics, but wrap each call in the same before/after delta and record
+  it. **The boolean answer is bit-for-bit unchanged**, which retires the
+  interpolation and empty-value-shadowing findings entirely: nothing is
+  re-parsed and no precedence rule is re-implemented. The leak closes because the
+  keys it introduces are now recorded and stripped at the subprocess boundary.
+- The `load_dotenv` import (`:21`) — **keep**. `tests/test_tools.py:3587`
+  monkeypatches `pmcp.tools.handlers.load_dotenv`; that test keeps working
+  unchanged.
 
 ### `tests/test_env_leak_229.py` (create)
 
-The proofs. Each must fail on unchanged `main`:
+Each must fail on unchanged `main`:
 
-- `test_the_availability_check_does_not_mutate_os_environ` — write a `.env` with a
-  sentinel key PMCP does not manage, ask about an **unrelated** variable, assert
-  the answer is correct **and** the sentinel is absent from `os.environ`. On
-  `main` the sentinel is present.
-- `test_a_project_env_secret_never_reaches_a_spawned_server` — the end-to-end one:
-  the same sentinel must not appear in `sanitized_subprocess_env()`. This is the
-  criterion that matches the reported impact; the previous test alone would pass
-  against an implementation that leaked by some other route.
-- `test_the_servers_own_credential_still_resolves` — decision (A)'s other half:
-  a server whose declared `env_var` lives only in `.env` still receives it.
-- `test_only_the_declared_key_is_injected` — the narrowing: a *second* key in the
-  same `.env` does not reach that server.
-- `test_pmcp_managed_stores_still_answer` — `.env.pmcp` and `~/.config/pmcp/pmcp.env`
-  still satisfy the availability check.
-- `test_no_load_dotenv_outside_cli` — structural guard, in the spirit of the
-  #224/#225 AST guards: `load_dotenv` may appear only in `cli.py`. Prevents the
-  side effect being reintroduced anywhere else.
+- `test_a_startup_env_secret_never_reaches_a_spawned_server` — **the honest
+  end-to-end proof.** Populate `os.environ` the way `main()` does (call
+  `load_dotenv` on a `.env` holding a sentinel PMCP does not manage), then assert
+  the sentinel **is** in `os.environ` — the gateway may see it — and **is not**
+  in `sanitized_subprocess_env()`. **WAS WRONG (rev 2.1):** the test asserted
+  absence after the availability check, which passes once that check stops
+  mutating *even if the sanitiser is never touched*.
+- `test_a_shell_provided_variable_sharing_a_name_is_not_stripped` — put a
+  variable already present in the environment into the `.env` too; it must
+  survive into the child env with the operator's value. This is rev 2.1's
+  `PATH`-deletion defect, pinned.
+- `test_the_availability_check_records_what_it_loads` — after
+  `_check_api_key_available`, a sentinel it loaded is absent from
+  `sanitized_subprocess_env()`.
+- `test_the_availability_boolean_is_unchanged` — the same {present, absent} ×
+  {`os.environ`, `.env`, `.env.pmcp`, `pmcp.env`} matrix answers identically to
+  `main`, **including** an interpolated value and an empty value in a
+  higher-priority file. Feasible now precisely because the semantics are untouched.
+- `test_the_servers_own_credential_still_resolves` and
+  `test_only_the_declared_key_is_injected` — decision (A), both halves.
+- `test_the_registry_is_empty_without_main` — importing the library and never
+  running `main()` records nothing and strips nothing.
 
 ## Documentation impact
 
-- `SECURITY.md` — modify — the "Credential isolation is scoped, not
-  identity-complete" bullet, and the `sanitized_subprocess_env` gap it mirrors,
-  must stop describing a plain `.env` as unsanitised-and-inherited once that is no
-  longer true. Do not overclaim: shell-exported secrets are still inherited.
-- `CHANGELOG.md` — add — `### Security`, naming the leak and the behaviour after
-  the fix. `src/` changes, so the `changelog` CI job requires it.
+- `SECURITY.md` — modify — the credential-isolation bullet and the
+  `sanitized_subprocess_env` gap it mirrors. State precisely what is now true: a
+  plain `.env` is stripped; shell-exported secrets are still inherited.
+- `CHANGELOG.md` — add — `### Security`. Required: this changes `src/`.
 
 ## Dependencies & order
 
-1. Settle the Decision. (A) and (B) produce different tests.
-2. `tests/test_env_leak_229.py` first, red against `main`.
-3. `_check_api_key_available` + import removal.
-4. The non-mutating resolver, only if (A).
+1. `env_store` registry + `sanitized_subprocess_env` strip — **the load-bearing
+   change**. **WAS WRONG (rev 2.1):** its order list omitted this step entirely
+   while naming it the load-bearing one in Changes.
+2. `tests/test_env_leak_229.py`, red against `main`.
+3. `cli.py` startup recording.
+4. `handlers.py` availability-check recording.
 5. Docs.
 
 ## Verification
 
 ```bash
-uv run pytest -q tests/test_env_leak_229.py          # the six proofs
-uv run pytest -q tests/test_tools.py                  # the 2239/2950 callers
-uv run pytest -q tests/                               # full suite; compare to main
+uv run pytest -q tests/test_env_leak_229.py
+uv run pytest -q tests/test_tools.py                  # the monkeypatch at :3587 still works
+uv run pytest -q tests/                               # compare to main, same dir
 uv run ruff check src/ tests/ scripts/ && uv run ruff format --check src/ tests/ scripts/
 uv run mypy src/
-grep -rn "load_dotenv" src/                           # expect: cli.py only
+grep -rn "load_dotenv" src/                           # cli.py + handlers.py, both now recorded
 ```
 
 Host note: `/tmp/package.json` makes ~107 npm-identity tests fail here
-(`tests/conftest.py`); compare the same command from the same directory
-before and after, not against a clean-machine expectation.
+(`tests/conftest.py`); compare the same command from the same directory before
+and after.
 
-Edge cases: no `.env` present; `.env` unreadable (must not raise — an
-availability check that throws is worse than one that says "no"); the same key in
-two files (first hit wins, preserving today's documented priority order); a key
-whose value is empty (today falsy → "not available"; keep that).
+Edge cases: `.env` absent or unreadable (record nothing, never raise); the same
+key in `.env` and a PMCP store (`managed_secret_keys` already strips it;
+double-strip is harmless); a server whose declared `env_var` is also a managed
+key (`own_env` wins, unchanged); registry state across tests (use the reset seam).
 
 ## Acceptance criteria
 
-- [ ] A sentinel key in `<cwd>/.env`, unrelated to the variable being asked about,
-      is **absent from `os.environ`** after the availability check — where on
-      unchanged `main` it is present.
-- [ ] That sentinel is **absent from `sanitized_subprocess_env()`**, i.e. it never
-      reaches a spawned server. This is the reported impact and the criterion that
-      matters most.
-- [ ] The availability check returns the **same boolean** as `main` for every
-      combination of {present, absent} × {`.env`, `.env.pmcp`, `pmcp.env`,
-      `os.environ`} — a fix that closes the leak by answering "no" more often is
-      not a fix.
-- [ ] Under decision (A): a server whose declared `env_var` exists only in `.env`
-      still receives it, **and** a second key in that same file does not.
-- [ ] `grep -rn "load_dotenv" src/` returns only `cli.py`, enforced by a test.
-- [ ] Full-suite failures/skips/deselects unchanged from `main`; passes increase by
-      exactly the new tests.
+- [ ] With `os.environ` populated as `main()` leaves it, a `.env` sentinel is
+      **present in `os.environ`** and **absent from `sanitized_subprocess_env()`**.
+      On unchanged `main` it is present in both.
+- [ ] A shell-provided variable that also appears in `.env` is **not** stripped —
+      the child env still has the operator's value.
+- [ ] The availability boolean is identical to `main` across the full
+      {present, absent} × four-source matrix, including an interpolated value and
+      an empty value shadowing a later file.
+- [ ] A server whose declared `env_var` lives only in `.env` still receives it,
+      and a second key in that same file does not.
+- [ ] `tests/test_tools.py` passes unmodified (the `load_dotenv` monkeypatch).
+- [ ] Full-suite failures/skips/deselects unchanged from `main`; passes increase
+      by exactly the new tests.
 
 ## Non-goals
 
 - **Removing** `cli.py`'s startup `load_dotenv()`. The gateway may keep reading
-  `.env` for its own configuration; what changes is that those keys no longer
-  reach downstream servers. **WAS WRONG (rev 1):** this was listed as simply out
-  of scope, which is what let the primary leak path survive the fix.
-- Sanitising shell-exported secrets. `sanitized_subprocess_env` inherits ambient
-  environment by design; changing that is a separate decision with a much larger
-  blast radius.
-- The wider trust-boundary programme (#230). This fix stands alone and should not
-  wait for it.
+  `.env` for its own configuration; what changes is that those keys stop being
+  inherited by downstream servers.
+- Sanitising shell-exported secrets — deliberate, and out of scope.
+- The wider trust-boundary programme (#230).
 
 ## Execution Policy
 
-- execute: effort=medium, reason=small diff but it changes credential-resolution behaviour and the tests must prove absence rather than presence
+- execute: effort=medium, reason=small diff but it changes credential-resolution behaviour and the proofs must assert absence at the subprocess boundary rather than in the gateway

--- a/.consiliency/plans/detailed-env-leak-availability-check-20260906-0300.md
+++ b/.consiliency/plans/detailed-env-leak-availability-check-20260906-0300.md
@@ -105,11 +105,21 @@ only).
 
 ### `src/pmcp/cli.py` (modify)
 
-- `main()` (`:2696-2702`) — modify — capture the before/after delta around the
-  **first** `load_dotenv()` (the plain `.env`) and pass it to
-  `record_dotenv_keys`. The two PMCP-store loads that follow need no recording:
-  `managed_secret_keys` already covers them. `load_dotenv` itself is unchanged —
-  the gateway still reads `.env` for its own configuration.
+- `load_startup_env()` — add — a **named, importable** function holding the three
+  startup loads currently inline in `main()` (`:2696-2702`), with the
+  before/after delta captured around the **first** `load_dotenv()` (the plain
+  `.env`) and passed to `record_dotenv_keys`. The two PMCP-store loads need no
+  recording: `managed_secret_keys` already covers them. `load_dotenv` itself is
+  unchanged — the gateway still reads `.env` for its own configuration.
+- `main()` — modify — call `load_startup_env()` in place of the inline loads.
+
+  **Why extract rather than inline the delta:** recording lives at the call site,
+  not inside `load_dotenv`. If the end-to-end test calls `load_dotenv` itself,
+  nothing is recorded and the test fails even against a correct implementation;
+  if the test calls `record_dotenv_keys` itself, it passes even when `main()`
+  never records — leaving the primary leak path unproven. A named function is
+  production code the test can execute directly, so the proof exercises the real
+  startup sequence.
 
 ### `src/pmcp/tools/handlers.py` (modify)
 
@@ -128,12 +138,21 @@ only).
 Each must fail on unchanged `main`:
 
 - `test_a_startup_env_secret_never_reaches_a_spawned_server` — **the honest
-  end-to-end proof.** Populate `os.environ` the way `main()` does (call
-  `load_dotenv` on a `.env` holding a sentinel PMCP does not manage), then assert
-  the sentinel **is** in `os.environ` — the gateway may see it — and **is not**
-  in `sanitized_subprocess_env()`. **WAS WRONG (rev 2.1):** the test asserted
-  absence after the availability check, which passes once that check stops
-  mutating *even if the sanitiser is never touched*.
+  end-to-end proof.** Call the **production** `cli.load_startup_env()` against a
+  `.env` holding a sentinel PMCP does not manage, then assert the sentinel **is**
+  in `os.environ` — the gateway may see it — and **is not** in
+  `sanitized_subprocess_env()`.
+  **WAS WRONG (rev 2.1):** asserted absence after the availability check, which
+  passes once that check stops mutating even if the sanitiser is untouched.
+  **WAS WRONG (rev 3):** called `load_dotenv` directly. Recording lives at the
+  call site, so that test either fails against a correct fix (nothing recorded)
+  or, if patched to call `record_dotenv_keys` itself, passes while `main()` still
+  leaks. Neither pins the primary path. The test must run production code.
+- `test_main_uses_the_recording_startup_path` — the wiring guard: `main()` must
+  call `load_startup_env()`, asserted by patching it and requiring it to be
+  invoked (or by AST, as in the #225 guards). Without this, the extraction can be
+  bypassed by a future edit re-inlining a bare `load_dotenv()` and every other
+  test still passes.
 - `test_a_shell_provided_variable_sharing_a_name_is_not_stripped` — put a
   variable already present in the environment into the `.env` too; it must
   survive into the child env with the operator's value. This is rev 2.1's

--- a/.consiliency/plans/detailed-env-leak-availability-check-20260906-0300.md
+++ b/.consiliency/plans/detailed-env-leak-availability-check-20260906-0300.md
@@ -61,9 +61,17 @@ def _check_api_key_available(self, env_var: str | None) -> bool:
 
 Note the shape: the function answers a **boolean question** and its only way of
 answering is to **change global process state**. Every key in the file is loaded,
-not just `env_var`. It is the sole `load_dotenv` in `handlers.py` (`:2942`); the
-three in `cli.py` (`:2699-2702`) are deliberate startup configuration and are
-**out of scope**.
+not just `env_var`. It is the sole `load_dotenv` in `handlers.py` (`:2942`).
+
+**But it is not the only way the project `.env` enters `os.environ`, and not even
+the first.** `cli.py:2696-2702` — `main()`, the gateway entry point — calls bare
+`load_dotenv()` before anything else, which loads `<cwd>/.env` unconditionally at
+startup. **WAS WRONG (rev 1):** it called the `cli.py` calls "deliberate startup
+configuration and out of scope", which would have left the primary leak path
+open while the plan claimed the leak was closed. The startup load itself is
+legitimate — the gateway may read `.env` for its own configuration — so the fix
+belongs at the boundary where those keys must *stop*: the subprocess
+environment.
 
 **The leak reaches spawned servers, and the code says so.** `env_store.sanitized_subprocess_env`
 (`src/pmcp/env_store.py:124`) builds a downstream server's environment from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Security
+- **The operator's project `.env` no longer reaches the servers PMCP spawns.**
+  `pmcp`'s entry point loads `<project>/.env` into its own environment at
+  startup, and `_check_api_key_available` loads whole env files to answer a
+  boolean — while `sanitized_subprocess_env` builds every downstream server's
+  environment from `os.environ.copy()`. Every key in the operator's `.env`, not
+  just PMCP's own, was therefore inherited by every third-party MCP server the
+  gateway launched. Both load sites now record the keys their `load_dotenv` call
+  introduced into the process, and the subprocess sanitizer strips exactly those.
+  The mechanism is recorded provenance, never a re-parse: `load_dotenv`'s
+  semantics are untouched — interpolation, `override=False` precedence and the
+  credential-availability boolean are all bit-for-bit unchanged — and a variable
+  the operator exported into their shell that merely shares a name with a `.env`
+  entry is not in the delta, so it is not stripped (stripping by name would have
+  deleted the operator's `PATH` from every spawned server). A server's own
+  declared `env_var` may still come from a plain `.env`: `own_env` is applied
+  after the strip, so that key reaches that server and nothing else in the file
+  does. Shell-exported secrets are still inherited, deliberately. Found by the
+  2026-09-01 codebase review (S-02); see
+  [#229](https://github.com/Consiliency/pmcp/issues/229).
 - **Dependency advisories on the auth path are closed, and CI now fails on new
   ones.** `pip-audit` reported nine advisories against the shipped lockfile; the
   one that mattered most was **PYSEC-2026-176 in PyJWT 2.10.1, a verifier-side

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -133,6 +133,18 @@ PMCP is a local-first MCP gateway. Its default security posture assumes:
   tenant-scoped files derived from the resolved project root and must not read
   another tenant's file, but PMCP still does not provide cross-user identity or
   authorization isolation by itself.
+- **The project `.env` does not reach downstream servers**: PMCP reads a plain
+  `.env` for its own configuration at startup, and its credential-availability
+  check loads env files to answer a boolean. Both record which keys those loads
+  introduced into the gateway's environment, and `sanitized_subprocess_env`
+  strips exactly those keys from every spawned server, so an unrelated secret in
+  the operator's `.env` is no longer inherited by third-party MCP servers. A
+  server's own declared `env_var` is still supplied from a plain `.env` — that
+  key only, into that server only. Stripping is by recorded provenance, not by
+  key name: a variable the operator exported into their shell that merely also
+  appears in `.env` is untouched. Secrets the operator exported into the shell
+  itself are still inherited — deliberately, and out of scope
+  ([#229](https://github.com/Consiliency/pmcp/issues/229)).
 - **Tenant code-mode hosting keeps execution outside PMCP**: the host contract
   in `specs/tenant-code-mode-host-contract.md` treats PMCP as the broker and
   the companion tenant server as the sandbox execution authority. The contract

--- a/src/pmcp/cli.py
+++ b/src/pmcp/cli.py
@@ -35,6 +35,7 @@ from pmcp.config.loader import (
     load_configs,
     set_startup_policy,
 )
+from pmcp.env_store import record_dotenv_keys
 from pmcp.manifest.loader import load_manifest
 from pmcp.types import StartupPolicyOperation
 
@@ -2693,13 +2694,48 @@ async def async_main(args: argparse.Namespace) -> None:
         await run_server(args)
 
 
-def main() -> None:
-    """Main entry point."""
-    # Load .env file from current directory or project root
-    load_dotenv()
+def load_startup_env(dotenv_path: str | os.PathLike[str] | None = None) -> None:
+    """Load the startup env files, recording what the plain ``.env`` introduced.
+
+    These are the loads that used to sit inline in ``main()``. ``load_dotenv``
+    is called with its semantics COMPLETELY unchanged -- default path discovery,
+    interpolation and ``override=False`` precedence all behave exactly as
+    before, and the gateway still reads ``.env`` for its own configuration.
+
+    What is new is that the keys the plain ``.env`` introduced *into this
+    process* are recorded, so ``sanitized_subprocess_env`` can keep them out of
+    the third-party servers PMCP spawns (Consiliency/pmcp#229, review finding
+    S-02). The delta is the provenance: a variable the operator already had in
+    their environment is in ``before``, so it is never recorded and never
+    stripped -- which is exactly right, because ``override=False`` means such a
+    variable did not come from the file.
+
+    The two PMCP-store loads need no recording; ``managed_secret_keys`` already
+    covers those keys.
+
+    ``dotenv_path`` is a test seam, and ``None`` -- the production call -- is
+    identical to the bare ``load_dotenv()`` this replaced: ``find_dotenv``
+    resolves the path by walking up from THIS module's directory either way. It
+    exists because that frame-based discovery cannot be pointed at a ``tmp_path``
+    (``monkeypatch.chdir`` has no effect on it), and the end-to-end proof of
+    #229 has to run this production function rather than call ``load_dotenv``
+    itself. ``tests/test_env_leak_229.py`` asserts ``main()`` still passes
+    nothing.
+    """
+    before = set(os.environ)
+    load_dotenv(dotenv_path)
+    record_dotenv_keys(set(os.environ) - before)
     # Load PMCP credential stores written by auth_connect (don't override already-set vars)
     load_dotenv(Path.home() / ".config" / "pmcp" / "pmcp.env", override=False)
     load_dotenv(Path.cwd() / ".env.pmcp", override=False)
+
+
+def main() -> None:
+    """Main entry point."""
+    # Load .env from the current directory or project root, plus the PMCP
+    # credential stores -- recording which keys the plain .env introduced so
+    # they do not reach downstream servers (Consiliency/pmcp#229).
+    load_startup_env()
 
     args = parse_args()
 

--- a/src/pmcp/env_store.py
+++ b/src/pmcp/env_store.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 import re
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 
 from dotenv import dotenv_values
@@ -104,6 +104,56 @@ def write_env_file(path: Path, values: dict[str, str]) -> None:
         env_file.write(content)
 
 
+# Env-var keys PMCP itself introduced into its OWN environment from a dotenv
+# file. Provenance, not file contents: see record_dotenv_keys (Consiliency/pmcp#229).
+_DOTENV_SOURCED_KEYS: set[str] = set()
+
+
+def record_dotenv_keys(keys: Iterable[str]) -> None:
+    """Record env-var keys that PMCP itself introduced from a dotenv file.
+
+    Callers record the delta they measured around their own ``load_dotenv``
+    call -- ``set(os.environ)`` after, minus before -- so this registry holds
+    *provenance*, never file contents, and never a re-parse:
+
+    .. code-block:: python
+
+        before = set(os.environ)
+        load_dotenv(...)                       # semantics untouched
+        record_dotenv_keys(set(os.environ) - before)
+
+    Recording rather than re-deriving is what makes the strip correct.
+    ``load_dotenv`` defaults to ``override=False``, so a variable the operator
+    exported into their shell is left alone even when a dotenv file names it
+    too; such a variable is already in ``before``, so it is never recorded and
+    never stripped. Stripping by key name instead would delete the operator's
+    ``PATH`` from every spawned server. Interpolation and empty-value shadowing
+    need no emulation either -- whatever ``load_dotenv`` did is what is recorded.
+
+    Additive and idempotent. An empty registry is the correct default: PMCP
+    imported as a library, with ``main()`` never run, has loaded no dotenv file
+    and so strips nothing extra.
+    """
+    _DOTENV_SOURCED_KEYS.update(keys)
+
+
+def dotenv_sourced_keys() -> frozenset[str]:
+    """Keys PMCP introduced into its own environment from dotenv files."""
+    return frozenset(_DOTENV_SOURCED_KEYS)
+
+
+def reset_dotenv_keys() -> None:
+    """Clear the dotenv provenance registry. **Test-only seam.**
+
+    Production never calls this: the registry only grows, as startup and
+    availability-check loads happen. Tests need it because the registry is
+    process-global -- without a reset, keys one test recorded would be stripped
+    from every later test's subprocess environment. An autouse fixture in
+    ``tests/conftest.py`` calls it around every test.
+    """
+    _DOTENV_SOURCED_KEYS.clear()
+
+
 def managed_secret_keys(project: Path | None = None) -> set[str]:
     """Env-var keys of credentials PMCP manages in its user/project secret stores.
 
@@ -132,11 +182,22 @@ def sanitized_subprocess_env(
     (e.g. a server whose runtime env_var equals a managed key gets its own value
     back). Non-secret ambient vars (PATH/HOME/NODE_*/proxy/locale) are preserved.
 
-    Note: this removes only PMCP-managed keys; secrets the operator exported into
-    the shell or a plain ``.env`` are not sanitized here.
+    Also stripped: keys PMCP introduced into its own environment from a dotenv
+    file (``dotenv_sourced_keys``) -- the operator's project ``.env`` reached
+    the gateway through ``cli.load_startup_env`` and the availability check, and
+    was inherited by every server PMCP spawned (Consiliency/pmcp#229). Those keys
+    are stripped by recorded provenance, not by name, so a shell-exported
+    variable that merely shares a name with a ``.env`` entry survives. A server's
+    OWN declared ``env_var`` still arrives via ``own_env``, which is applied
+    after the strip.
+
+    Note: secrets the operator exported into their shell are still inherited --
+    deliberately, and out of scope here.
     """
     env = os.environ.copy()
     for key in managed_secret_keys(project):
+        env.pop(key, None)
+    for key in dotenv_sourced_keys():
         env.pop(key, None)
     if own_env:
         env.update(own_env)

--- a/src/pmcp/tools/handlers.py
+++ b/src/pmcp/tools/handlers.py
@@ -50,7 +50,11 @@ from pmcp.config.loader import (
     summarize_startup_resolution,
 )
 from pmcp.errors import ErrorCode, GatewayException, make_error
-from pmcp.env_store import sanitized_subprocess_env, set_env_value
+from pmcp.env_store import (
+    record_dotenv_keys,
+    sanitized_subprocess_env,
+    set_env_value,
+)
 from pmcp.validation import env_var_allowed, is_valid_package_name
 from pmcp.identity import filter_self_references
 from pmcp.manifest.code_patterns_loader import get_code_hint
@@ -2924,7 +2928,18 @@ class GatewayTools:
         )
 
     def _check_api_key_available(self, env_var: str | None) -> bool:
-        """Check if an API key is available in environment or any pmcp env store."""
+        """Check if an API key is available in environment or any pmcp env store.
+
+        This answers a boolean question by loading whole files into the
+        gateway's ``os.environ`` -- every key in them, not just the one asked
+        about. The load stays exactly as it was (so this predicate's answer is
+        bit-for-bit unchanged, interpolation and ``override=False`` precedence
+        included); what is new is that the keys each load INTRODUCES are
+        recorded, so ``sanitized_subprocess_env`` keeps them out of the servers
+        PMCP spawns (Consiliency/pmcp#229). Recording the delta rather than the
+        file's contents is what makes that strip safe -- see
+        ``env_store.record_dotenv_keys``.
+        """
         if not env_var:
             return False
 
@@ -2939,7 +2954,9 @@ class GatewayTools:
             Path.home() / ".config" / "pmcp" / "pmcp.env",
         ]:
             if env_path.exists():
+                before = set(os.environ)
                 load_dotenv(env_path)
+                record_dotenv_keys(set(os.environ) - before)
                 if os.environ.get(env_var):
                     return True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,12 +30,14 @@ passes for the wrong reason and looks green forever. So:
 from __future__ import annotations
 
 import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from pmcp.env_store import reset_dotenv_keys
 from pmcp.policy.policy import PolicyManager
 from pmcp.types import (
     LocalMcpServerConfig,
@@ -45,6 +47,23 @@ from pmcp.types import (
     ServerStatusEnum,
     ToolInfo,
 )
+
+
+@pytest.fixture(autouse=True)
+def _reset_dotenv_provenance() -> Iterator[None]:
+    """Keep the dotenv provenance registry from leaking between tests.
+
+    ``env_store``'s registry of keys PMCP loaded from a dotenv file
+    (Consiliency/pmcp#229) is process-global, and production paths that tests
+    exercise write to it: any test that drives ``_check_api_key_available``
+    against a real ``.env`` records that file's keys. Without this reset, those
+    keys would be stripped from every LATER test's
+    ``sanitized_subprocess_env()`` -- an order-dependent failure in tests that
+    have nothing to do with #229.
+    """
+    reset_dotenv_keys()
+    yield
+    reset_dotenv_keys()
 
 
 # === Sample Data Factories ===

--- a/tests/test_env_leak_229.py
+++ b/tests/test_env_leak_229.py
@@ -1,0 +1,317 @@
+"""The operator's project `.env` must not reach the servers PMCP spawns.
+
+Consiliency/pmcp#229, review finding S-02 (HIGH). Two sites load a dotenv file
+into the gateway's own `os.environ` -- `cli.load_startup_env` (called from
+`main()`, the console-script entry) and `GatewayTools._check_api_key_available`
+-- and `env_store.sanitized_subprocess_env` builds every downstream server's
+environment from `os.environ.copy()`. So before this fix, every key in the
+operator's `.env` was inherited by every third-party server PMCP launched.
+
+The mechanism under test is **recorded provenance, not re-derivation**: each
+call site measures `set(os.environ)` before and after its own `load_dotenv` and
+registers the delta, and the sanitiser strips exactly those keys. Two properties
+follow, and both are pinned below because both are ways this has been got wrong:
+
+* `load_dotenv`'s semantics are untouched -- interpolation and `override=False`
+  precedence still behave exactly as they did, so the availability boolean is
+  unchanged (`test_the_availability_*`). Nothing re-parses a dotenv file.
+* Stripping is by *provenance*, never by *name*. A variable the operator
+  exported into their shell that merely also appears in `.env` was never sourced
+  from that file, so it is not in the delta and survives into the child
+  (`test_a_shell_provided_variable_sharing_a_name_is_not_stripped`). Stripping
+  by name would have deleted the operator's `PATH` from every spawned server.
+
+Operator decision (A) is pinned by `test_the_servers_own_credential_still_
+resolves` / `test_only_the_declared_key_is_injected`: a plain `.env` may still
+supply a server's OWN declared `env_var` -- that key only, into that server only
+-- because `own_env` is applied after the strip.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from pmcp import cli
+from pmcp.env_store import dotenv_sourced_keys, sanitized_subprocess_env
+from pmcp.tools.handlers import GatewayTools
+
+PREFIX = "PMCP_TEST_229_"
+SENTINEL = f"{PREFIX}SENTINEL"
+OWN_KEY = f"{PREFIX}OWN_KEY"
+OTHER_KEY = f"{PREFIX}OTHER_KEY"
+QUERIED = f"{PREFIX}API_KEY"
+BASE = f"{PREFIX}BASE"
+DERIVED = f"{PREFIX}DERIVED"
+
+
+@pytest.fixture(autouse=True)
+def _drop_test_keys() -> Iterator[None]:
+    """`load_dotenv` writes `os.environ` directly, so monkeypatch teardown does
+    not restore it -- these tests introduce keys for real. Every key this module
+    can introduce shares one prefix; drop them before and after each test."""
+    for key in [k for k in os.environ if k.startswith(PREFIX)]:
+        del os.environ[key]
+    yield
+    for key in [k for k in os.environ if k.startswith(PREFIX)]:
+        del os.environ[key]
+
+
+def _isolate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """An empty project directory and an empty HOME.
+
+    Both matter: `load_startup_env` and `_check_api_key_available` read
+    `Path.cwd()/.env.pmcp` and `Path.home()/.config/pmcp/pmcp.env`, and
+    `managed_secret_keys` reads the same two files. Pointing them at empty
+    directories keeps the assertions about the *plain* `.env` unambiguous.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(project)
+    return project
+
+
+def test_a_startup_env_secret_never_reaches_a_spawned_server(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The end-to-end proof, run against production code.
+
+    It calls `cli.load_startup_env` -- the function `main()` actually calls (see
+    `test_main_uses_the_recording_startup_path`) -- not `load_dotenv` and not
+    `record_dotenv_keys`. Calling `load_dotenv` here would record nothing and so
+    fail even against a correct fix; calling `record_dotenv_keys` here would pass
+    even if `main()` never recorded anything. Only production code proves the
+    primary leak path is closed.
+
+    The gateway may still SEE the value (it reads `.env` for its own config);
+    what must not happen is the child process inheriting it.
+    """
+    project = _isolate(tmp_path, monkeypatch)
+    (project / ".env").write_text(f"{SENTINEL}=leaked-secret\n")
+
+    cli.load_startup_env(project / ".env")
+
+    assert os.environ.get(SENTINEL) == "leaked-secret"
+    assert SENTINEL not in sanitized_subprocess_env()
+
+
+def test_main_uses_the_recording_startup_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The wiring guard: without it, a future edit could re-inline a bare
+    `load_dotenv()` into `main()` and every other test here would still pass.
+
+    `main()` calls `parse_args()` outside its `try`, so raising `SystemExit`
+    there stops the entry point right after the startup loads.
+    """
+    calls: list[tuple[tuple, dict]] = []
+    monkeypatch.setattr(cli, "load_startup_env", lambda *a, **kw: calls.append((a, kw)))
+
+    def _stop() -> None:
+        raise SystemExit(0)
+
+    monkeypatch.setattr(cli, "parse_args", _stop)
+
+    with pytest.raises(SystemExit):
+        cli.main()
+
+    assert calls == [((), {})], (
+        "main() must call load_startup_env() once, with no arguments"
+    )
+
+
+def test_main_has_no_inline_dotenv_load() -> None:
+    """The other half of the wiring guard, in the style of the #225 AST guards.
+
+    `load_startup_env`'s `dotenv_path` parameter is a test seam: bare
+    `load_dotenv()` resolves its path by walking up from the CALLING MODULE's
+    directory (`find_dotenv(usecwd=False)`), which no `tmp_path` can influence.
+    This asserts the production call site still passes nothing, so the default
+    discovery `main()` has always used is what actually runs.
+    """
+    tree = ast.parse(Path(cli.__file__).read_text(), filename=cli.__file__)
+    main_def = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "main"
+    )
+    calls = [node for node in ast.walk(main_def) if isinstance(node, ast.Call)]
+    called_names = {node.func.id for node in calls if isinstance(node.func, ast.Name)}
+    assert "load_dotenv" not in called_names, (
+        "main() must not load a dotenv file inline -- the recording lives in "
+        "load_startup_env()"
+    )
+
+    startup_calls = [
+        node
+        for node in calls
+        if isinstance(node.func, ast.Name) and node.func.id == "load_startup_env"
+    ]
+    assert len(startup_calls) == 1
+    assert not startup_calls[0].args and not startup_calls[0].keywords
+
+
+def test_a_shell_provided_variable_sharing_a_name_is_not_stripped(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stripping by NAME would have deleted the operator's PATH from every
+    spawned server: `load_dotenv` defaults to `override=False`, so a variable
+    already in the environment is left alone and was never sourced from the
+    file. Recording the delta is what makes the distinction."""
+    project = _isolate(tmp_path, monkeypatch)
+    monkeypatch.setenv("PATH", "/operator/bin")
+    (project / ".env").write_text(f"PATH=/dotenv/bin\n{SENTINEL}=leaked-secret\n")
+
+    cli.load_startup_env(project / ".env")
+
+    assert os.environ["PATH"] == "/operator/bin"
+    assert "PATH" not in dotenv_sourced_keys()
+
+    child = sanitized_subprocess_env()
+    assert child["PATH"] == "/operator/bin"
+    assert SENTINEL not in child
+
+
+def test_the_availability_check_records_what_it_loads(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The second load site. `_check_api_key_available` answers a boolean by
+    loading whole files into `os.environ`; every key it introduces is now
+    recorded, so none of them reaches a child."""
+    project = _isolate(tmp_path, monkeypatch)
+    (project / ".env").write_text(f"{QUERIED}=key-value\n{OTHER_KEY}=other\n")
+
+    tools = _gateway_tools()
+    assert tools._check_api_key_available(QUERIED) is True
+
+    child = sanitized_subprocess_env()
+    assert QUERIED not in child
+    assert OTHER_KEY not in child
+
+
+def _gateway_tools() -> GatewayTools:
+    """`_check_api_key_available` reads no instance state, so it needs no wired
+    client/policy manager. `__new__` keeps these tests independent of
+    GatewayTools' constructor; if the method ever starts using `self`, it fails
+    loudly rather than silently testing something else."""
+    return GatewayTools.__new__(GatewayTools)
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("environ", True),
+        ("dotenv", True),
+        ("project_store", True),
+        ("user_store", True),
+        ("absent", False),
+    ],
+)
+def test_the_availability_boolean_is_unchanged(
+    source: str, expected: bool, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """{present, absent} x {os.environ, .env, .env.pmcp, pmcp.env}.
+
+    Characterization: every answer here was recorded against unchanged `main`
+    before the fix. It stays feasible precisely because the fix records what
+    `load_dotenv` did instead of re-deriving it -- nothing re-parses a file and
+    no precedence rule is re-implemented.
+    """
+    project = _isolate(tmp_path, monkeypatch)
+    home = Path(os.environ["HOME"])
+    if source == "environ":
+        monkeypatch.setenv(QUERIED, "v")
+    elif source == "dotenv":
+        (project / ".env").write_text(f"{QUERIED}=v\n")
+    elif source == "project_store":
+        (project / ".env.pmcp").write_text(f"{QUERIED}=v\n")
+    elif source == "user_store":
+        (home / ".config" / "pmcp").mkdir(parents=True)
+        (home / ".config" / "pmcp" / "pmcp.env").write_text(f"{QUERIED}=v\n")
+
+    assert _gateway_tools()._check_api_key_available(QUERIED) is expected
+
+
+def test_the_availability_check_still_interpolates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`load_dotenv` interpolates; `read_env_file`/`dotenv_values(interpolate=
+    False)` would have returned the literal `${BASE}/x`. This is why the fix
+    must not re-parse the file."""
+    project = _isolate(tmp_path, monkeypatch)
+    (project / ".env").write_text(f"{BASE}=abc\n{DERIVED}=${{{BASE}}}/x\n")
+
+    assert _gateway_tools()._check_api_key_available(DERIVED) is True
+    assert os.environ[DERIVED] == "abc/x"
+    assert DERIVED not in sanitized_subprocess_env()
+
+
+def test_an_empty_value_shadows_a_later_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An empty value in a higher-priority file blocks a real value in a later
+    one, because `load_dotenv(..., override=False)` will not replace a key that
+    is already set -- even to the empty string. Per-file dicts do not reproduce
+    that. Unchanged from `main`, and pinned so it stays that way."""
+    project = _isolate(tmp_path, monkeypatch)
+    (project / ".env").write_text(f"{QUERIED}=\n")
+    (project / ".env.pmcp").write_text(f"{QUERIED}=real\n")
+
+    assert _gateway_tools()._check_api_key_available(QUERIED) is False
+    assert os.environ[QUERIED] == ""
+
+
+def test_the_availability_check_short_circuits_on_no_env_var() -> None:
+    assert _gateway_tools()._check_api_key_available(None) is False
+    assert _gateway_tools()._check_api_key_available("") is False
+
+
+def test_the_servers_own_credential_still_resolves(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Operator decision (A), first half: a plain `.env` may still supply a
+    server's OWN declared `env_var`. Credential resolution reads it from
+    `os.environ` (which still has it) and passes it as `own_env`, which is
+    applied AFTER the strip."""
+    project = _isolate(tmp_path, monkeypatch)
+    (project / ".env").write_text(f"{OWN_KEY}=own-value\n{OTHER_KEY}=other-value\n")
+
+    cli.load_startup_env(project / ".env")
+
+    child = sanitized_subprocess_env({OWN_KEY: os.environ[OWN_KEY]})
+
+    assert child[OWN_KEY] == "own-value"
+
+
+def test_only_the_declared_key_is_injected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Decision (A), second half: that key only. The other key in the same file
+    does not ride along into the same server."""
+    project = _isolate(tmp_path, monkeypatch)
+    (project / ".env").write_text(f"{OWN_KEY}=own-value\n{OTHER_KEY}=other-value\n")
+
+    cli.load_startup_env(project / ".env")
+
+    child = sanitized_subprocess_env({OWN_KEY: os.environ[OWN_KEY]})
+
+    assert OTHER_KEY not in child
+    assert os.environ[OTHER_KEY] == "other-value"  # the gateway still sees it
+
+
+def test_the_registry_is_empty_without_main(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PMCP imported as a library, with `main()` never run, has loaded no dotenv
+    file: it records nothing and therefore strips nothing extra. An empty
+    registry is the correct default, not a missing initialisation."""
+    _isolate(tmp_path, monkeypatch)
+    monkeypatch.setenv(SENTINEL, "from-the-operators-shell")
+
+    assert dotenv_sourced_keys() == frozenset()
+    assert sanitized_subprocess_env()[SENTINEL] == "from-the-operators-shell"


### PR DESCRIPTION
## The leak

`pmcp`'s console-script entry point loads `<project>/.env` into its own
`os.environ` at startup, and `GatewayTools._check_api_key_available` loads whole
env files to answer a boolean — while `env_store.sanitized_subprocess_env`
builds every downstream server's environment from `os.environ.copy()` minus
PMCP-managed keys. So **every key in the operator's `.env` was inherited by
every third-party MCP server PMCP spawned**, not just the one a server declared.
`sanitized_subprocess_env`'s own docstring recorded the gap.

Review finding **S-02** (HIGH); see #229.

Reproduced on unchanged `main` — a `.env` sentinel PMCP does not manage was
present in **both** `os.environ` and `sanitized_subprocess_env()`:

```
in os.environ:               True
in sanitized_subprocess_env: True
child value:                 leaked-secret
```

## The fix: record provenance, don't re-derive it

```python
before = set(os.environ)
load_dotenv(...)                      # semantics COMPLETELY unchanged
record_dotenv_keys(set(os.environ) - before)
```

`sanitized_subprocess_env` strips the recorded keys in addition to
`managed_secret_keys`, and `own_env` is applied **after** the strip.

Two properties follow, and both are why this shape was chosen over the
alternatives:

- **`load_dotenv` keeps its exact semantics.** Nothing re-parses a dotenv file
  and no precedence rule is re-implemented, so interpolation (`${BASE}/x` →
  `abc/x`, where `dotenv_values(interpolate=False)` would return the literal),
  `override=False` empty-value shadowing, and the credential-availability
  boolean are all bit-for-bit unchanged.
- **The strip is by provenance, never by key name.** `load_dotenv` defaults to
  `override=False`, so a variable the operator exported into their shell that
  merely *also* appears in `.env` was never sourced from that file — it is in
  `before`, so it is never recorded and never stripped. Stripping by name would
  have deleted the operator's `PATH` from every spawned server.

**Operator decision (A) preserved:** a plain `.env` may still supply a server's
OWN declared `env_var` — that key only, into that server only, because `own_env`
is applied after the strip. Shell-exported secrets are still inherited:
deliberate, and out of scope.

## Changes

| File | Change |
|---|---|
| `src/pmcp/env_store.py` | `record_dotenv_keys` / `dotenv_sourced_keys` provenance registry + `reset_dotenv_keys` test seam; `sanitized_subprocess_env` strips the recorded keys; the docstring's gap sentence now states what is actually true |
| `src/pmcp/cli.py` | `load_startup_env()` — the startup loads extracted from `main()`, with the delta recorded around the plain `.env` load; `main()` calls it |
| `src/pmcp/tools/handlers.py` | `_check_api_key_available` records what each of its loads introduces; the `load_dotenv` call and import are untouched |
| `tests/test_env_leak_229.py` | 16 tests (new) |
| `tests/conftest.py` | autouse `reset_dotenv_keys()` — the registry is process-global and existing tests drive the production paths that write to it |
| `SECURITY.md`, `CHANGELOG.md` | state precisely what is now true |

The end-to-end test calls the **production** `cli.load_startup_env()` — not
`load_dotenv` (which would record nothing and fail against a correct fix) and
not `record_dotenv_keys` (which would pass while `main()` still leaked). A
wiring guard asserts `main()` calls it, with zero arguments, and contains no
inline `load_dotenv`.

## Verification

| Command | Result |
|---|---|
| `uv run pytest -q tests/test_env_leak_229.py` | 16 passed |
| `uv run pytest -q tests/test_tools.py` | 19 failed / 174 passed — **identical set** to `main` (host `/tmp/package.json`, `tests/conftest.py`); the `load_dotenv` monkeypatch test passes, file unmodified |
| `uv run pytest -q tests/` | 107 failed, **3215 passed**, 3 skipped, 25 deselected, 106 errors — vs `main`'s 107 / **3199** / 3 / 25 / 106. Failure and error sets diff clean; passes +16, exactly the new tests |
| `uv run ruff check` / `ruff format --check` | clean |
| `uv run mypy src/` | Success, 43 files |

The production **default** path was also proven end-to-end with a real
`<project>/.env` and a zero-argument `load_startup_env()`: sentinel present in
`os.environ`, absent from `sanitized_subprocess_env()`, `PATH` intact.

The availability boolean was characterized against unchanged `main` first
({present, absent} × {`os.environ`, `.env`, `.env.pmcp`, `pmcp.env`}, plus an
interpolated value and an empty value shadowing a later file); the shipped tests
make the same assertions and pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HXnhuCY1DhNdGJTuRCa23

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791300097&installation_model_id=427051&pr_number=237&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F237&signature=258fae8a71e49ea8b023dabfcc1ef0cc18128b5a25259ab4e679012b4a2dd43b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->