### PR TITLE
docs: v13 trust-boundary roadmap + TRUST phase plan (see #230)

### DIFF
--- a/plans/phase-plan-v13-TRUST.md
+++ b/plans/phase-plan-v13-TRUST.md
@@ -1,0 +1,208 @@
+---
+phase_loop_plan_version: 1
+phase: TRUST
+roadmap: specs/phase-plans-v13.md
+roadmap_sha256: b5f85f7b74a7d9f57bb57b3330ef912c04ac6304aee37a49f5a67345856116dc
+---
+
+# PHASE-1-TRUST: Trust primitives
+
+## Context
+
+TRUST is the freeze phase of the v13 trust-boundary roadmap. It publishes the two
+contracts CONSENT and PKGID code against and **wires no caller** — that is
+deliberate, and it is why the phase is small.
+
+What exists today:
+
+- `src/pmcp/env_store.py` already establishes the user-scope convention:
+  `resolve_scope_path("user")` → `~/.config/pmcp/pmcp.env` (`:36-44`). The trust
+  store belongs beside it, in the same user-scoped directory, which is what makes
+  EC-TRUST-5 (store outside any repository) natural rather than novel.
+- `read_env_file` (`:45-58`) shows the house style for reading a user-scoped file
+  into a dict without touching global state — the #229 lesson, freshly applied.
+- `src/pmcp/manifest/npm_resolver.py` provides `NpmResolver`, the frozen
+  `NpmResolution` dataclass (`:195-215`), `get_resolver()` (`:619`) and
+  `reset_resolver_for_tests()` (`:634`). Package identity **adapts** this; it does
+  not start a new subsystem (roadmap Assumption 4).
+- `src/pmcp/cli.py` registers subcommands with `subparsers.add_parser(...)`
+  (`:291` onward) — `pmcp trust` follows that pattern.
+
+Two constraints from the roadmap's rev-2 board that shape the design:
+
+1. `is_approved` takes **the bytes the caller is about to apply**, not a path. A
+   path-based check is defeated by swapping the file between check and use.
+2. The store's **residency and write authority are part of the freeze**. A
+   checkout-writable store lets a repository ship an approval for its own
+   malicious content, which would make "absence is never assent" decorative.
+
+## Interface Freeze Gates
+
+- [ ] IF-0-TRUST-1 — `TrustRecord(absolute_path: Path, content_sha256: str, scope: str, decision: str, recorded_at: datetime)`; `is_approved(path: Path, content: bytes) -> bool`, `record(path: Path, content: bytes, scope: str, decision: str) -> TrustRecord`, `revoke(path: Path) -> bool`, `list_records() -> list[TrustRecord]`; store resides at `~/.config/pmcp/trust.json` (user scope) and refuses a path inside the current checkout. The freeze also fixes the semantics a downstream lane would otherwise guess: `decision` is the closed vocabulary `{"approved", "denied"}` and `is_approved` returns `True` only for `"approved"` — a `"denied"` record is not merely absent; the store keeps **one record per absolute path** (re-approving replaces, it does not append a history); every I/O or parse failure reading the store **fails closed** (`is_approved` returns `False`, never raises to a caller that might treat an exception as permission); and the store file is created mode `0o600` with the residency check resolving symlinks before comparing against the checkout root.
+- [ ] IF-0-TRUST-2 — `PackageIdentity(registry: str, name: str, resolved_version: str, integrity: str | None)` and `resolve_package_identity(spec: str) -> PackageIdentity | None`, resolving without executing the package.
+
+## Lane Index & Dependencies
+
+SL-1 — Trust store core
+  Depends on: (none)
+  Blocks: SL-3, SL-4
+  Parallel-safe: yes
+
+SL-2 — Package identity adapter
+  Depends on: (none)
+  Blocks: SL-4
+  Parallel-safe: yes
+
+SL-3 — `pmcp trust` CLI verbs
+  Depends on: SL-1
+  Blocks: SL-4
+  Parallel-safe: yes
+
+SL-4 — Documentation & spec reconciliation
+  Depends on: SL-1, SL-2, SL-3
+  Blocks: (none)
+  Parallel-safe: no
+
+## Lanes
+
+### SL-1 — Trust store core
+
+- **Scope**: The provenance/approval record, its user-scoped store, and the content-hash predicate every downstream loader will call.
+- **Owned files**: `src/pmcp/trust_store.py`, `tests/test_trust_store.py`
+- **Interfaces provided**: `TrustRecord`, `is_approved`, `record`, `revoke`, `list_records`, `trust_store_path`
+- **Interfaces consumed**: (none)
+- **Parallel-safe**: yes
+- **Tasks**:
+
+| Task ID | Type | Depends on | Files in scope | Tests owned | Test command |
+|---|---|---|---|---|---|
+| SL-1.1 | test | — | `tests/test_trust_store.py` | **exactly these names**, because the acceptance criteria address them individually: `test_a_record_round_trips`, `test_changed_content_is_no_longer_approved`, `test_an_unknown_path_is_not_approved`, `test_an_unreadable_store_fails_closed`, `test_a_store_inside_the_checkout_is_refused`, `test_a_symlinked_store_into_the_checkout_is_refused`, `test_is_approved_judges_supplied_bytes_not_the_path`, `test_a_denied_record_is_not_approved` | `uv run pytest -q tests/test_trust_store.py` |
+| SL-1.2 | impl | SL-1.1 | `src/pmcp/trust_store.py` | — | — |
+| SL-1.3 | verify | SL-1.2 | `src/pmcp/trust_store.py`, `tests/test_trust_store.py` | all SL-1 tests | `uv run pytest -q tests/test_trust_store.py && uv run mypy src/` |
+
+### SL-2 — Package identity adapter
+
+- **Scope**: Resolve an npm spec to a stable identity tuple without executing it, adapting the existing #195 resolver.
+- **Owned files**: `src/pmcp/manifest/package_identity.py`, `tests/test_package_identity.py`
+- **Interfaces provided**: `PackageIdentity`, `resolve_package_identity`
+- **Interfaces consumed**: (none — reads `npm_resolver` but does not modify it)
+- **Parallel-safe**: yes
+- **Tasks**:
+
+| Task ID | Type | Depends on | Files in scope | Tests owned | Test command |
+|---|---|---|---|---|---|
+| SL-2.1 | test | — | `tests/test_package_identity.py` | identity resolves offline from a fixture; an unresolvable spec returns `None` rather than raising; no subprocess is spawned | `uv run pytest -q tests/test_package_identity.py` |
+| SL-2.2 | impl | SL-2.1 | `src/pmcp/manifest/package_identity.py` | — | — |
+| SL-2.3 | verify | SL-2.2 | `src/pmcp/manifest/package_identity.py`, `tests/test_package_identity.py` | all SL-2 tests | `uv run pytest -q tests/test_package_identity.py && uv run mypy src/` |
+
+### SL-3 — `pmcp trust` CLI verbs
+
+- **Scope**: `pmcp trust approve <path>`, `pmcp trust list`, `pmcp trust revoke <path>` over the SL-1 store.
+- **Owned files**: `src/pmcp/cli.py`, `tests/test_trust_cli.py`
+- **Interfaces provided**: the `pmcp trust` subcommand surface
+- **Interfaces consumed**: `TrustRecord`, `is_approved`, `record`, `revoke`, `list_records` (SL-1)
+- **Parallel-safe**: yes
+- **Tasks**:
+
+| Task ID | Type | Depends on | Files in scope | Tests owned | Test command |
+|---|---|---|---|---|---|
+| SL-3.1 | test | — | `tests/test_trust_cli.py` | each verb round-trips through the store; `approve` on a missing file exits non-zero; `list` output names path and decision | `uv run pytest -q tests/test_trust_cli.py` |
+| SL-3.2 | impl | SL-3.1 | `src/pmcp/cli.py` | — | — |
+| SL-3.3 | verify | SL-3.2 | `src/pmcp/cli.py`, `tests/test_trust_cli.py` | all SL-3 tests | `uv run pytest -q tests/test_trust_cli.py tests/test_cli.py` |
+
+### SL-docs — Documentation & spec reconciliation
+
+- **Scope**: Refresh the docs catalog, update cross-cutting documentation touched or invalidated by this phase's impl lanes, and append any post-execution amendments to phase specs whose interface freezes turned out wrong.
+- **Owned files**: `.claude/docs-catalog.json`, `CHANGELOG.md`, `specs/phase-plans-v13.md`
+- **Interfaces provided**: (none)
+- **Interfaces consumed**: (none)
+- **Parallel-safe**: no (terminal)
+- **Depends on**: SL-1, SL-2, SL-3
+- **Tasks**:
+
+| Task ID | Type | Depends on | Files in scope | Action |
+|---|---|---|---|---|
+| SL-docs.1 | docs | — | `.claude/docs-catalog.json` | Rescan via `_shared/scaffold_docs_catalog.py --rescan` if present; if absent, record "docs-catalog rescan helper unavailable; manual catalog audit" in the commit message and proceed. |
+| SL-docs.2 | docs | SL-docs.1 | per catalog | Decide per catalog file whether this phase changes it. **SECURITY.md is deliberately NOT updated here** — the roadmap assigns the trust-model write-up to SEAL, once, rather than four partial descriptions. Record that skip explicitly. |
+| SL-docs.3 | docs | SL-docs.2 | `specs/phase-plans-v13.md` | Append `### Post-execution amendments` to the TRUST phase section if either IF-0-TRUST gate proved wrong in practice. |
+| SL-docs.4 | verify | SL-docs.3 | — | `uv run ruff format --check src/ tests/ scripts/` (same paths as `## Verification`) plus any repo doc linters; no-op if none configured. |
+
+## Execution Notes
+
+- **Machine validators unavailable in this checkout.** `scripts/validate_plan_doc.py`
+  does not exist in this repo and `phase_loop_runtime.planner_validation` is not
+  importable from this worktree's interpreter. The Lane validation checklist was
+  walked by hand: file ownership is disjoint (`trust_store.py` / `package_identity.py`
+  / `cli.py`), the DAG is acyclic, every `impl` follows a `test`, and every
+  acceptance item names a proving command. `## Dispatch Hints` is deliberately
+  omitted rather than authored unvalidated. The skill's advisor-review step
+  (7.75) was also unavailable in this session; this plan has had **no** automated
+  review, only the hand-walked checklist and the roadmap's own board round — treat
+  its freezes as slightly less hardened than the roadmap's. **A board round was
+  subsequently run** and produced three real findings, all folded in: the freeze
+  left `decision` semantics, record cardinality, fail-closed I/O and write
+  authority unstated; the acceptance criteria used `-k` expressions guessing at
+  test names that do not exist yet (measured: a non-matching `-k` exits 5, so it
+  fails loudly rather than passing vacuously — but it proves nothing either, and
+  an implementer would have had to reverse-engineer the intended names); and the
+  stale-base guidance still carried the template's unfilled placeholder. Two of
+  three seats spent their verdict objecting that a plan contains no
+  implementation evidence, which is what a plan is — those objections are not
+  folded in.
+- **Single-writer files**: `src/pmcp/cli.py` — owner **SL-3**. No other lane in this
+  phase touches it. Note for later phases: CONSENT and PKGID do not write `cli.py`,
+  so no cross-phase serialization edge is created here.
+- **Known destructive changes**: none — every lane is purely additive. `SL-3` adds a
+  subparser to `cli.py` and modifies no existing verb.
+- **Expected add/add conflicts**: none — there is no SL-0 preamble lane; SL-1 and SL-2
+  create new modules that no other lane stubs.
+- **SL-0 re-exports**: not applicable — this phase adds no package `__init__.py`
+  re-exports. If a later phase wants `pmcp.trust_store` re-exported from a package
+  `__init__`, use the `__getattr__` lazy form.
+- **Parallelism**: SL-1 and SL-2 are DAG roots and share no files — run them
+  concurrently. SL-3 opens when SL-1's interfaces land; it consumes them and must not
+  begin against a guessed signature.
+- **Do not wire any caller.** No loader, policy path, or provisioning path changes in
+  this phase. A lane that "helpfully" wires CONSENT's or PKGID's consumer has broken
+  the freeze and made those phases un-parallel.
+- **Stale-base guidance** (copy verbatim): Lane teammates working in isolated worktrees do not see sibling-lane merges automatically. If a lane finds its worktree base is pre-SL-1 (for SL-3, the only lane here with an upstream), it MUST stop and report rather than committing — the orchestrator will re-spawn or rebase. Silent `git reset --hard` or `git checkout HEAD~N -- …` in a stale worktree produces commits that destroy peer-lane work on `--no-ff` merge.
+
+## Acceptance Criteria
+
+- [ ] EC-TRUST-1 — proven by `uv run pytest -q tests/test_package_identity.py`, falsified by a negative control that resolves a spec with the network and any subprocess spawn monkeypatched to raise (identity must still resolve from the fixture, and no spawn is attempted).
+- [ ] EC-TRUST-2 — proven by `uv run pytest -q tests/test_trust_store.py::test_a_record_round_trips tests/test_trust_store.py::test_changed_content_is_no_longer_approved`, falsified by approving a file, mutating one byte, and asserting `is_approved` returns `False`.
+- [ ] EC-TRUST-3 — proven by `uv run pytest -q tests/test_trust_store.py::test_an_unknown_path_is_not_approved tests/test_trust_store.py::test_an_unreadable_store_fails_closed`, falsified by querying a path with no record and asserting `False` (never a default-true or a raise swallowed to true).
+- [ ] EC-TRUST-4 — proven by `uv run pytest -q tests/test_trust_cli.py`, falsified by invoking each of `approve` / `list` / `revoke` and asserting the store state changed as named; `approve` must exist, because every downstream refusal message names it.
+- [ ] EC-TRUST-5 — proven by `uv run pytest -q tests/test_trust_store.py::test_a_store_inside_the_checkout_is_refused tests/test_trust_store.py::test_a_symlinked_store_into_the_checkout_is_refused`, falsified by pointing the store at a path inside the checkout — directly and via symlink — and asserting refusal rather than a read.
+- [ ] EC-TRUST-6 — proven by `uv run pytest -q tests/test_trust_store.py::test_is_approved_judges_supplied_bytes_not_the_path`, falsified by approving content A, then calling `is_approved(path, content_B)` for a file whose on-disk bytes are still A, and asserting `False` — the predicate must judge the supplied bytes, not the path.
+
+## Verification
+
+```bash
+uv run pytest -q tests/test_trust_store.py tests/test_package_identity.py tests/test_trust_cli.py
+uv run pytest -q tests/                       # compare counts to the pre-phase baseline, same dir
+uv run ruff check src/ tests/ scripts/ && uv run ruff format --check src/ tests/ scripts/
+uv run mypy src/
+uv run python -c "import pmcp.trust_store, pmcp.manifest.package_identity"   # both importable
+git diff --name-only origin/main..HEAD -- src/pmcp/policy src/pmcp/config src/pmcp/manifest/loader.py
+# ^ MUST be empty: TRUST wires no caller. A non-empty result means the freeze leaked.
+```
+
+Host note: `/tmp/package.json` makes ~107 npm-identity tests fail on some hosts
+(`tests/conftest.py`); compare the same command from the same directory before and
+after, never against a clean-machine expectation.
+
+## Spec Closeout Plan
+
+- schema: `spec_delta_closeout.v1`
+- decision: `no_spec_delta`
+- target surfaces: `src/pmcp/trust_store.py`, `src/pmcp/manifest/package_identity.py`, `src/pmcp/cli.py`
+- evidence paths: `tests/test_trust_store.py`, `tests/test_package_identity.py`, `tests/test_trust_cli.py`, `CHANGELOG.md`
+- redaction posture: `metadata_only`
+- downstream handling: none — SECURITY.md's trust-model write-up is owned by SEAL
+
+## Execution Policy
+
+- default: effort=low, reason=two new self-contained modules plus one subparser
+- SL-1: effort=high, reason=security predicate where a wrong default silently grants trust
+- SL-2: effort=medium, reason=adapts an existing resolver whose refusal semantics are subtle

--- a/specs/phase-plans-v13.md
+++ b/specs/phase-plans-v13.md
@@ -1,0 +1,386 @@
+# PMCP phase plans v13 — trust boundaries
+
+> **Revision 2 (2026-09-08).** Boarded 3x DISAGREE. Seven real defects, fixed below.
+> The load-bearing ones: the DAG claimed CONSENT and PKGID "share no files" while both
+> list `policy/policy.py`; an unapproved project overlay that *adds* a server (rather
+> than replacing one) slipped the seam between CONSENT and PKGID; and IF-0-TRUST-1
+> froze the record shape but not **where the store lives or who may write it** — a
+> checkout-writable store lets a repository ship its own approval and makes
+> absence-is-not-assent meaningless.
+>
+> **One verdict is rejected.** Two seats judged this as a pre-merge implementation
+> review — "no implementation evidence, exit criteria unchecked, missing evidence is
+> `contract_bug`". A roadmap is a plan; unchecked exit criteria are its purpose, and the
+> `spec_delta_closeout` evidence rule binds *phase execution*, not the roadmap artifact.
+> Their structural findings are folded in; the evidence objection is not.
+
+
+## Context
+
+PMCP is a local-first MCP gateway that brokers untrusted third-party servers on
+behalf of a semi-trusted, prompt-injectable agent. The 2026-09-01 codebase review
+(`plans/codebase-review-2026-09-01.md`) found that the remaining risk has moved up
+a level: not bugs inside functions, but the **trust boundaries between the agent,
+repository-supplied configuration, and the host**.
+
+Four findings look separate and are one question — *what may introduce code the
+gateway will execute or actions it will take, and who consents?*
+
+| Finding | Severity | Substance |
+|---|---|---|
+| **S-01** | HIGH | `register_discovered_server` accepts any npm package; `provision` runs it with `npx -y`. Policy checks the **agent-chosen server name**, not the package. Reproduced: allowlisting `internal-approved-tool` executes `npx -y totally-arbitrary-evil-package`. |
+| **S-03** | MEDIUM (HIGH shared/CI) | A checkout's `.pmcp/manifest.yaml` replaces any shipped server's command wholesale; `.mcp.json` is trusted the same way. "Clone a repo and use GitHub" becomes code execution. |
+| **S-11** | MEDIUM | A project `.mcp-gateway-policy.yaml` **silently shadows** the operator's global policy — first match wins, project paths first, default allow-all. |
+| **S-04** | MEDIUM | `gateway.submit_feedback` posts agent-authored text to a public repo using the ambient `GITHUB_TOKEN`. |
+
+Each has a local patch. Patching them separately would produce four inconsistent
+consent mechanisms, and S-11's own fix note already says it "ties into S-03's trust
+store". This roadmap builds **one** trust model and routes all four through it.
+
+## Architecture North Star
+
+```
+        agent (prompt-injectable)        repository checkout        operator
+              |                                 |                      |
+              | register / provision            | .pmcp/manifest.yaml  | pmcp trust
+              | submit_feedback                 | .mcp.json            | pmcp approve
+              v                                 v  policy.yaml         v
+   +---------------------------------------------------------------------+
+   |  TRUST  identity + provenance + approval record (the frozen core)    |
+   |    package identity: (registry, name, resolved version, integrity)   |
+   |    source provenance: (abs path, content hash, scope, decision)      |
+   +---------------------------------------------------------------------+
+        |                        |                            |
+        v                        v                            v
+   PKGID: provisioning     CONSENT: project-scoped      EGRESS: outbound acts
+   binds to package        config gated + policy        with operator identity
+   identity, not a name    narrowing-only               explicit + preview-first
+        \                        |                            /
+         \                       v                           /
+          +--------------> SEAL: documented model + ---------+
+                           adversarial end-to-end proof
+```
+
+## Assumptions (fail-loud if wrong)
+
+1. Downstream tool output is untrusted and the agent is prompt-injectable. If the
+   agent is trusted, most of this roadmap is unnecessary.
+2. The operator is a human who can be asked once and remembered — an approval
+   store is meaningful. If PMCP runs fully unattended, the default must be deny,
+   not prompt.
+3. `provision` consults the shipped manifest **before** the discovered registry
+   (`handlers.py:4262-4266`), so a discovered entry cannot shadow a manifest name.
+   Verified in the review; if it regresses, S-01's blast radius grows.
+4. The npm identity machinery from #195 (`manifest/npm_resolver.py`,
+   `manifest/version_checker.py`) can resolve a package identity without executing
+   it. TRUST extends that work rather than starting a new subsystem.
+5. Existing operators keep working configurations. A default-deny that silently
+   breaks a working setup is a failed phase, not a strict one.
+
+## Non-Goals
+
+- Sandboxing downstream servers, or any container/namespace isolation.
+- Sanitising shell-exported secrets — deliberate, documented in SECURITY.md, and
+  unchanged by this roadmap (#229 closed the plain-`.env` path only).
+- Auditing PMCP's own supply chain (that is #217/#228 territory).
+- A general policy engine. Policy gains package identifiers and narrowing
+  semantics; it does not become a rules language.
+- Retroactive approval of already-provisioned servers beyond a one-time migration.
+
+## Cross-Cutting Principles
+
+- **Fail closed on the new gates, fail open on nothing.** Every gate added here
+  refuses on ambiguity, matching #202 and #217.
+- **Identity, not labels.** A decision binds to what will execute (package,
+  file content hash), never to a name the agent supplied.
+- **Consent is recorded, revocable, and legible.** An approval is a durable record
+  an operator can list and revoke — not a flag buried in a config.
+- **A narrowing-only rule for project scope.** Repository-supplied configuration
+  may restrict, never widen.
+- **Every refusal names the decision and how to grant it.** A blocked action must
+  print the exact `pmcp` command that would allow it.
+- **No behaviour change without a CHANGELOG entry**, and no security claim in
+  SECURITY.md that the tests do not prove.
+
+## Phases
+
+### Phase 1 — Trust primitives (TRUST)
+
+**Objective**
+Freeze the two data contracts every other phase codes against: a package identity
+tuple and a source-provenance/approval record, with a store to read and write them.
+
+**Exit criteria**
+- [ ] EC-TRUST-1 — a package identity `(registry, name, resolved_version, integrity)` is resolvable for any npm spec without executing it, reusing `manifest/npm_resolver.py`; proven by a test that resolves a real spec offline from a fixture.
+- [ ] EC-TRUST-2 — a source provenance record `(absolute_path, content_sha256, scope, decision, recorded_at)` round-trips through the store; a file whose content changes after approval reads back as **not approved**.
+- [ ] EC-TRUST-3 — the store refuses to answer "approved" for any path it has no record of; absence is never assent.
+- [ ] EC-TRUST-4 — the full CLI surface exists and is covered by tests: `pmcp trust approve <path>` (records), `pmcp trust list`, `pmcp trust revoke <path>`. The **approve** verb is what every downstream refusal message names, so omitting it would leave those messages naming a command that does not exist.
+- [ ] EC-TRUST-5 — the store lives **outside any repository** (user scope, e.g. `~/.config/pmcp/`), and a store path inside the current checkout is refused at startup. A repository that ships its own approval record must not be believed; without this, absence-is-not-assent is decorative.
+- [ ] EC-TRUST-6 — `is_approved` answers about **bytes, not paths**: the caller passes the content it is about to apply and the store hashes that, so a file swapped between check and use is not approved by a stale decision.
+
+**Scope notes**
+Decompose into 2 lanes with disjoint files: **lane A** owns the provenance/approval
+store and its CLI surface; **lane B** owns the package-identity resolver adapter over
+the existing #195 machinery. Both publish their shapes on day 1 so CONSENT and PKGID
+can start against the contract rather than the implementation. No caller is wired in
+this phase — that is deliberate, and it is why this phase is small.
+
+**Non-goals**
+Wiring any consumer; changing provisioning or policy behaviour.
+
+**Key files**
+- `src/pmcp/trust_store.py` (new)
+- `src/pmcp/manifest/npm_resolver.py`
+- `src/pmcp/cli.py`
+- `tests/test_trust_store.py` (new)
+
+**Depends on**
+- (none)
+
+**Produces**
+- IF-0-TRUST-1
+- IF-0-TRUST-2
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `no_spec_delta`
+- target surfaces: `src/pmcp/trust_store.py`, `src/pmcp/cli.py`
+- evidence paths: `tests/test_trust_store.py`, `CHANGELOG.md`
+- redaction posture: `metadata_only`
+- missing or malformed evidence routes to `blocker_class=contract_bug` (non-human).
+
+### Phase 2 — Project-scoped configuration requires consent (CONSENT)
+
+**Objective**
+Gate every repository-supplied configuration source through the trust store, and
+make a project policy able only to narrow the operator's policy.
+
+**Exit criteria**
+- [ ] EC-CONSENT-1 — an unapproved `.pmcp/manifest.yaml` does **not** replace a shipped server's command; the shipped definition is used and the skip is logged at WARNING naming the exact `pmcp trust` command.
+- [ ] EC-CONSENT-2 — an unapproved project `.mcp.json` is not applied, on the same terms.
+- [ ] EC-CONSENT-3 — a project policy may only **narrow**: a project file that allows a server the user policy denies leaves it denied; proven by a test that fails on today's first-match-wins behaviour.
+- [ ] EC-CONSENT-4 — approving a file, then editing it, revokes the approval automatically (content hash, not path).
+- [ ] EC-CONSENT-5 — an operator with no project files sees byte-identical behaviour to today; proven by the existing config/policy suites passing unmodified.
+- [ ] EC-CONSENT-6 — an unapproved overlay that **adds a new server** rather than replacing a shipped one is also not applied, and the added server is **not** treated as manifest-backed downstream. Without this the add path slips the seam: CONSENT only refuses replacement, PKGID's default-deny exempts manifest-backed servers, and an unapproved package executes through the gap between two phases that each look complete.
+- [ ] EC-CONSENT-7 — an unapproved project `.mcp-gateway-policy.yaml` is **not applied at all** (not merely narrowed), on the same trust terms as the manifest and `.mcp.json`. EC-CONSENT-3 governs what an *approved* project policy may do; this governs whether it is read.
+
+**Scope notes**
+Decompose into 3 lanes with disjoint files: **lane A** owns the manifest overlay
+walk-up (`manifest/loader.py`), **lane B** owns `.mcp.json` (`config/loader.py`),
+**lane C** owns policy precedence and intersection (`policy/policy.py`). The three
+consume IF-0-TRUST-1 and never write to each other's files. Lane C is the one with a
+behaviour change an existing operator could feel — sequence its CHANGELOG note first.
+
+**Non-goals**
+Package identity (PKGID owns it); any change to user- or env-scoped sources.
+
+**Key files**
+- `src/pmcp/manifest/loader.py`
+- `src/pmcp/config/loader.py`
+- `src/pmcp/policy/policy.py`
+- `tests/test_project_source_consent.py` (new)
+
+**Depends on**
+- TRUST
+
+**Produces**
+- IF-0-CONSENT-1
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `no_spec_delta`
+- target surfaces: `src/pmcp/manifest/loader.py`, `src/pmcp/config/loader.py`, `src/pmcp/policy/policy.py`
+- evidence paths: `tests/test_project_source_consent.py`, `SECURITY.md`, `CHANGELOG.md`
+- redaction posture: `metadata_only`
+- missing or malformed evidence routes to `blocker_class=contract_bug` (non-human).
+
+### Phase 3 — Provisioning binds to package identity (PKGID)
+
+**Objective**
+Stop the agent choosing what executes. Bind provisioning decisions to a resolved
+package identity and put discovered-package installation behind an operator opt-in.
+
+**Exit criteria**
+- [ ] EC-PKGID-1 — the review's reproduction fails closed: registering `internal-approved-tool` with package `totally-arbitrary-evil-package` and provisioning it does **not** exec `npx -y totally-arbitrary-evil-package`; the refusal names the package and the command that would approve it.
+- [ ] EC-PKGID-2 — policy can allow or deny **package identifiers**, and `provision` checks the package, not only the server name.
+- [ ] EC-PKGID-3 — discovered-package provisioning is default-deny; an operator opt-in (config flag or recorded approval) is required, and a manifest-backed server is unaffected.
+- [ ] EC-PKGID-4 — the exact argv is logged at WARNING before every install spawn.
+- [ ] EC-PKGID-5 — a registration without a resolvable version is refused, or the version is resolved and recorded at registration and passed as `pkg@<version>`; whichever is chosen is asserted by test.
+- [ ] EC-PKGID-6 — servers already provisioned before this phase keep working: a one-time migration records approvals for them, or they are grandfathered by an explicit recorded decision. Assumption 5 says a default-deny that silently breaks a working setup is a failed phase; this criterion is the phase that owns it, and no other phase did.
+
+**Scope notes**
+Decompose into 3 lanes with disjoint files: **lane A** owns the register/provision
+gate in `tools/handlers.py`, **lane B** owns policy package identifiers in
+`policy/policy.py` and `types.py`, **lane C** owns argv logging plus version pinning
+in `manifest/installer.py`. Lane A is the single-writer risk — `handlers.py` is large
+and touched by other work; serialise any other writer against it. Parallel-safe with
+CONSENT: no shared file, and both depend only on TRUST.
+
+**Non-goals**
+Sandboxing what does run; auditing PMCP's own dependencies.
+
+**Key files**
+- `src/pmcp/tools/handlers.py`
+- `src/pmcp/policy/policy.py`
+- `src/pmcp/manifest/installer.py`
+- `src/pmcp/validation.py`
+- `tests/test_package_identity_gate.py` (new)
+
+**Depends on**
+- TRUST
+
+**Produces**
+- IF-0-PKGID-1
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `no_spec_delta`
+- target surfaces: `src/pmcp/tools/handlers.py`, `src/pmcp/policy/policy.py`, `src/pmcp/manifest/installer.py`
+- evidence paths: `tests/test_package_identity_gate.py`, `SECURITY.md`, `CHANGELOG.md`
+- redaction posture: `metadata_only`
+- missing or malformed evidence routes to `blocker_class=contract_bug` (non-human).
+
+### Phase 4 — Outbound actions need explicit authority (EGRESS)
+
+**Objective**
+Stop `gateway.submit_feedback` acting publicly under the operator's ambient identity;
+make preview the default and explicit opt-in the only path to submission.
+
+**Exit criteria**
+- [ ] EC-EGRESS-1 — ambient `GITHUB_TOKEN` is never used; only a dedicated `PMCP_FEEDBACK_TOKEN` is honoured, asserted by a test that sets `GITHUB_TOKEN` and requires no request to be attempted.
+- [ ] EC-EGRESS-2 — the default is preview-only: the handler returns the payload and a browser URL, and `confirm_submission` alone cannot cause a post without `enable_feedback_submission: true`.
+- [ ] EC-EGRESS-3 — the default repository is corrected to the real remote, asserted against the value in the packaged config rather than a literal duplicated in the test.
+- [ ] EC-EGRESS-4 — no blocking HTTP call runs on the event loop in this path (addresses P-03).
+
+**Scope notes**
+Decompose into 2 lanes with disjoint concerns in one file: **lane A** owns the
+credential and consent gate, **lane B** owns the repository default and moving HTTP
+off the loop. Both touch `tools/handlers.py:4796-4992` — treat that range as a
+single-writer region and serialise the two lanes if the phase is executed
+concurrently. Root phase: it shares the consent *principle* with TRUST but none of
+its data contracts, so forcing a dependency would serialise the roadmap for nothing.
+
+**Non-goals**
+Redesigning the feedback feature; the wider redaction rework (that is S-12/#234).
+
+**Key files**
+- `src/pmcp/tools/handlers.py`
+- `tests/test_feedback_egress.py` (new)
+
+**Depends on**
+- (none)
+
+**Produces**
+- IF-0-EGRESS-1
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `no_spec_delta`
+- target surfaces: `src/pmcp/tools/handlers.py`
+- evidence paths: `tests/test_feedback_egress.py`, `SECURITY.md`, `CHANGELOG.md`
+- redaction posture: `metadata_only`
+- missing or malformed evidence routes to `blocker_class=contract_bug` (non-human).
+
+### Phase 5 — Document and prove the model (SEAL)
+
+**Objective**
+State the trust model in SECURITY.md exactly as implemented, and prove the four
+boundaries hold together against an adversarial end-to-end suite.
+
+**Exit criteria**
+- [ ] EC-SEAL-1 — SECURITY.md describes the implemented model with no claim the tests do not prove; each claim cites the test that proves it.
+- [ ] EC-SEAL-2 — an adversarial suite drives the four review reproductions end to end and each fails closed, run against the real handlers rather than mocks.
+- [ ] EC-SEAL-5 — the **composition** cases fail closed too, not only the four original reproductions: an unapproved overlay that adds a server (EC-CONSENT-6), and an approval record shipped inside the checkout (EC-TRUST-5). Both are seams between phases that each pass their own criteria, which is exactly what a per-phase suite cannot catch.
+- [ ] EC-SEAL-3 — every refusal path prints the exact `pmcp` command that would grant the action, asserted for each gate.
+- [ ] EC-SEAL-4 — a fresh operator with no trust store and no project files sees unchanged behaviour for manifest-backed servers.
+
+**Scope notes**
+Decompose into 2 lanes with disjoint files: **lane A** owns SECURITY.md and the
+CHANGELOG narrative, **lane B** owns the adversarial end-to-end suite. Lane B is the
+one that can fail late, so start it as soon as PKGID and CONSENT publish their gates
+rather than waiting for this phase to open.
+
+**Non-goals**
+New gates. This phase proves and documents; it does not add behaviour.
+
+**Key files**
+- `SECURITY.md`
+- `CHANGELOG.md`
+- `tests/test_trust_boundaries_e2e.py` (new)
+
+**Depends on**
+- CONSENT
+- PKGID
+- EGRESS
+
+**Produces**
+- IF-0-SEAL-1
+
+**Spec closeout policy**
+- schema: `spec_delta_closeout.v1`
+- decision: `canonical_spec_update`
+- target surfaces: `SECURITY.md`
+- evidence paths: `tests/test_trust_boundaries_e2e.py`, `CHANGELOG.md`
+- redaction posture: `metadata_only`
+- missing or malformed evidence routes to `blocker_class=contract_bug` (non-human).
+
+## Top Interface-Freeze Gates
+
+- IF-0-TRUST-1 — the provenance/approval record `(absolute_path, content_sha256, scope, decision, recorded_at)`; `is_approved(path, content: bytes) -> bool` (**hashes the bytes the caller is about to apply**, closing the check-then-use window), `record(path, content, scope, decision)`, `revoke(path)`. The freeze also fixes **store residency and write authority**: user-scoped, outside any repository, never agent-writable. Frozen before CONSENT and PKGID start — a downstream lane that has to guess residency cannot start.
+- IF-0-TRUST-2 — the package identity tuple `(registry, name, resolved_version, integrity)` and the resolver that produces it without executing the package.
+- IF-0-CONSENT-1 — the project-source gate decision surface: given a candidate source path and scope, the single call every loader uses to decide whether to apply it.
+- IF-0-PKGID-1 — the provisioning gate: given a server config and a resolved package identity, the single call `provision` uses to decide whether an install may spawn.
+- IF-0-EGRESS-1 — the outbound-action gate: the credential and consent predicate `submit_feedback` consults before any network call, and the preview payload shape returned when it refuses.
+- IF-0-SEAL-1 — the documented trust model in SECURITY.md, each claim bound to a proving test.
+
+## Phase Dependency DAG
+
+```
+  TRUST ─┬─> CONSENT ─┐
+         │            ├─> SEAL
+         └─> PKGID ───┤
+                      │
+  EGRESS ─────────────┘   (root; parallel with TRUST from day 1)
+```
+
+- `CONSENT` and `PKGID` both depend only on `TRUST` and can be **planned** concurrently, but they are **not file-disjoint**: both write `src/pmcp/policy/policy.py` (CONSENT lane C, PKGID lane B). Execute those two lanes serially against that file, or land one phase's policy lane before opening the other's. **WAS WRONG (rev 1):** this line claimed they "share no files", contradicting both phases' own Key files.
+- `EGRESS` shares no ancestor with `TRUST` — it can start immediately, in parallel with everything.
+- Critical path: `TRUST → PKGID → SEAL` (PKGID is the largest phase).
+
+## Execution Notes
+
+- Plan in DAG order: `/claude-plan-phase TRUST` first. Once TRUST merges, run
+  `/claude-plan-phase CONSENT` and `/claude-plan-phase PKGID` **concurrently**.
+  `/claude-plan-phase EGRESS` can be planned at any time, including now.
+- Execute with `/claude-execute-phase <alias>` per phase. `CONSENT` and `PKGID` are
+  parallel-safe; `EGRESS` is parallel with all of them.
+- `SEAL` opens only after `CONSENT`, `PKGID` and `EGRESS` have merged, but its lane B
+  (adversarial suite) should be written against the gates as they land.
+- Single-writer hazards to serialise: `src/pmcp/tools/handlers.py` is written by
+  PKGID lane A and both EGRESS lanes; `src/pmcp/policy/policy.py` by CONSENT lane C
+  and PKGID lane B. Do not run those lanes against the same file concurrently.
+- Every phase ships a CHANGELOG entry; `SECURITY.md` is written once, in SEAL, to
+  avoid four partial descriptions of one model.
+
+## Verification
+
+```bash
+# Each phase's own suite
+uv run pytest -q tests/test_trust_store.py
+uv run pytest -q tests/test_project_source_consent.py
+uv run pytest -q tests/test_package_identity_gate.py
+uv run pytest -q tests/test_feedback_egress.py
+
+# The roadmap's end-to-end proof: the four review reproductions must fail closed
+uv run pytest -q tests/test_trust_boundaries_e2e.py
+
+# No regression for an operator with no trust store and no project files
+uv run pytest -q tests/                 # compare counts to the pre-roadmap baseline
+uv run ruff check src/ tests/ scripts/ && uv run ruff format --check src/ tests/ scripts/
+uv run mypy src/
+uv run python scripts/check_workflows.py --base-ref origin/main
+```
+
+Host note: `/tmp/package.json` makes ~107 npm-identity tests fail on some hosts
+(`tests/conftest.py`); compare the same command from the same directory before and
+after, never against a clean-machine expectation.


### PR DESCRIPTION
Planning artifacts only — **no `src/` changes**. See Consiliency/pmcp#230.

## What this is

Two documents that turn the four trust-boundary findings from the 2026-09-01 codebase review (`plans/codebase-review-2026-09-01.md`) into executable work:

- **`specs/phase-plans-v13.md`** — a 5-phase roadmap covering **S-01** (agent-chosen npm packages executed; policy binds the name, not the package), **S-03** (repository-supplied config trusted with no approval), **S-11** (project policy silently shadows the operator's), and **S-04** (`submit_feedback` posts under the operator's ambient `GITHUB_TOKEN`). Passes `phase-loop validate-roadmap` (5 phases).
- **`plans/phase-plan-v13-TRUST.md`** — the phase plan for TRUST, the freeze phase. 4 lanes, frontmatter `roadmap_sha256` verified against the roadmap.

Both were produced with `claude-phase-roadmap-builder` / `claude-plan-phase` and follow this repo's existing convention (`specs/phase-plans-v1..v12.md`, `plans/phase-plan-v11-*.md`).

## Shape

```
  TRUST ─┬─> CONSENT ─┐
         │            ├─> SEAL
         └─> PKGID ───┤
  EGRESS ─────────────┘   (second root; parallel from day 1)
```

TRUST freezes two contracts — a source-provenance/approval record and a package-identity tuple — and **wires no caller**, which is why it is small. CONSENT and PKGID then depend only on TRUST and can be planned concurrently. EGRESS is a second root: it shares the consent *principle* but none of the data contracts, so making it depend on TRUST would serialise the roadmap for nothing.

## Both artifacts were boarded, and both changed as a result

**Roadmap → rev 2.** The load-bearing findings:

- the DAG claimed CONSENT and PKGID "share no files" while both listed `src/pmcp/policy/policy.py` — a self-contradiction two seats found independently, and acting on it would have run two lanes concurrently against the same file;
- an unapproved project overlay that **adds** a server (rather than replacing one) slipped the seam between CONSENT and PKGID, executing an unapproved package through the gap between two phases that each looked complete;
- `IF-0-TRUST-1` froze the record shape but not **where the store lives or who may write it** — a checkout-writable store lets a repository ship its own approval, which makes "absence is never assent" decorative.

Plus: no CLI verb to *approve* (while downstream refusals must name one), no criterion gating an unapproved project *policy file*, the Assumption-5 migration owned by no phase, and `IF-0-EGRESS-1` produced but missing from the Top gates list.

**TRUST plan → rev 2.** The freeze left four things a downstream lane would have guessed (decision vocabulary, record cardinality, fail-closed store I/O, write authority); the acceptance criteria used `-k` expressions guessing at test names that do not exist yet; and the stale-base guidance still carried the skill template's unfilled placeholder.

## Two things a reviewer should know

1. **The TRUST plan received no automated review.** `validate_plan_dispatch_hints` is not importable in this checkout, this repo has no `scripts/validate_plan_doc.py`, and the advisor step was unavailable. The lane checklist was walked by hand and the board round above is the only review it got. This is recorded in the plan's own Execution Notes rather than left implicit, and `## Dispatch Hints` was omitted rather than authored unvalidated.
2. **On both boards, a majority of seats blocked on "no implementation evidence / unchecked exit criteria"** — which is what a planning artifact is. Their structural findings were folded in; the evidence objection was not, and the reasoning is recorded in the roadmap's revision note. Filed upstream as Consiliency/agent-harness#802.

## Verification

- `phase-loop validate-roadmap specs/phase-plans-v13.md` → `OK — 5 phase(s)`
- plan frontmatter `roadmap_sha256` recomputed against the roadmap after both revisions → MATCH
- lane ownership disjoint (`trust_store.py` / `package_identity.py` / `cli.py` / docs), DAG acyclic, every `impl` preceded by a `test`, every acceptance item names a proving command
- no `src/` changes: `git diff --name-only origin/main..HEAD -- src/` is empty

## Next

`/claude-plan-phase CONSENT` and `/claude-plan-phase PKGID` can be planned concurrently once this lands; `EGRESS` can be planned at any time. Execution of TRUST is `/claude-execute-phase TRUST`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018NR2LKqZgn7CXVH2816gaa

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791426456&installation_model_id=427051&pr_number=238&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F238&signature=e404c20aa106bc72624372ed584fcaac4bb43c57202debdbb0291fa1badb9a18"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->