### PR TITLE
feat(trust): TRUST phase — content-keyed trust store, package identity, pmcp trust verbs (see #230)

### DIFF
--- a/.claude/docs-catalog.json
+++ b/.claude/docs-catalog.json
@@ -1,10 +1,15 @@
 {
   "version": 1,
-  "last_updated": "2026-08-24T12:16:05+00:00",
+  "last_updated": "2026-09-08T15:48:24+00:00",
   "files": {
-    ".claude/plans/ticklish-inventing-stearns.md": {
-      "purpose": "markdown document",
-      "touched_by_phases": []
+    "README.md": {
+      "purpose": "root project README",
+      "touched_by_phases": [
+        "P5",
+        "P2",
+        "P3B",
+        "UPDPATH"
+      ]
     },
     "CHANGELOG.md": {
       "purpose": "release changelog",
@@ -13,7 +18,8 @@
         "P5",
         "P2",
         "P3B",
-        "UPDPATH"
+        "UPDPATH",
+        "TRUST"
       ]
     },
     "CONTRIBUTING.md": {
@@ -21,15 +27,6 @@
       "touched_by_phases": [
         "P1",
         "P5"
-      ]
-    },
-    "README.md": {
-      "purpose": "root project README",
-      "touched_by_phases": [
-        "P5",
-        "P2",
-        "P3B",
-        "UPDPATH"
       ]
     },
     "SECURITY.md": {
@@ -46,6 +43,82 @@
         "P3B"
       ]
     },
+    ".claude/plans/ticklish-inventing-stearns.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
+    "specs/README.md": {
+      "purpose": "root project README",
+      "touched_by_phases": []
+    },
+    "specs/active/pmcp-gateway-orchestration-plan.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v1.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v10.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v11.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": [
+        "P1",
+        "P2",
+        "P3B"
+      ]
+    },
+    "specs/phase-plans-v12.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": [
+        "UPDPATH"
+      ]
+    },
+    "specs/phase-plans-v13.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": [
+        "TRUST"
+      ]
+    },
+    "specs/phase-plans-v2.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v3.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v4.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v5.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v6.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v7.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v8.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/phase-plans-v9.md": {
+      "purpose": "multi-phase roadmap spec",
+      "touched_by_phases": []
+    },
+    "specs/tenant-code-mode-host-contract.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
     "plans/HANDOFF-agent-board-mcp-registration.md": {
       "purpose": "markdown document",
       "touched_by_phases": []
@@ -55,6 +128,10 @@
       "touched_by_phases": []
     },
     "plans/codebase-review-2026-06-15.md": {
+      "purpose": "markdown document",
+      "touched_by_phases": []
+    },
+    "plans/codebase-review-2026-09-01.md": {
       "purpose": "markdown document",
       "touched_by_phases": []
     },
@@ -140,6 +217,20 @@
       "purpose": "per-phase lane plan",
       "touched_by_phases": [
         "UPDPATH"
+      ]
+    },
+    "plans/phase-plan-v13-CONSENT.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v13-PKGID.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": []
+    },
+    "plans/phase-plan-v13-TRUST.md": {
+      "purpose": "per-phase lane plan",
+      "touched_by_phases": [
+        "TRUST"
       ]
     },
     "plans/phase-plan-v2-lifecycle.md": {
@@ -303,72 +394,6 @@
       "touched_by_phases": []
     },
     "plans/v7-issue-tracker.md": {
-      "purpose": "markdown document",
-      "touched_by_phases": []
-    },
-    "specs/README.md": {
-      "purpose": "root project README",
-      "touched_by_phases": []
-    },
-    "specs/active/pmcp-gateway-orchestration-plan.md": {
-      "purpose": "markdown document",
-      "touched_by_phases": []
-    },
-    "specs/phase-plans-v1.md": {
-      "purpose": "multi-phase roadmap spec",
-      "touched_by_phases": []
-    },
-    "specs/phase-plans-v10.md": {
-      "purpose": "multi-phase roadmap spec",
-      "touched_by_phases": []
-    },
-    "specs/phase-plans-v11.md": {
-      "purpose": "multi-phase roadmap spec",
-      "touched_by_phases": [
-        "P1",
-        "P2",
-        "P3B"
-      ]
-    },
-    "specs/phase-plans-v12.md": {
-      "purpose": "multi-phase roadmap spec",
-      "touched_by_phases": [
-        "UPDPATH"
-      ]
-    },
-    "specs/phase-plans-v2.md": {
-      "purpose": "multi-phase roadmap spec",
-      "touched_by_phases": []
-    },
-    "specs/phase-plans-v3.md": {
-      "purpose": "multi-phase roadmap spec",
-      "touched_by_phases": []
-    },
-    "specs/phase-plans-v4.md": {
-      "purpose": "multi-phase roadmap spec",
-      "touched_by_phases": []
-    },
-    "specs/phase-plans-v5.md": {
-      "purpose": "multi-phase roadmap spec",
-      "touched_by_phases": []
-    },
-    "specs/phase-plans-v6.md": {
-      "purpose": "multi-phase roadmap spec",
-      "touched_by_phases": []
-    },
-    "specs/phase-plans-v7.md": {
-      "purpose": "multi-phase roadmap spec",
-      "touched_by_phases": []
-    },
-    "specs/phase-plans-v8.md": {
-      "purpose": "multi-phase roadmap spec",
-      "touched_by_phases": []
-    },
-    "specs/phase-plans-v9.md": {
-      "purpose": "multi-phase roadmap spec",
-      "touched_by_phases": []
-    },
-    "specs/tenant-code-mode-host-contract.md": {
       "purpose": "markdown document",
       "touched_by_phases": []
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`pmcp trust approve|list|revoke`, and a user-scoped trust store at
+  `~/.config/pmcp/trust.json`.** The store records one decision per absolute
+  path — the file's SHA-256, the scope, the decision and when it was taken —
+  and answers one question: are *these bytes* approved to be applied as *this
+  path*? `is_approved(path, content)` hashes the content the caller is about to
+  use and never reads the path, so a file swapped between the check and the use
+  is not covered by the earlier approval; editing an approved file by one byte
+  makes it unapproved with no further action. `approve` records the file's
+  current bytes and replaces any earlier decision for that path (there is no
+  history); `list` prints decision, digest, timestamp and path; `revoke` drops
+  the record, returning the path to *absent*, and exits non-zero if there was
+  nothing to drop.
+  **Nothing consults the store yet, and this release changes no existing
+  behaviour.** These verbs and the record shape are the contract the
+  project-consent and package-identity work is written against, published ahead
+  of the code that will read them so those changes can be built in parallel; a
+  gateway that never runs `pmcp trust` behaves exactly as it did before, and
+  approving a file today gates nothing today.
+  Two properties are worth knowing before you rely on it. The store must live
+  **outside** the checkout it judges — a store path that resolves inside the
+  current repository, directly or through a symlink, is refused rather than
+  read, because a repository that ships its own approval record must not be
+  believed. And every read failure is a refusal: a missing, unreadable or
+  corrupt store makes `is_approved` answer `False` rather than raise, so a
+  broken file can never be mistaken for permission. The operator-facing verbs
+  do the opposite and fail loudly, because a silent failure there would hide
+  the broken store. The store file is created mode `0o600`.
+  Also added: `resolve_package_identity()`, which resolves an npm spec to
+  `(registry, name, resolved_version, integrity)` from the registry's metadata
+  document alone — no install, no `npx`, no subprocess — and returns nothing at
+  all for a range, an unknown dist-tag or any spec it cannot pin to one
+  concrete published version. It has no caller in this release either. See
+  [#230](https://github.com/Consiliency/pmcp/issues/230).
+
 ### Security
 - **The operator's project `.env` no longer reaches the servers PMCP spawns.**
   `pmcp`'s entry point loads `<project>/.env` into its own environment at

--- a/plans/phase-plan-v13-CONSENT.md
+++ b/plans/phase-plan-v13-CONSENT.md
@@ -2,7 +2,7 @@
 phase_loop_plan_version: 1
 phase: CONSENT
 roadmap: specs/phase-plans-v13.md
-roadmap_sha256: 084b23212b9df39888f3772476dc7895bc99ff3d837d003a4c60cde4f2da2d14
+roadmap_sha256: 9b77ee0a3e9c1ff6d71f65ef6c36ccdc2714b506b4f62f74b746da5299891aa9
 ---
 
 # PHASE-2-CONSENT: Project-scoped configuration requires consent

--- a/plans/phase-plan-v13-PKGID.md
+++ b/plans/phase-plan-v13-PKGID.md
@@ -2,7 +2,7 @@
 phase_loop_plan_version: 1
 phase: PKGID
 roadmap: specs/phase-plans-v13.md
-roadmap_sha256: 084b23212b9df39888f3772476dc7895bc99ff3d837d003a4c60cde4f2da2d14
+roadmap_sha256: 9b77ee0a3e9c1ff6d71f65ef6c36ccdc2714b506b4f62f74b746da5299891aa9
 ---
 
 # PHASE-3-PKGID: Provisioning binds to package identity
@@ -155,12 +155,22 @@ SL-4 — Documentation & spec reconciliation
 - **Owned files**: `src/pmcp/provision_gate.py`, `src/pmcp/package_approvals.py`, `src/pmcp/tools/handlers.py`, `src/pmcp/cli.py`, `tests/test_package_identity_gate.py`, `tests/test_package_approvals.py`
 - **Interfaces provided**: `ProvisionDecision`, `ProvisionSource`, `evaluate_provision`, `PackageApproval`, `approve_package`, `is_package_approved`, `revoke_package`, `list_package_approvals`, the `pmcp trust approve-package|list-packages|revoke-package` verbs
 - **Interfaces consumed**: `PackageIdentity`, `resolve_package_identity` (TRUST SL-2); `trust_store_path` (TRUST SL-1); `evaluate_package_policy`, `PackagePolicy` (SL-2); `parse_package_spec`, `is_valid_package_version` (SL-2, `validation.py`)
+  - **`resolve_package_identity` is SYNCHRONOUS and does blocking network I/O**
+    (`src/pmcp/manifest/package_identity.py:176`; `_OPENER.open(..., timeout=_FETCH_TIMEOUT)`
+    at `:120` with `_FETCH_TIMEOUT = 10.0` at `:58`), while every existing registry
+    lookup in `version_checker.py:1375-1530` is async/aiohttp. This lane calls it from
+    inside `async def register_discovered_server` (`handlers.py:5513`), so calling it
+    directly **blocks the event loop for up to 10 s** — the whole gateway, not just the
+    request. TRUST's signature is frozen and this lane does not own that file, so the
+    fix is caller-side: `anyio.to_thread.run_sync` (or `run_in_executor`), plus a
+    handler-level timeout — the 10 s socket timeout is not a request bound. Found while
+    executing TRUST SL-2; see the roadmap's Post-execution amendments for TRUST.
 - **Parallel-safe**: yes
 - **Tasks**:
 
 | Task ID | Type | Depends on | Files in scope | Tests owned | Test command |
 |---|---|---|---|---|---|
-| SL-1.1 | test | — | `tests/test_package_identity_gate.py`, `tests/test_package_approvals.py` | **exactly these names**: `test_a_configured_server_with_unpinned_argv_is_refused`,, because the acceptance criteria address them individually: `test_the_review_reproduction_does_not_spawn_npx_for_an_arbitrary_package`, `test_the_refusal_names_the_package_and_the_approval_command`, `test_discovered_provisioning_is_denied_without_opt_in`, `test_a_manifest_backed_server_provisions_unchanged`, `test_a_resolvable_registration_records_the_version_and_pins_the_install_argv`, `test_an_unresolvable_registration_is_refused_at_registration`, `test_a_resolved_version_that_fails_validation_is_refused`, `test_an_approved_package_provisions_after_the_refusal`, `test_a_store_read_failure_denies_rather_than_raises`, `test_source_is_taken_from_the_lookup_path_not_from_server_config`, `test_policy_denylist_blocks_an_approved_package`, `test_policy_package_allowlist_permits_provision_without_a_recorded_approval`, `test_package_denylist_beats_a_recorded_approval` | `uv run pytest -q tests/test_package_identity_gate.py tests/test_package_approvals.py` |
+| SL-1.1 | test | — | `tests/test_package_identity_gate.py`, `tests/test_package_approvals.py` | **exactly these names**, because the acceptance criteria address them individually: `test_a_configured_server_with_unpinned_argv_is_refused`, `test_the_review_reproduction_does_not_spawn_npx_for_an_arbitrary_package`, `test_the_refusal_names_the_package_and_the_approval_command`, `test_discovered_provisioning_is_denied_without_opt_in`, `test_a_manifest_backed_server_provisions_unchanged`, `test_a_resolvable_registration_records_the_version_and_pins_the_install_argv`, `test_an_unresolvable_registration_is_refused_at_registration`, `test_a_resolved_version_that_fails_validation_is_refused`, `test_an_approved_package_provisions_after_the_refusal`, `test_a_store_read_failure_denies_rather_than_raises`, `test_source_is_taken_from_the_lookup_path_not_from_server_config`, `test_policy_denylist_blocks_an_approved_package`, `test_policy_package_allowlist_permits_provision_without_a_recorded_approval`, `test_package_denylist_beats_a_recorded_approval` | `uv run pytest -q tests/test_package_identity_gate.py tests/test_package_approvals.py` |
 | SL-1.2 | impl | SL-1.1 | `src/pmcp/provision_gate.py`, `src/pmcp/package_approvals.py` | — | — |
 | SL-1.3 | impl | SL-1.1 | `src/pmcp/tools/handlers.py` | — | — |
 | SL-1.4 | impl | SL-1.1 | `src/pmcp/cli.py` | — | — |

--- a/plans/phase-plan-v13-TRUST.md
+++ b/plans/phase-plan-v13-TRUST.md
@@ -2,7 +2,7 @@
 phase_loop_plan_version: 1
 phase: TRUST
 roadmap: specs/phase-plans-v13.md
-roadmap_sha256: 084b23212b9df39888f3772476dc7895bc99ff3d837d003a4c60cde4f2da2d14
+roadmap_sha256: 9b77ee0a3e9c1ff6d71f65ef6c36ccdc2714b506b4f62f74b746da5299891aa9
 ---
 
 # PHASE-1-TRUST: Trust primitives

--- a/scripts/check_plan_consistency.py
+++ b/scripts/check_plan_consistency.py
@@ -12,14 +12,44 @@ tells an executing lane which tests to write. The result is a plan whose own pha
 command fails collection, or worse, a lane contracted to write a test named after the
 unsafe rule that was replaced. Careful reading did not catch it three times; this does.
 
+It also verifies each plan's `roadmap_sha256:` frontmatter pin against the actual
+digest of the roadmap it names. That pin is the plan's trust contract; a stale one
+means the plan was written against a roadmap that no longer exists. This check was
+added after the registry cross-check above shipped WITHOUT it and duly reported
+"0 blocking" while all three pins were stale — the exact bug it was meant to prevent.
+
 Usage:
     python3 scripts/check_plan_consistency.py plans/phase-plan-v13-*.md
-Exits non-zero if any EC runs a node id no lane is contracted to write.
+Exits non-zero if any EC runs a node id no lane is contracted to write, or if any
+roadmap_sha256 pin is stale.
 """
 
+import hashlib
 import re
 import sys
 import pathlib
+
+
+def check_pin(path):
+    """Verify the plan's roadmap_sha256 against the roadmap it names."""
+    p = pathlib.Path(path)
+    s = p.read_text()
+    m = re.search(r"^roadmap:\s*(\S+)$", s, re.M)
+    d = re.search(r"^roadmap_sha256:\s*(\w+)$", s, re.M)
+    if not m or not d:
+        return 0  # not a pinned phase plan
+    roadmap = p.parent.parent / m.group(1)
+    if not roadmap.exists():
+        print(f"  [BLOCKING] {p.name} pins roadmap {m.group(1)} — file not found")
+        return 1
+    actual = hashlib.sha256(roadmap.read_bytes()).hexdigest()
+    if actual != d.group(1):
+        print(
+            f"  [BLOCKING] {p.name} roadmap_sha256 is STALE "
+            f"(pinned {d.group(1)[:12]}…, actual {actual[:12]}…)"
+        )
+        return 1
+    return 0
 
 
 def check(path):
@@ -53,7 +83,7 @@ def check(path):
         print(f"  [warn]     {lane_of[n]} writes {n} — no EC proves it")
     if not bad and lane >= ec:
         print("  consistent")
-    return bad
+    return bad + check_pin(path)
 
 
 total = sum(check(p) for p in sys.argv[1:])

--- a/specs/phase-plans-v13.md
+++ b/specs/phase-plans-v13.md
@@ -149,6 +149,75 @@ Wiring any consumer; changing provisioning or policy behaviour.
 - redaction posture: `metadata_only`
 - missing or malformed evidence routes to `blocker_class=contract_bug` (non-human).
 
+### Post-execution amendments — TRUST (2026-09-08)
+
+Recorded by SL-docs after SL-1, SL-2 and SL-3 landed and were merged. Both freeze
+gates shipped with exactly the signatures they declared, and no exit criterion had to
+be weakened — nothing below reopens a contract. What each gate got wrong is a detail
+it left implicit, and in both cases the phase that has to consume the gate is the one
+that pays. The third item is a defect in `plans/phase-plan-v13-TRUST.md`, not in this
+roadmap, recorded here because it is the file a later planner reads.
+
+1. **IF-0-TRUST-1 froze a `"denied"` decision that no shipped command can write.**
+   The gate fixes `decision` as the closed vocabulary `{"approved", "denied"}` and
+   requires `is_approved` to distinguish a `"denied"` record from an absent one, and
+   `src/pmcp/trust_store.py` implements precisely that: `DECISIONS` rejects any other
+   value at `record` time rather than storing it, and `is_approved` returns `False`
+   for a `"denied"` record even when the digest matches. But EC-TRUST-4 froze the CLI
+   as exactly `approve` / `list` / `revoke`, and `run_trust` (`src/pmcp/cli.py`)
+   dispatches those three and no more — so no operator surface constructs
+   `decision="denied"`, and `revoke` *deletes* the record rather than denying it.
+   **This is not a security hole.** Absence already refuses, so the reachable
+   behaviour is a strict subset of the frozen behaviour; the gap is a reserved
+   vocabulary value with no writer, not a permissive default. It is recorded because
+   a downstream lane reading IF-0-TRUST-1 would reasonably plan a "the operator
+   denied this" path and find nothing to call. **CONSENT and PKGID must treat
+   `"denied"` as reserved, not as available.** Whichever phase first needs an
+   explicit deny owns adding the verb — with its own CHANGELOG entry — or SEAL
+   documents the value as reserved when it writes the trust-model section of
+   `SECURITY.md`. TRUST did neither on purpose: shipping a verb whose records no
+   caller reads would have broken this phase's "wire no caller" rule.
+
+2. **IF-0-TRUST-2 froze a synchronous signature over blocking network I/O. Read this
+   before PKGID SL-1 is executed.** The gate declares
+   `resolve_package_identity(spec: str) -> PackageIdentity | None`, and the shipped
+   code honours it: `src/pmcp/manifest/package_identity.py:120` calls
+   `_OPENER.open(request, timeout=_FETCH_TIMEOUT)` over `urllib`, with
+   `_FETCH_TIMEOUT = 10.0` (`:58`). Every other registry lookup in this codebase is a
+   coroutine — `get_npm_version`, `get_pypi_version`, `get_cargo_version` and
+   `get_docker_version` (`src/pmcp/manifest/version_checker.py:1375-1530`) are all
+   `async def` over `aiohttp.ClientSession` — so the house pattern a PKGID lane will
+   assume by analogy is the one this function does not follow. That matters because
+   PKGID SL-1 owns `src/pmcp/tools/handlers.py` and its EC-PKGID-5 decision resolves
+   and pins **at registration**, inside `async def register_discovered_server`
+   (`handlers.py:5513`). Calling `resolve_package_identity` directly from that
+   coroutine blocks the gateway's event loop for up to ten seconds per registration —
+   no other downstream call is served meanwhile, and a slow or unreachable registry
+   turns one agent's registration into a gateway-wide stall.
+   The signature stays frozen and PKGID must **not** change it: that file belongs to
+   TRUST and an async rewrite would edit a merged phase's contract. The fix is
+   caller-side and belongs in PKGID's plan — hand the call to a thread
+   (`asyncio.get_running_loop().run_in_executor(None, resolve_package_identity, spec)`
+   or `anyio.to_thread.run_sync`) and give the enclosing handler its own timeout
+   rather than treating the 10 s socket timeout as the bound, since a redirect chain
+   can spend that timeout more than once. `plans/phase-plan-v13-PKGID.md` does not
+   mention any of this; it was found only by reading TRUST's merged code, after that
+   plan was written.
+
+3. **The TRUST phase plan names frozen tests in one lane and behaviours in another,
+   and says nowhere that it is doing so.** In `plans/phase-plan-v13-TRUST.md`, SL-1.1's
+   "Tests owned" cell reads "**exactly these names**, because the acceptance criteria
+   address them individually" and lists eight `test_*` identifiers, which the
+   EC-TRUST-2/3/5/6 criteria then cite by name. SL-2.1's cell for the same column
+   reads "identity resolves offline from a fixture; an unresolvable spec returns
+   `None` rather than raising; no subprocess is spawned" — behaviour descriptions, not
+   names. The asymmetry is defensible in substance (EC-TRUST-1 proves itself by naming
+   the whole file, so there was no name to freeze) but it is stated nowhere, and a lane
+   brief written from the plan read the two cells as carrying the same instruction. A
+   phase plan that mixes frozen test names with behaviour descriptions must say which
+   kind each cell is, in the cell — the reader cannot infer it from the column header,
+   which is identical for both.
+
 ### Phase 2 — Project-scoped configuration requires consent (CONSENT)
 
 **Objective**
@@ -215,6 +284,13 @@ gate in `tools/handlers.py`, **lane B** owns policy package identifiers in
 in `manifest/installer.py`. Lane A is the single-writer risk — `handlers.py` is large
 and touched by other work; serialise any other writer against it. Parallel-safe with
 CONSENT: no shared file, and both depend only on TRUST.
+
+**Before executing lane A, read TRUST → Post-execution amendments item 2.**
+`resolve_package_identity` is synchronous and performs blocking network I/O with a
+10 s socket timeout; `register_discovered_server` is a coroutine, so calling it
+directly there stalls the event loop. The fix is caller-side (a thread executor) and
+belongs to this phase — `plans/phase-plan-v13-PKGID.md` was written before the
+finding and does not carry it.
 
 **Non-goals**
 Sandboxing what does run; auditing PMCP's own dependencies.

--- a/src/pmcp/cli.py
+++ b/src/pmcp/cli.py
@@ -19,6 +19,7 @@ from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
 from dotenv import load_dotenv
+from pmcp import trust_store
 from pmcp.auth import redact_auth_url, sanitize_auth_diagnostic
 from pmcp.cli_commands.doctor import collect_remote_header_diagnostics
 from pmcp.cli_commands.install import (
@@ -753,6 +754,47 @@ Environment overrides:
         "--json",
         action="store_true",
         help="Emit JSON output",
+    )
+
+    # Trust command
+    #
+    # The verb spelling is a contract, not a preference: refusal messages
+    # elsewhere print the runnable string `pmcp trust approve <absolute path>`,
+    # so an operator who copies one must land here (Consiliency/pmcp#230).
+    trust_parser = subparsers.add_parser(
+        "trust",
+        help="Approve, list, and revoke content PMCP is allowed to trust",
+        description="Manage the user-scoped trust store at ~/.config/pmcp/trust.json.",
+    )
+    trust_subparsers = trust_parser.add_subparsers(
+        dest="trust_command",
+        required=True,
+        help="Trust subcommands",
+    )
+
+    trust_approve_parser = trust_subparsers.add_parser(
+        "approve",
+        help="Approve a file's current content",
+    )
+    trust_approve_parser.add_argument(
+        "path",
+        type=Path,
+        help="File whose current content is approved",
+    )
+
+    trust_subparsers.add_parser(
+        "list",
+        help="List every recorded trust decision",
+    )
+
+    trust_revoke_parser = trust_subparsers.add_parser(
+        "revoke",
+        help="Drop the trust record for a path",
+    )
+    trust_revoke_parser.add_argument(
+        "path",
+        type=Path,
+        help="File whose trust record is dropped",
     )
 
     return parser.parse_args()
@@ -2442,6 +2484,76 @@ def run_capabilities(args: argparse.Namespace) -> None:
             print(capability["name"])
 
 
+#: Every `pmcp trust` record this CLI writes is user-scoped, because the store
+#: itself is: there is no project-scoped trust file to point a --scope flag at.
+_TRUST_SCOPE = "user"
+
+
+def _trust_fail(message: str) -> None:
+    """Report an operator-facing trust failure and exit non-zero."""
+    print(f"Error: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def _format_trust_record(rec: trust_store.TrustRecord) -> str:
+    """One record as a line naming its decision, digest, time, and path."""
+    return (
+        f"{rec.decision:<8}  {rec.content_sha256[:12]}  "
+        f"{rec.recorded_at.isoformat()}  {rec.absolute_path}"
+    )
+
+
+def _run_trust_approve(args: argparse.Namespace) -> None:
+    """Approve the file's current bytes, replacing any earlier decision."""
+    path = Path(args.path)
+    try:
+        content = path.read_bytes()
+    except OSError as exc:
+        _trust_fail(f"cannot read {path}: {exc}")
+        return
+
+    rec = trust_store.record(path, content, _TRUST_SCOPE, trust_store.APPROVED)
+    print(f"Approved {rec.absolute_path}")
+    print(f"  sha256 {rec.content_sha256}")
+
+
+def _run_trust_list(args: argparse.Namespace) -> None:
+    """Print every recorded decision, or say plainly that there are none."""
+    records = trust_store.list_records()
+    if not records:
+        print("No trust records.")
+        return
+    for rec in records:
+        print(_format_trust_record(rec))
+
+
+def _run_trust_revoke(args: argparse.Namespace) -> None:
+    """Drop the record for a path, reporting when there was nothing to drop."""
+    path = Path(args.path)
+    if not trust_store.revoke(path):
+        _trust_fail(f"no trust record for {Path(path).resolve()}")
+        return
+    print(f"Revoked {Path(path).resolve()}")
+
+
+def run_trust(args: argparse.Namespace) -> None:
+    """Dispatch `pmcp trust <verb>` over the user-scoped trust store."""
+    handlers = {
+        "approve": _run_trust_approve,
+        "list": _run_trust_list,
+        "revoke": _run_trust_revoke,
+    }
+    handler = handlers.get(args.trust_command)
+    if handler is None:
+        _trust_fail(f"Unknown trust subcommand: {args.trust_command}")
+        return
+
+    try:
+        handler(args)
+    except (trust_store.TrustStoreError, ValueError) as exc:
+        _trust_fail(str(exc))
+
+
 def _build_gateway_auth_client(args: argparse.Namespace) -> tuple[Any, Any]:
     from pmcp.client.manager import ClientManager
     from pmcp.policy.policy import PolicyManager
@@ -2655,6 +2767,8 @@ async def async_main(args: argparse.Namespace) -> None:
         run_guidance(args)  # Synchronous command
     elif args.command == "capabilities":
         run_capabilities(args)  # Synchronous command
+    elif args.command == "trust":
+        run_trust(args)  # Synchronous command
     elif args.command == "doctor":
         await run_doctor(args)
     elif args.command == "upgrade":

--- a/src/pmcp/manifest/package_identity.py
+++ b/src/pmcp/manifest/package_identity.py
@@ -157,14 +157,24 @@ def _resolve_version(requested: str, packument: dict[str, Any]) -> str | None:
     Three cases and no fourth: nothing requested resolves through
     ``dist-tags.latest``; a dist-tag resolves through ``dist-tags``; an exact
     SemVer 2.0.0 version is taken literally. A range names a set, and a set is
-    not something an approval can be about.
+    not something an approval can be about. Every path -- including a dist-tag's
+    target, which the registry controls -- must end at a concrete SemVer, or
+    this returns ``None``.
     """
     if requested == "" or _DIST_TAG_RE.match(requested):
         dist_tags = packument.get("dist-tags")
         if not isinstance(dist_tags, dict):
             return None
         version = dist_tags.get(requested or "latest")
-        return version if isinstance(version, str) else None
+        if not isinstance(version, str):
+            return None
+        # A dist-tag's TARGET is registry-supplied data and gets the same
+        # concrete-version check as a user-supplied one. Without this a
+        # packument whose `latest` points at `^1.0.0` yields an identity whose
+        # `resolved_version` is a range -- and a consumer pinning argv to
+        # `pkg@^1.0.0` re-resolves at every spawn, which is the exact
+        # check-then-use hole this primitive exists to close.
+        return version if semver.Version.is_valid(version) else None
     # `semver`, not a hand-rolled parse: every hand-written version comparison
     # in this package has been wrong at least once (see the dependency's note
     # in pyproject.toml).

--- a/src/pmcp/manifest/package_identity.py
+++ b/src/pmcp/manifest/package_identity.py
@@ -1,0 +1,229 @@
+"""Name the package an npm spec would fetch, at a RESOLVED version, or refuse.
+
+Consiliency/pmcp#230 (IF-0-TRUST-2). Policy today checks the agent-chosen
+*server name* while ``provision`` runs the agent-chosen *package* with
+``npx -y``, so an allowlist entry for ``internal-approved-tool`` happily
+executes ``totally-arbitrary-evil-package`` (2026-09-01 review, finding S-01).
+An approval is only worth something if it names the thing that actually runs.
+This module supplies that name; TRUST wires no caller, by design.
+
+**Why a resolved version is the whole point.** ``npx -y pkg`` re-resolves
+``latest`` at every spawn, so approving the spec ``pkg`` approves code that has
+not been published yet -- the approval is a label, not an identity. A spec this
+module cannot pin to one concrete version *in the registry's own document* is
+therefore not an identity at all, and returns ``None``.
+
+**Relationship to the #195 resolver.** ``npm_resolver`` answers a different
+question -- "which package does this argv name" -- by driving npm's own parser
+in a node child. This module consumes that answer's TYPE (a package spec
+string) and copies its conventions (a frozen result dataclass, refusal rather
+than a confident guess, a module-level seam tests patch). It deliberately does
+**not** call it: identity here must be obtainable with no subprocess at all,
+because every process this code could spawn is one more thing to trust, and
+because ``npx``'s own resolution runs the package it is resolving.
+
+**Everything fails closed.** A refusal is ``None``, never an exception: a caller
+that gates provisioning on identity would otherwise need a ``try`` around every
+call, and one bare ``except Exception`` there reads as consent.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import HTTPError
+from urllib.parse import quote
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+import semver
+
+from pmcp.validation import is_valid_package_name
+
+logger = logging.getLogger(__name__)
+
+# The ecosystem, not the endpoint. `version_checker` already discriminates
+# `npm:` / `pypi:` / `cargo:` in its cache keys, and this field is the slot
+# those adapters would fill; keying it on a URL instead would make the same
+# package resolved through a mirror unequal to itself.
+NPM_REGISTRY = "npm"
+NPM_REGISTRY_URL = "https://registry.npmjs.org"
+
+# npm's abbreviated packument: same `dist-tags`, `versions` and `dist.integrity`
+# this module reads, without the README and the full metadata history. The full
+# document for a popular package runs to tens of megabytes.
+_PACKUMENT_ACCEPT = "application/vnd.npm.install-v1+json"
+_FETCH_TIMEOUT = 10.0
+# Generous on purpose. A cap sized for the auth-metadata fetches (256 KiB) would
+# truncate the abbreviated packument of any package with a long release history
+# -- and the tests are offline, so that would ship green and fail only in
+# production, on exactly the popular packages this is meant to gate.
+_MAX_PACKUMENT_BYTES = 8 * 1024 * 1024
+
+# A dist-tag is anything npm did not parse as a version. Restricting it to a
+# letter-led identifier keeps range syntax (`^1.0.0`, `>=1.0 <2.0`, `1.x`, `*`)
+# out of the tag lookup, where a stray hit would pin something the caller never
+# asked for.
+_DIST_TAG_RE = re.compile(r"^[A-Za-z][A-Za-z0-9._-]*$")
+
+
+class _NoRedirectHandler(HTTPRedirectHandler):
+    """Refuse HTTP redirects so the registry cannot 3xx to another host."""
+
+    def redirect_request(
+        self,
+        req: Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> Request | None:
+        raise HTTPError(newurl, code, "Redirects are not allowed.", headers, fp)
+
+
+_OPENER = build_opener(_NoRedirectHandler)
+
+
+@dataclass(frozen=True)
+class PackageIdentity:
+    """What a spec resolves to. Frozen: an identity that can be edited after a
+    policy check is not an identity."""
+
+    registry: str
+    name: str
+    resolved_version: str
+    integrity: str | None
+
+
+def _packument_url(name: str) -> str:
+    """The registry document for *name*, as a single escaped path component.
+
+    ``safe=''`` is load-bearing: a scoped ``@scope/name`` must become
+    ``%40scope%2Fname`` rather than two path segments, so no package name can
+    steer the request to another registry path.
+    """
+    return f"{NPM_REGISTRY_URL}/{quote(name, safe='')}"
+
+
+def _fetch_packument(name: str) -> dict[str, Any] | None:
+    """The registry's document for *name*, or ``None``.
+
+    The seam the tests patch, so identity resolution is provable offline. *name*
+    is already validated by ``resolve_package_identity``; this function never
+    builds a URL from an unvalidated string.
+    """
+    request = Request(_packument_url(name), headers={"Accept": _PACKUMENT_ACCEPT})
+    try:
+        with _OPENER.open(request, timeout=_FETCH_TIMEOUT) as response:  # nosec B310
+            body = response.read(_MAX_PACKUMENT_BYTES)
+        data = json.loads(body.decode("utf-8"))
+    except Exception as exc:
+        logger.debug("npm packument fetch failed for %r: %s", name, exc)
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _split_spec(spec: str) -> tuple[str, str] | None:
+    """Split ``name[@requested]``, or ``None`` if the name is not a package name.
+
+    The leading ``@`` of a scope is not a separator, so the search starts at
+    index 1 for a scoped spec. A trailing bare ``@`` is refused rather than read
+    as "no version requested": treating ``pkg@`` as ``pkg@latest`` would mint an
+    identity for a version the caller never named.
+    """
+    if not spec:
+        return None
+    at = spec.find("@", 1) if spec.startswith("@") else spec.find("@")
+    if at == -1:
+        name, requested = spec, ""
+    else:
+        name, requested = spec[:at], spec[at + 1 :]
+        if not requested:
+            return None
+    if not is_valid_package_name(name):
+        # Rejects leading dashes, whitespace, path separators and the
+        # `npm:` / `file:` / `github:` spec forms whose name is not a registry
+        # name at all -- none of which this module can name honestly.
+        return None
+    return name, requested
+
+
+def _resolve_version(requested: str, packument: dict[str, Any]) -> str | None:
+    """The one concrete version *requested* names, or ``None``.
+
+    Three cases and no fourth: nothing requested resolves through
+    ``dist-tags.latest``; a dist-tag resolves through ``dist-tags``; an exact
+    SemVer 2.0.0 version is taken literally. A range names a set, and a set is
+    not something an approval can be about.
+    """
+    if requested == "" or _DIST_TAG_RE.match(requested):
+        dist_tags = packument.get("dist-tags")
+        if not isinstance(dist_tags, dict):
+            return None
+        version = dist_tags.get(requested or "latest")
+        return version if isinstance(version, str) else None
+    # `semver`, not a hand-rolled parse: every hand-written version comparison
+    # in this package has been wrong at least once (see the dependency's note
+    # in pyproject.toml).
+    if semver.Version.is_valid(requested):
+        return requested
+    return None
+
+
+def resolve_package_identity(spec: str) -> PackageIdentity | None:
+    """The identity *spec* resolves to right now, or ``None``.
+
+    Resolves from the registry's metadata document only -- it never installs,
+    spawns, or executes the package, so the answer is available *before* the
+    decision to run it is made.
+
+    ``None`` is returned for a name that is not a package name, a package the
+    registry does not describe, a version or dist-tag it does not carry, a range
+    (which pins nothing), a document that names a different package, and any I/O
+    or parse failure along the way.
+    """
+    split = _split_spec(spec)
+    if split is None:
+        return None
+    name, requested = split
+
+    try:
+        packument = _fetch_packument(name)
+    except Exception as exc:  # pragma: no cover - the fetch handles its own
+        logger.debug("npm packument lookup raised for %r: %s", name, exc)
+        return None
+    if not isinstance(packument, dict):
+        return None
+    if packument.get("name") != name:
+        # A mirror, a cache, or a redirect that answered with some other
+        # package's document must not be minted as this package's identity.
+        return None
+    versions = packument.get("versions")
+    if not isinstance(versions, dict):
+        return None
+
+    version = _resolve_version(requested, packument)
+    if version is None:
+        return None
+    entry = versions.get(version)
+    if not isinstance(entry, dict):
+        # A dist-tag pointing at a version the document does not describe. There
+        # is no `dist` to read an integrity from, so there is nothing to approve.
+        return None
+
+    dist = entry.get("dist")
+    integrity = dist.get("integrity") if isinstance(dist, dict) else None
+    if not isinstance(integrity, str) or not integrity:
+        # Absent, not fabricated: a registry entry may predate subresource
+        # integrity, and inventing a digest would be worse than reporting none.
+        integrity = None
+
+    return PackageIdentity(
+        registry=NPM_REGISTRY,
+        name=name,
+        resolved_version=version,
+        integrity=integrity,
+    )

--- a/src/pmcp/trust_store.py
+++ b/src/pmcp/trust_store.py
@@ -179,13 +179,7 @@ def _write_store(path: Path, records: list[TrustRecord]) -> None:
     }
 
     parent = path.parent
-    parent_created = not parent.exists()
-    parent.mkdir(parents=True, exist_ok=True)
-    if parent_created:
-        try:
-            os.chmod(parent, 0o700)
-        except OSError:
-            pass
+    _ensure_store_dir(parent)
 
     # Write a sibling temp file and rename it into place. `os.replace` is
     # atomic, so a reader never observes a half-written store and an
@@ -205,6 +199,26 @@ def _write_store(path: Path, records: list[TrustRecord]) -> None:
         raise
 
 
+def _ensure_store_dir(parent: Path) -> None:
+    """Create the store's directory, tightening it only if we created it.
+
+    Both ``_store_lock`` and ``_write_store`` need the directory to exist, and
+    whichever runs first is the one that created it. Deciding "did PMCP create
+    this?" independently in each is how a 0o700 became a 0o775: the lock's
+    ``mkdir`` ran first, so ``_write_store`` then saw an existing directory and
+    skipped the chmod, and a fresh install got the umask default instead. One
+    helper, one decision. As before, never tighten a directory the user already
+    had (mirrors ``env_store.write_env_file``).
+    """
+    if parent.exists():
+        return
+    parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.chmod(parent, 0o700)
+    except OSError:
+        pass
+
+
 @contextlib.contextmanager
 def _store_lock(path: Path) -> Iterator[None]:
     """Hold an exclusive lock for one read-modify-write of the store.
@@ -221,8 +235,7 @@ def _store_lock(path: Path) -> Iterator[None]:
     matches the store's read path -- callers that cannot get a guarantee still
     get correct single-process behaviour.
     """
-    parent = path.parent
-    parent.mkdir(parents=True, exist_ok=True)
+    _ensure_store_dir(path.parent)
     try:
         import fcntl
     except ImportError:  # pragma: no cover - non-POSIX

--- a/src/pmcp/trust_store.py
+++ b/src/pmcp/trust_store.py
@@ -32,9 +32,12 @@ absolute path: re-approving replaces, it does not append a history.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import os
+import tempfile
+from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -184,11 +187,55 @@ def _write_store(path: Path, records: list[TrustRecord]) -> None:
         except OSError:
             pass
 
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    os.fchmod(fd, 0o600)
-    with os.fdopen(fd, "w", encoding="utf-8") as store_file:
-        json.dump(payload, store_file, indent=2)
-        store_file.write("\n")
+    # Write a sibling temp file and rename it into place. `os.replace` is
+    # atomic, so a reader never observes a half-written store and an
+    # interrupted write leaves the previous one intact rather than truncated.
+    fd, tmp_name = tempfile.mkstemp(dir=parent, prefix=".trust-", suffix=".tmp")
+    try:
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as store_file:
+            json.dump(payload, store_file, indent=2)
+            store_file.write("\n")
+            store_file.flush()
+            os.fsync(store_file.fileno())
+        os.replace(tmp_name, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp_name)
+        raise
+
+
+@contextlib.contextmanager
+def _store_lock(path: Path) -> Iterator[None]:
+    """Hold an exclusive lock for one read-modify-write of the store.
+
+    ``record`` and ``revoke`` both read every record, change one, and write the
+    whole set back. Without a lock two concurrent operations interleave into a
+    lost update: if ``record`` reads a snapshot containing an approval, a
+    ``revoke`` then removes it, and ``record`` writes its stale snapshot back,
+    **the revoked approval is silently restored**. An operator's decision to
+    withdraw trust must not be undone by a concurrent approve.
+
+    The lock is advisory and POSIX-only; where ``fcntl`` is unavailable this
+    degrades to no serialization rather than failing the operation, which
+    matches the store's read path -- callers that cannot get a guarantee still
+    get correct single-process behaviour.
+    """
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover - non-POSIX
+        yield
+        return
+    fd = os.open(str(path) + ".lock", os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        with contextlib.suppress(OSError):
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
 
 
 def is_approved(path: Path, content: bytes) -> bool:
@@ -242,11 +289,16 @@ def record(path: Path, content: bytes, scope: str, decision: str) -> TrustRecord
         recorded_at=datetime.now(timezone.utc),
     )
 
-    records = [
-        rec for rec in _read_store(store) if rec.absolute_path != entry.absolute_path
-    ]
-    records.append(entry)
-    _write_store(store, records)
+    # Read and write under one lock: a concurrent revoke between the read and
+    # the write would otherwise be silently undone by this stale snapshot.
+    with _store_lock(store):
+        records = [
+            rec
+            for rec in _read_store(store)
+            if rec.absolute_path != entry.absolute_path
+        ]
+        records.append(entry)
+        _write_store(store, records)
     return entry
 
 
@@ -258,14 +310,14 @@ def revoke(path: Path) -> bool:
     explicitly. Raises ``TrustStoreError`` if the store is unusable.
     """
     store = trust_store_path()
-    records = _read_store(store)
     target = Path(path).resolve()
 
-    kept = [rec for rec in records if rec.absolute_path != target]
-    if len(kept) == len(records):
-        return False
-
-    _write_store(store, kept)
+    with _store_lock(store):
+        records = _read_store(store)
+        kept = [rec for rec in records if rec.absolute_path != target]
+        if len(kept) == len(records):
+            return False
+        _write_store(store, kept)
     return True
 
 

--- a/src/pmcp/trust_store.py
+++ b/src/pmcp/trust_store.py
@@ -199,11 +199,24 @@ def _write_store(path: Path, records: list[TrustRecord]) -> None:
         # the pre-revoke store on disk and resurrect the approval the operator
         # just withdrew. That is the same invariant the lock protects against a
         # race, reached through power loss instead.
-        dir_fd = os.open(parent, os.O_RDONLY)
+        # Best effort, and deliberately so. Directory fsync is unsupported on
+        # some platforms and filesystems (macOS returns EINVAL, NFS and some
+        # overlay mounts ENOTSUP), and `os.open` on a directory fails outright
+        # on Windows. The replace has ALREADY succeeded by this point, so
+        # raising here would report a failed `record`/`revoke` for a write that
+        # landed -- telling an operator their revoke did not take when it did is
+        # worse than losing a durability guarantee the platform cannot give.
         try:
-            os.fsync(dir_fd)
-        finally:
-            os.close(dir_fd)
+            dir_fd = os.open(parent, os.O_RDONLY)
+        except OSError:
+            pass
+        else:
+            try:
+                os.fsync(dir_fd)
+            except OSError:
+                pass
+            finally:
+                os.close(dir_fd)
     except BaseException:
         with contextlib.suppress(OSError):
             os.unlink(tmp_name)
@@ -223,11 +236,30 @@ def _ensure_store_dir(parent: Path) -> None:
     """
     if parent.exists():
         return
-    parent.mkdir(parents=True, exist_ok=True)
-    try:
-        os.chmod(parent, 0o700)
-    except OSError:
-        pass
+    # Create every missing component RESTRICTIVE AT CREATION, one at a time.
+    # `mkdir(parents=True, mode=0o700)` is not enough on two counts, both
+    # measured: the intermediates are created with the default mode because
+    # pathlib deliberately ignores `mode` for parents (mimicking `mkdir -p`), so
+    # a freshly created `~/.config` lands 0o775 under umask 002; and creating
+    # loosely and tightening afterwards leaves a window in which another account
+    # in the user's group can insert a forged `trust.json` that a later
+    # `record()` will read and carry forward. `mkdir`'s mode is applied by the
+    # kernel at creation and umask can only remove bits, never add them.
+    missing: list[Path] = []
+    probe = parent
+    while not probe.exists():
+        missing.append(probe)
+        if probe.parent == probe:
+            break
+        probe = probe.parent
+    for component in reversed(missing):
+        component.mkdir(mode=0o700, exist_ok=True)
+        try:
+            # Only for a pathological umask that stripped owner bits from the
+            # mode above; it can never loosen a directory beyond 0o700.
+            os.chmod(component, 0o700)
+        except OSError:
+            pass
 
 
 @contextlib.contextmanager

--- a/src/pmcp/trust_store.py
+++ b/src/pmcp/trust_store.py
@@ -193,6 +193,17 @@ def _write_store(path: Path, records: list[TrustRecord]) -> None:
             store_file.flush()
             os.fsync(store_file.fileno())
         os.replace(tmp_name, path)
+        # fsync the DIRECTORY too, not just the file. `os.replace` is atomic
+        # against readers, but the rename itself is only durable once the
+        # directory entry is synced -- so a crash right after a revoke can leave
+        # the pre-revoke store on disk and resurrect the approval the operator
+        # just withdrew. That is the same invariant the lock protects against a
+        # race, reached through power loss instead.
+        dir_fd = os.open(parent, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
     except BaseException:
         with contextlib.suppress(OSError):
             os.unlink(tmp_name)

--- a/src/pmcp/trust_store.py
+++ b/src/pmcp/trust_store.py
@@ -1,0 +1,280 @@
+"""User-scoped store of approval records for content PMCP is about to trust.
+
+This module publishes the contract downstream consent and package-identity work
+codes against (`IF-0-TRUST-1`, Consiliency/pmcp#230). It wires no caller: it
+records decisions and answers one question, `is_approved`.
+
+Three properties are load-bearing, and each exists because the obvious
+alternative is exploitable:
+
+* **The predicate judges bytes, not a path.** ``is_approved(path, content)``
+  hashes the bytes the caller is *about to apply* and never reads ``path``. A
+  path-based check is defeated by swapping the file between the check and the
+  use; passing the bytes closes that window by construction.
+* **Every failure is a refusal.** A corrupt, unreadable, or missing store makes
+  ``is_approved`` return ``False``. It never raises to a caller that might read
+  an exception as permission. The other verbs *do* raise, loudly: they are
+  operator-facing, and a silent failure there would hide a broken store.
+* **The store may not live inside the checkout being judged.** A
+  checkout-resident store lets a repository ship an approval for its own
+  content, which would make "absence is never assent" decorative. The check
+  resolves symlinks first, so a symlinked ``~/.config/pmcp`` pointing into the
+  repository is refused too.
+
+That residency rule binds *where the store file lives*, never which paths may be
+recorded. ``record(path, ...)`` takes the path of the file being approved, which
+is normally inside a checkout -- that is the whole use case.
+
+The store sits beside the credential store (``env_store.resolve_scope_path``) at
+``~/.config/pmcp/trust.json``, mode ``0o600``, and holds exactly one record per
+absolute path: re-approving replaces, it does not append a history.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from pmcp.config.loader import find_project_root
+
+APPROVED = "approved"
+DENIED = "denied"
+
+#: The closed decision vocabulary. Anything else is rejected at ``record`` time
+#: rather than stored: a store that can hold a decision no reader understands
+#: is a store whose meaning depends on the reader.
+DECISIONS = frozenset({APPROVED, DENIED})
+
+_STORE_VERSION = 1
+
+
+class TrustStoreError(RuntimeError):
+    """The trust store cannot be used as configured, or cannot be parsed."""
+
+
+@dataclass(frozen=True)
+class TrustRecord:
+    """One decision about one file's exact content."""
+
+    absolute_path: Path
+    content_sha256: str
+    scope: str
+    decision: str
+    recorded_at: datetime
+
+
+def _checkout_root() -> Path | None:
+    """Resolved root of the checkout the process is working in, if any."""
+    root = find_project_root(Path.cwd())
+    return root.resolve() if root else None
+
+
+def trust_store_path() -> Path:
+    """Resolved path of the user-scoped trust store.
+
+    Raises ``TrustStoreError`` if the store would land inside the current
+    checkout -- directly, or through a symlink anywhere in its path. Symlinks
+    are resolved *before* the comparison, which is the only reason a planted
+    ``~/.config/pmcp -> ./vendor`` is caught.
+    """
+    path = (Path.home() / ".config" / "pmcp" / "trust.json").resolve()
+    checkout = _checkout_root()
+    if checkout is not None and path.is_relative_to(checkout):
+        raise TrustStoreError(
+            f"Trust store {path} resolves inside the checkout at {checkout}. "
+            "A checkout-resident store lets a repository approve its own "
+            "content; move it under a home directory outside the repository."
+        )
+    return path
+
+
+def _decode(entry: Any) -> TrustRecord:
+    """Decode one stored entry, refusing anything malformed.
+
+    Strict on purpose: a half-understood entry is rejected as a whole-store
+    parse failure, which every caller turns into a refusal.
+    """
+    if not isinstance(entry, dict):
+        raise TrustStoreError("Trust store entry is not an object")
+    try:
+        absolute_path = entry["absolute_path"]
+        content_sha256 = entry["content_sha256"]
+        scope = entry["scope"]
+        decision = entry["decision"]
+        recorded_at = entry["recorded_at"]
+    except KeyError as exc:
+        raise TrustStoreError(f"Trust store entry is missing {exc}") from exc
+
+    if decision not in DECISIONS:
+        raise TrustStoreError(f"Unknown trust decision: {decision!r}")
+
+    try:
+        parsed_at = datetime.fromisoformat(str(recorded_at))
+    except ValueError as exc:
+        raise TrustStoreError(f"Unparseable trust timestamp: {exc}") from exc
+
+    return TrustRecord(
+        absolute_path=Path(str(absolute_path)),
+        content_sha256=str(content_sha256),
+        scope=str(scope),
+        decision=str(decision),
+        recorded_at=parsed_at,
+    )
+
+
+def _read_store(path: Path) -> list[TrustRecord]:
+    """Read every record from the store, or raise ``TrustStoreError``.
+
+    An absent store is empty, not an error -- a user who has approved nothing is
+    the normal starting state.
+    """
+    if not path.exists():
+        return []
+
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise TrustStoreError(f"Cannot read trust store {path}: {exc}") from exc
+
+    try:
+        data = json.loads(raw)
+    except ValueError as exc:
+        raise TrustStoreError(f"Cannot parse trust store {path}: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise TrustStoreError(f"Trust store {path} is not a JSON object")
+    entries = data.get("records")
+    if not isinstance(entries, list):
+        raise TrustStoreError(f"Trust store {path} has no records list")
+
+    return [_decode(entry) for entry in entries]
+
+
+def _write_store(path: Path, records: list[TrustRecord]) -> None:
+    """Write the store, creating it mode 0o600.
+
+    Mirrors ``env_store.write_env_file``: tighten only a directory PMCP itself
+    created, never a pre-existing one.
+    """
+    payload = {
+        "version": _STORE_VERSION,
+        "records": [
+            {
+                "absolute_path": str(rec.absolute_path),
+                "content_sha256": rec.content_sha256,
+                "scope": rec.scope,
+                "decision": rec.decision,
+                "recorded_at": rec.recorded_at.isoformat(),
+            }
+            for rec in records
+        ],
+    }
+
+    parent = path.parent
+    parent_created = not parent.exists()
+    parent.mkdir(parents=True, exist_ok=True)
+    if parent_created:
+        try:
+            os.chmod(parent, 0o700)
+        except OSError:
+            pass
+
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    os.fchmod(fd, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as store_file:
+        json.dump(payload, store_file, indent=2)
+        store_file.write("\n")
+
+
+def is_approved(path: Path, content: bytes) -> bool:
+    """Is ``content`` approved to be applied as ``path``?
+
+    ``content`` is the bytes the caller is about to use, not a promise about
+    what is on disk; this function never reads ``path``. The answer is ``True``
+    only for a record whose decision is ``"approved"`` AND whose digest matches
+    these exact bytes -- a ``"denied"`` record, a stale digest, and no record at
+    all are all ``False``.
+
+    Never raises. Every I/O, parse, and configuration failure answers ``False``,
+    because a caller that treated an exception as permission would be granted
+    trust by a corrupt file.
+    """
+    try:
+        records = _read_store(trust_store_path())
+        target = Path(path).resolve()
+        digest = hashlib.sha256(content).hexdigest()
+        for rec in records:
+            if rec.absolute_path == target:
+                return rec.decision == APPROVED and rec.content_sha256 == digest
+        return False
+    except Exception:  # noqa: BLE001 -- fail closed; see docstring
+        return False
+
+
+def record(path: Path, content: bytes, scope: str, decision: str) -> TrustRecord:
+    """Record a decision about ``path``'s exact ``content``, replacing any prior.
+
+    ``decision`` must be one of ``DECISIONS``; anything else raises
+    ``ValueError`` rather than being stored, so a typo cannot become a decision
+    that no reader recognises. Raises ``TrustStoreError`` if the store is
+    unusable (checkout-resident, unreadable, or corrupt) -- writing over a store
+    that could not be read would silently discard existing decisions.
+    """
+    if decision not in DECISIONS:
+        raise ValueError(
+            f"Unsupported trust decision: {decision!r} "
+            f"(expected one of {sorted(DECISIONS)})"
+        )
+    if not scope:
+        raise ValueError("Trust scope must be a non-empty string")
+
+    store = trust_store_path()
+    entry = TrustRecord(
+        absolute_path=Path(path).resolve(),
+        content_sha256=hashlib.sha256(content).hexdigest(),
+        scope=scope,
+        decision=decision,
+        recorded_at=datetime.now(timezone.utc),
+    )
+
+    records = [
+        rec for rec in _read_store(store) if rec.absolute_path != entry.absolute_path
+    ]
+    records.append(entry)
+    _write_store(store, records)
+    return entry
+
+
+def revoke(path: Path) -> bool:
+    """Drop any record for ``path``. Returns whether one was removed.
+
+    Revoking returns the path to *absent*, which is not the same as recording a
+    ``"denied"`` decision -- use ``record(..., decision="denied")`` to say no
+    explicitly. Raises ``TrustStoreError`` if the store is unusable.
+    """
+    store = trust_store_path()
+    records = _read_store(store)
+    target = Path(path).resolve()
+
+    kept = [rec for rec in records if rec.absolute_path != target]
+    if len(kept) == len(records):
+        return False
+
+    _write_store(store, kept)
+    return True
+
+
+def list_records() -> list[TrustRecord]:
+    """Every record in the store, in insertion order.
+
+    Raises ``TrustStoreError`` if the store is unusable. This surface is
+    operator-facing -- unlike ``is_approved``, an empty list here would be a
+    misleading way to report a broken store, and it cannot be misread as
+    permission by anything.
+    """
+    return _read_store(trust_store_path())

--- a/tests/test_package_identity.py
+++ b/tests/test_package_identity.py
@@ -331,3 +331,43 @@ def test_the_packument_fetch_refuses_redirects() -> None:
         isinstance(h, package_identity._NoRedirectHandler)
         for h in package_identity._OPENER.handlers
     )
+
+
+def test_a_dist_tag_pointing_at_a_range_resolves_to_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dist-tag's target is registry-controlled and gets the same check.
+
+    The user-supplied half of a spec was always refused when it named a range.
+    The tag half was not: a packument whose `latest` points at `^1.0.0` yielded
+    an identity whose `resolved_version` was that range. A consumer pinning argv
+    to `pkg@^1.0.0` then re-resolves at every spawn, which is the check-then-use
+    hole this primitive exists to close -- reached through registry data rather
+    than through the caller.
+    """
+    for target in ("^1.0.0", ">=1.0 <2.0", "1.x", "latest", "not-a-version"):
+        packument = {
+            "name": "evil-mcp",
+            "dist-tags": {"latest": target},
+            "versions": {target: {"dist": {"integrity": "sha512-deadbeef"}}},
+        }
+        monkeypatch.setattr(
+            package_identity,
+            "_fetch_packument",
+            lambda _name, _doc=packument: _doc,
+            raising=False,
+        )
+        assert resolve_package_identity("evil-mcp") is None, (
+            f"a dist-tag pointing at {target!r} must not resolve"
+        )
+
+    concrete = {
+        "name": "good-mcp",
+        "dist-tags": {"latest": "1.4.2"},
+        "versions": {"1.4.2": {"dist": {"integrity": "sha512-cafe"}}},
+    }
+    monkeypatch.setattr(
+        package_identity, "_fetch_packument", lambda _n: concrete, raising=False
+    )
+    resolved = resolve_package_identity("good-mcp")
+    assert resolved is not None and resolved.resolved_version == "1.4.2"

--- a/tests/test_package_identity.py
+++ b/tests/test_package_identity.py
@@ -1,0 +1,333 @@
+"""Package identity: WHICH package a spec names, and at which resolved version.
+
+Consiliency/pmcp#230, phase TRUST lane SL-2 (IF-0-TRUST-2). The 2026-09-01
+review's finding S-01 is that policy checks the agent-chosen SERVER NAME while
+``provision`` runs the agent-chosen PACKAGE with ``npx -y`` -- so allowlisting
+``internal-approved-tool`` executes ``totally-arbitrary-evil-package``. This
+module's job is to supply the thing a later phase can actually gate on.
+
+Two properties carry the whole lane and both are asserted here:
+
+* **Resolution must not execute the package.** ``npx -y pkg`` resolves *by
+  running it*; an identity obtained that way is obtained too late. So the tests
+  block ``subprocess.Popen`` and ``socket.socket`` and still require an answer.
+* **A resolved version, or nothing.** An unpinned spec re-resolves to whatever
+  is latest at every spawn, so an approval of a range would approve code that
+  does not exist yet. Anything this module cannot pin to one concrete version
+  in the registry's own document is ``None``.
+
+The packument is inlined rather than kept under ``tests/fixtures/`` because
+SL-2 owns exactly two files; the shape is npm's abbreviated packument
+(``application/vnd.npm.install-v1+json``).
+"""
+
+from __future__ import annotations
+
+import socket
+import subprocess
+from typing import Any
+from urllib.error import HTTPError
+
+import pytest
+
+from pmcp.manifest import package_identity
+from pmcp.manifest.package_identity import PackageIdentity, resolve_package_identity
+
+_LATEST_INTEGRITY = "sha512-cGFja2FnZS1pZGVudGl0eS1sYXRlc3Q="
+_PINNED_INTEGRITY = "sha512-cGFja2FnZS1pZGVudGl0eS1waW5uZWQ="
+
+
+def _packument(name: str = "example-mcp") -> dict[str, Any]:
+    """An abbreviated packument, trimmed to the keys this module reads."""
+    return {
+        "name": name,
+        "dist-tags": {"latest": "1.4.2", "next": "2.0.0-rc.1"},
+        "versions": {
+            "1.0.0": {
+                "name": name,
+                "version": "1.0.0",
+                "dist": {
+                    "tarball": f"https://registry.npmjs.org/{name}/-/pkg-1.0.0.tgz",
+                    "integrity": _PINNED_INTEGRITY,
+                },
+            },
+            "1.4.2": {
+                "name": name,
+                "version": "1.4.2",
+                "dist": {
+                    "tarball": f"https://registry.npmjs.org/{name}/-/pkg-1.4.2.tgz",
+                    "integrity": _LATEST_INTEGRITY,
+                },
+            },
+            # A registry entry may predate subresource integrity. The identity
+            # must say so rather than invent a digest.
+            "2.0.0-rc.1": {
+                "name": name,
+                "version": "2.0.0-rc.1",
+                "dist": {
+                    "tarball": f"https://registry.npmjs.org/{name}/-/pkg-2.0.0.tgz"
+                },
+            },
+        },
+    }
+
+
+class _OfflineRegistry:
+    """A packument source that never leaves the process, and counts its reads."""
+
+    def __init__(self) -> None:
+        self.packuments: dict[str, dict[str, Any]] = {
+            "example-mcp": _packument(),
+            "@scope/example": _packument("@scope/example"),
+        }
+        self.calls: list[str] = []
+
+    def fetch(self, name: str) -> dict[str, Any] | None:
+        self.calls.append(name)
+        return self.packuments.get(name)
+
+
+@pytest.fixture
+def registry(monkeypatch: pytest.MonkeyPatch) -> _OfflineRegistry:
+    """Serve packuments from memory.
+
+    ``raising=False`` is deliberate: it makes a failing run fail on BEHAVIOUR --
+    a resolver that reaches for the network anyway -- rather than on the absence
+    of an attribute. That distinction is what made the pre-implementation
+    falsification runs mean something.
+    """
+    source = _OfflineRegistry()
+    monkeypatch.setattr(
+        package_identity, "_fetch_packument", source.fetch, raising=False
+    )
+    return source
+
+
+@pytest.fixture
+def no_network(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Make every spawn and every socket an error, and record the attempts.
+
+    ``subprocess.Popen`` is patched at the class level because that is what
+    ``subprocess.run``/``check_output`` and ``NpmResolver._spawn`` all go
+    through -- patching ``run`` alone would leave the interesting path open.
+    """
+    attempts: list[str] = []
+
+    def _no_spawn(*args: Any, **kwargs: Any) -> Any:
+        attempts.append(f"subprocess.Popen({args!r})")
+        raise AssertionError("resolving a package identity must not spawn a process")
+
+    def _no_socket(*args: Any, **kwargs: Any) -> Any:
+        attempts.append(f"socket.socket({args!r})")
+        raise AssertionError("resolving a package identity must not open a socket")
+
+    monkeypatch.setattr(subprocess, "Popen", _no_spawn)
+    monkeypatch.setattr(socket, "socket", _no_socket)
+    return attempts
+
+
+# ---------------------------------------------------------------------------
+# SL-2.1: identity resolves offline from a fixture
+# ---------------------------------------------------------------------------
+
+
+def test_identity_resolves_offline_from_a_fixture(
+    registry: _OfflineRegistry, no_network: list[str]
+) -> None:
+    identity = resolve_package_identity("example-mcp")
+
+    assert identity == PackageIdentity(
+        registry="npm",
+        name="example-mcp",
+        resolved_version="1.4.2",
+        integrity=_LATEST_INTEGRITY,
+    )
+    assert registry.calls == ["example-mcp"]
+
+
+def test_an_exact_pin_resolves_to_that_version(
+    registry: _OfflineRegistry, no_network: list[str]
+) -> None:
+    identity = resolve_package_identity("example-mcp@1.0.0")
+
+    assert identity is not None
+    # Not `dist-tags.latest`: a pinned spec must not silently drift upward, and
+    # the integrity must be the pinned entry's own.
+    assert identity.resolved_version == "1.0.0"
+    assert identity.integrity == _PINNED_INTEGRITY
+
+
+def test_a_dist_tag_resolves_through_dist_tags(
+    registry: _OfflineRegistry, no_network: list[str]
+) -> None:
+    identity = resolve_package_identity("example-mcp@next")
+
+    assert identity is not None
+    assert identity.resolved_version == "2.0.0-rc.1"
+
+
+def test_a_scoped_spec_splits_at_the_version_separator(
+    registry: _OfflineRegistry, no_network: list[str]
+) -> None:
+    identity = resolve_package_identity("@scope/example@1.0.0")
+
+    assert identity is not None
+    # The leading `@` of a scope is not a version separator.
+    assert identity.name == "@scope/example"
+    assert identity.resolved_version == "1.0.0"
+    assert registry.calls == ["@scope/example"]
+
+
+def test_a_missing_integrity_is_none_not_a_fabrication(
+    registry: _OfflineRegistry, no_network: list[str]
+) -> None:
+    identity = resolve_package_identity("example-mcp@2.0.0-rc.1")
+
+    assert identity is not None
+    assert identity.integrity is None
+
+
+# ---------------------------------------------------------------------------
+# SL-2.1: an unresolvable spec returns None rather than raising
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        "",  # no package at all
+        "unknown-package",  # the registry has no such document
+        "example-mcp@9.9.9",  # a real package, a version it never published
+        "example-mcp@nightly",  # a dist-tag the registry does not carry
+        "example-mcp@^1.0.0",  # a range: no single version to approve
+        "example-mcp@>=1.0 <2.0",  # ditto, in npa's whitespace spelling
+        "example-mcp@1.x",  # ditto
+        "example-mcp@*",  # ditto
+        "example-mcp@",  # a separator with nothing after it
+        "-evil",  # npx would read this as a flag
+        "../../etc/passwd",  # path traversal into the registry URL
+        "example mcp",  # whitespace
+        "npm:alias@1.0.0",  # an alias spec: the name is not the name
+        "file:../local",  # not a registry package at all
+        "github:owner/repo",  # ditto
+    ],
+)
+def test_an_unresolvable_spec_returns_none_rather_than_raising(
+    registry: _OfflineRegistry, no_network: list[str], spec: str
+) -> None:
+    # `None`, never an exception: a caller that gates on identity would have to
+    # wrap every call, and one unwrapped call site turns a refusal into a crash
+    # -- or, worse, into an `except Exception: pass` that reads as consent.
+    assert resolve_package_identity(spec) is None
+
+
+def test_an_invalid_package_name_is_refused_before_any_fetch(
+    registry: _OfflineRegistry, no_network: list[str]
+) -> None:
+    for spec in ("-evil", "../../etc/passwd", "example mcp", ""):
+        assert resolve_package_identity(spec) is None
+
+    # Refused by `validation.is_valid_package_name` before a URL is ever built,
+    # so a hostile spec never reaches the network layer at all.
+    assert registry.calls == []
+
+
+def test_a_packument_naming_a_different_package_is_refused(
+    registry: _OfflineRegistry, no_network: list[str]
+) -> None:
+    registry.packuments["example-mcp"] = _packument("something-else")
+
+    # A mirror, a redirect, or a cache-poisoning answer that serves another
+    # package's document must not be minted as this package's identity.
+    assert resolve_package_identity("example-mcp") is None
+
+
+@pytest.mark.parametrize(
+    "packument",
+    [
+        None,
+        [],
+        {},
+        {"name": "example-mcp"},
+        {"name": "example-mcp", "dist-tags": {"latest": "1.4.2"}},
+        {"name": "example-mcp", "dist-tags": "latest", "versions": {}},
+        {"name": "example-mcp", "dist-tags": {"latest": 142}, "versions": {}},
+        # `latest` points at a version the document does not describe: there is
+        # no `dist` entry to take an integrity from, so there is no identity.
+        {"name": "example-mcp", "dist-tags": {"latest": "1.4.2"}, "versions": {}},
+        {
+            "name": "example-mcp",
+            "dist-tags": {"latest": "1.4.2"},
+            "versions": {"1.4.2": "not-an-object"},
+        },
+    ],
+)
+def test_a_malformed_packument_fails_closed(
+    registry: _OfflineRegistry, no_network: list[str], packument: Any
+) -> None:
+    registry.packuments["example-mcp"] = packument
+
+    assert resolve_package_identity("example-mcp") is None
+
+
+def test_a_registry_failure_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, no_network: list[str]
+) -> None:
+    def _boom(name: str) -> dict[str, Any] | None:
+        raise OSError("connection reset by peer")
+
+    monkeypatch.setattr(package_identity, "_fetch_packument", _boom, raising=False)
+
+    # Fail closed: an exception escaping here would reach a caller that may well
+    # treat "no refusal" as permission.
+    assert resolve_package_identity("example-mcp") is None
+
+
+# ---------------------------------------------------------------------------
+# SL-2.1 / EC-TRUST-1: no subprocess is spawned
+# ---------------------------------------------------------------------------
+
+
+def test_no_subprocess_is_spawned(
+    registry: _OfflineRegistry, no_network: list[str]
+) -> None:
+    # The negative control for EC-TRUST-1. `npm view` / `npx -y` would both
+    # answer the question -- the second by running the package, which is the
+    # bug -- so the identity must come from the registry document alone.
+    identity = resolve_package_identity("example-mcp@1.0.0")
+
+    assert identity is not None
+    assert no_network == []
+    # Belt and braces: the #195 resolver is a process-spawner and this module
+    # deliberately does not drive it (it consumes the SPEC STRING that resolver
+    # produces, which is a different relationship).
+    assert package_identity.__dict__.get("get_resolver") is None
+
+
+# ---------------------------------------------------------------------------
+# Fetch hardening (only the pure parts; the fetch itself is never exercised)
+# ---------------------------------------------------------------------------
+
+
+def test_the_packument_url_escapes_the_package_name() -> None:
+    url = package_identity._packument_url("@scope/example")
+
+    # One path component: a scoped name must not introduce a `/` that could
+    # redirect the request to another registry path.
+    assert url == "https://registry.npmjs.org/%40scope%2Fexample"
+    assert url.startswith(package_identity.NPM_REGISTRY_URL + "/")
+    assert "/" not in url[len(package_identity.NPM_REGISTRY_URL) + 1 :]
+
+
+def test_the_packument_fetch_refuses_redirects() -> None:
+    handler = package_identity._NoRedirectHandler()
+
+    with pytest.raises(HTTPError):
+        handler.redirect_request(
+            None, None, 302, "Found", {}, "http://169.254.169.254/latest/meta-data/"
+        )
+
+    assert any(
+        isinstance(h, package_identity._NoRedirectHandler)
+        for h in package_identity._OPENER.handlers
+    )

--- a/tests/test_trust_cli.py
+++ b/tests/test_trust_cli.py
@@ -1,0 +1,194 @@
+"""Tests for the ``pmcp trust`` CLI verbs (Consiliency/pmcp#230, EC-TRUST-4).
+
+Every test drives the real entry path -- ``parse_args`` over an argv, then
+``async_main`` -- rather than calling the command function directly. That is
+deliberate: ``async_main``'s fallthrough is "run the gateway server", so a test
+that hand-built a ``Namespace`` would stay green even if the dispatch branch
+were missing, while ``pmcp trust approve ...`` silently started a server.
+
+The verb spelling is a contract, not a preference: downstream refusal messages
+print the runnable string ``pmcp trust approve <absolute path>``, so
+``test_the_frozen_verb_spelling_parses`` guards it at the parser.
+
+Isolation: the store is user-scoped at ``~/.config/pmcp/trust.json``. The
+``trust_home`` fixture repoints ``$HOME`` at a tmp directory and *asserts* the
+redirect took before any test body runs, so a test run cannot record a real
+approval on the machine it runs on.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from pmcp import trust_store
+from pmcp.cli import async_main, parse_args
+
+
+@pytest.fixture
+def trust_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Repoint the user-scoped trust store into ``tmp_path`` and prove it moved."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+
+    store = trust_store.trust_store_path()
+    assert store.is_relative_to(home.resolve()), (
+        f"trust store did not follow $HOME: {store} is outside {home}. "
+        "Refusing to run -- this test would write the operator's real store."
+    )
+    assert not store.exists()
+    yield home
+
+
+def run_cli(*argv: str) -> None:
+    """Run one ``pmcp`` invocation exactly as ``main()`` would dispatch it."""
+    with patch("sys.argv", ["mcp-gateway", *argv]):
+        args = parse_args()
+    asyncio.run(async_main(args))
+
+
+def test_the_frozen_verb_spelling_parses(tmp_path: Path) -> None:
+    """`trust approve|list|revoke` are the spellings downstream messages name."""
+    with patch("sys.argv", ["mcp-gateway", "trust", "approve", str(tmp_path / "f")]):
+        approve = parse_args()
+    assert approve.command == "trust"
+    assert approve.trust_command == "approve"
+    assert approve.path == tmp_path / "f"
+
+    with patch("sys.argv", ["mcp-gateway", "trust", "list"]):
+        listing = parse_args()
+    assert (listing.command, listing.trust_command) == ("trust", "list")
+
+    with patch("sys.argv", ["mcp-gateway", "trust", "revoke", str(tmp_path / "f")]):
+        revoke = parse_args()
+    assert (revoke.command, revoke.trust_command) == ("trust", "revoke")
+    assert revoke.path == tmp_path / "f"
+
+
+def test_approve_records_the_file_and_makes_its_content_approved(
+    trust_home: Path, tmp_path: Path
+) -> None:
+    """`approve` writes a record the store's own predicate then honours."""
+    target = tmp_path / "server.json"
+    target.write_bytes(b'{"ok": true}')
+
+    run_cli("trust", "approve", str(target))
+
+    records = trust_store.list_records()
+    assert len(records) == 1
+    assert records[0].absolute_path == target.resolve()
+    assert records[0].decision == "approved"
+    assert trust_store.is_approved(target, b'{"ok": true}') is True
+    assert trust_store.is_approved(target, b'{"ok": false}') is False
+
+
+def test_approve_replaces_the_record_when_the_file_changes(
+    trust_home: Path, tmp_path: Path
+) -> None:
+    """Re-approving edited content replaces the digest; it does not append."""
+    target = tmp_path / "server.json"
+    target.write_bytes(b"first")
+    run_cli("trust", "approve", str(target))
+
+    target.write_bytes(b"second")
+    run_cli("trust", "approve", str(target))
+
+    records = trust_store.list_records()
+    assert len(records) == 1
+    assert trust_store.is_approved(target, b"second") is True
+    assert trust_store.is_approved(target, b"first") is False
+
+
+def test_approve_on_a_missing_file_exits_non_zero_and_records_nothing(
+    trust_home: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Approving what cannot be read is a refusal, not an empty approval."""
+    missing = tmp_path / "not-here.json"
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_cli("trust", "approve", str(missing))
+
+    assert exc_info.value.code != 0
+    assert str(missing) in capsys.readouterr().err
+    assert trust_store.list_records() == []
+
+
+def test_approve_records_the_absolute_path_for_a_relative_argument(
+    trust_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The store is keyed on the resolved path however the operator spelled it."""
+    work = tmp_path / "work"
+    work.mkdir()
+    target = work / "server.json"
+    target.write_bytes(b"payload")
+    monkeypatch.chdir(work)
+
+    run_cli("trust", "approve", "server.json")
+
+    records = trust_store.list_records()
+    assert [rec.absolute_path for rec in records] == [target.resolve()]
+
+
+def test_list_names_the_path_and_the_decision(
+    trust_home: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`list` is the operator's read of the store, so it must print both."""
+    target = tmp_path / "server.json"
+    target.write_bytes(b"payload")
+    run_cli("trust", "approve", str(target))
+    capsys.readouterr()
+
+    run_cli("trust", "list")
+
+    out = capsys.readouterr().out
+    assert str(target.resolve()) in out
+    assert "approved" in out
+
+
+def test_list_on_an_empty_store_says_so_and_exits_zero(
+    trust_home: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Nothing approved is the normal starting state, not an error."""
+    run_cli("trust", "list")
+
+    out = capsys.readouterr().out
+    assert out.strip() != ""
+    assert trust_store.list_records() == []
+
+
+def test_revoke_removes_the_record_so_the_content_is_no_longer_approved(
+    trust_home: Path, tmp_path: Path
+) -> None:
+    """`revoke` returns the path to absent, which `is_approved` reports as False."""
+    target = tmp_path / "server.json"
+    target.write_bytes(b"payload")
+    run_cli("trust", "approve", str(target))
+    assert trust_store.is_approved(target, b"payload") is True
+
+    run_cli("trust", "revoke", str(target))
+
+    assert trust_store.list_records() == []
+    assert trust_store.is_approved(target, b"payload") is False
+
+
+def test_revoke_of_an_unrecorded_path_exits_non_zero_and_keeps_other_records(
+    trust_home: Path, tmp_path: Path
+) -> None:
+    """Revoking nothing reports failure rather than a misleading success."""
+    approved = tmp_path / "approved.json"
+    approved.write_bytes(b"payload")
+    run_cli("trust", "approve", str(approved))
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_cli("trust", "revoke", str(tmp_path / "never-approved.json"))
+
+    assert exc_info.value.code != 0
+    assert [rec.absolute_path for rec in trust_store.list_records()] == [
+        approved.resolve()
+    ]

--- a/tests/test_trust_store.py
+++ b/tests/test_trust_store.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import stat
+import threading
 from datetime import datetime
 from pathlib import Path
 
@@ -222,3 +223,47 @@ def test_a_denied_record_is_not_approved(checkout: Path) -> None:
     record(target, b"payload", "user", "approved")
     assert len(list_records()) == 1
     assert is_approved(target, b"payload") is True
+
+
+def test_concurrent_record_and_revoke_do_not_resurrect_an_approval(
+    checkout: Path,
+) -> None:
+    """A revoke must not be undone by a concurrent approve's stale snapshot.
+
+    ``record`` and ``revoke`` each read every record, change one, and write the
+    whole set back. Unserialized, they interleave into a lost update: record
+    reads a snapshot containing A, revoke removes A, record writes its snapshot
+    back and A is approved again -- an operator's withdrawal silently reversed.
+    Both now hold an exclusive lock for the whole read-modify-write.
+
+    Falsifier: remove the `_store_lock` from either function and this resurrects
+    `victim` within a few iterations.
+    """
+    victim = _write(checkout / "victim.json", b"victim")
+    other = _write(checkout / "other.json", b"other")
+
+    for _ in range(40):
+        record(victim, b"victim", "user", "approved")
+        barrier = threading.Barrier(2)
+
+        def approve_other() -> None:
+            barrier.wait()
+            record(other, b"other", "user", "approved")
+
+        def revoke_victim() -> None:
+            barrier.wait()
+            revoke(victim)
+
+        threads = [
+            threading.Thread(target=approve_other),
+            threading.Thread(target=revoke_victim),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert not is_approved(victim, b"victim"), (
+            "a concurrent approve resurrected a revoked approval"
+        )
+        revoke(other)

--- a/tests/test_trust_store.py
+++ b/tests/test_trust_store.py
@@ -267,3 +267,29 @@ def test_concurrent_record_and_revoke_do_not_resurrect_an_approval(
             "a concurrent approve resurrected a revoked approval"
         )
         revoke(other)
+
+
+def test_a_store_directory_pmcp_creates_is_not_group_or_world_accessible(
+    checkout: Path,
+) -> None:
+    """A directory PMCP creates for the store is 0o700, not the umask default.
+
+    The store file is 0o600, but the directory around it matters too: at the
+    common umask of 022 an untightened directory is 0o755, and at 002 it is
+    0o775 -- group-writable, so another account in the group can rename or
+    replace `trust.json` wholesale even though it cannot read the old one.
+
+    Falsifier: this caught a real regression. Adding the lock introduced a
+    second `mkdir` that ran before `_write_store`'s, so `_write_store` saw an
+    existing directory, skipped its chmod, and a fresh install silently got the
+    umask default. Give `_store_lock` and `_write_store` independent "did we
+    create it?" decisions again and this fails.
+    """
+    target = _write(checkout / "server.json", b"payload")
+    record(target, b"payload", "user", "approved")
+
+    store = trust_store_path()
+    assert store.stat().st_mode & 0o777 == 0o600
+    assert store.parent.stat().st_mode & 0o777 == 0o700, (
+        "the store directory must not be group- or world-accessible"
+    )

--- a/tests/test_trust_store.py
+++ b/tests/test_trust_store.py
@@ -9,6 +9,7 @@ checkout is the normal case -- that is what every CONSENT caller will do.
 from __future__ import annotations
 
 import json
+import os
 import stat
 import threading
 from datetime import datetime
@@ -293,3 +294,74 @@ def test_a_store_directory_pmcp_creates_is_not_group_or_world_accessible(
     assert store.parent.stat().st_mode & 0o777 == 0o700, (
         "the store directory must not be group- or world-accessible"
     )
+
+
+def test_every_directory_pmcp_creates_is_private_including_intermediates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No component is group- or world-accessible, even transiently.
+
+    Two measured facts drive this. `Path.mkdir(parents=True, mode=...)` ignores
+    `mode` for the intermediates it creates, so a freshly created `~/.config`
+    lands 0o775 under umask 002 while only the leaf is tightened. And creating
+    loosely then tightening leaves a window in which another account in the
+    user's group can insert a forged `trust.json` that a later `record()` reads
+    and carries forward -- the store file being 0o600 does not help, because the
+    attack replaces the file rather than reading it.
+
+    Falsifier: restore `parent.mkdir(parents=True)` plus a trailing chmod and
+    the intermediate assertion fails under this umask.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    checkout = tmp_path / "checkout"
+    (checkout / ".git").mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(checkout)
+    monkeypatch.setattr(os, "umask", lambda _mask: 0o002, raising=False)
+    old_mask = os.umask(0o002)
+    try:
+        target = _write(checkout / "server.json", b"payload")
+        record(target, b"payload", "user", "approved")
+
+        store = trust_store_path()
+        assert store.parent.stat().st_mode & 0o777 == 0o700
+        # the intermediate PMCP created on the way down, e.g. ~/.config
+        intermediate = store.parent.parent
+        assert intermediate != home, "test must exercise a created intermediate"
+        assert intermediate.stat().st_mode & 0o777 == 0o700, (
+            f"{intermediate} was created group/world-accessible"
+        )
+    finally:
+        os.umask(old_mask)
+
+
+def test_a_directory_fsync_failure_does_not_fail_a_completed_write(
+    checkout: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Durability is best effort; the write already landed.
+
+    Directory fsync is unsupported on macOS (EINVAL), on NFS and some overlay
+    mounts (ENOTSUP), and `os.open` on a directory fails outright on Windows.
+    Because the fsync runs AFTER `os.replace`, raising would report a failed
+    `revoke` for a revoke that succeeded -- and an operator told their
+    withdrawal did not take, when it did, is the worst direction for this tool
+    to be wrong in.
+
+    Falsifier: drop the `except OSError` around the fsync and this raises
+    OSError(22) while `is_approved` already reads False.
+    """
+    target = _write(checkout / "server.json", b"payload")
+    record(target, b"payload", "user", "approved")
+
+    real_fsync = os.fsync
+
+    def fails_on_directories(fd: int) -> None:
+        if os.fstat(fd).st_mode & 0o170000 == 0o040000:
+            raise OSError(22, "Invalid argument")
+        real_fsync(fd)
+
+    monkeypatch.setattr(os, "fsync", fails_on_directories)
+
+    assert revoke(target) is True, "a completed revoke must not report failure"
+    assert not is_approved(target, b"payload")

--- a/tests/test_trust_store.py
+++ b/tests/test_trust_store.py
@@ -1,0 +1,224 @@
+"""Tests for the user-scoped trust store (Consiliency/pmcp#230, IF-0-TRUST-1).
+
+Every test runs with ``cwd`` inside a *fake checkout* and ``HOME`` outside it,
+because the store's residency rule is a property of where the store file lives
+relative to the checkout being examined. Approving files that live *inside* the
+checkout is the normal case -- that is what every CONSENT caller will do.
+"""
+
+from __future__ import annotations
+
+import json
+import stat
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from pmcp.trust_store import (
+    TrustStoreError,
+    is_approved,
+    list_records,
+    record,
+    revoke,
+    trust_store_path,
+)
+
+
+@pytest.fixture
+def checkout(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """A checkout to work in, with the user's home deliberately outside it."""
+    checkout_dir = tmp_path / "checkout"
+    (checkout_dir / ".git").mkdir(parents=True)
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(checkout_dir)
+    return checkout_dir
+
+
+def _write(path: Path, content: bytes) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return path
+
+
+def test_a_record_round_trips(checkout: Path) -> None:
+    """An approval survives a write/read cycle, and re-approving replaces it."""
+    target = _write(checkout / "server.py", b"print('hello')")
+
+    written = record(target, b"print('hello')", "user", "approved")
+
+    assert written.absolute_path == target.resolve()
+    assert written.decision == "approved"
+    assert written.scope == "user"
+    assert written.recorded_at.tzinfo is not None
+    assert isinstance(written.recorded_at, datetime)
+
+    store = trust_store_path()
+    assert store.exists(), "record() must persist to the store file"
+    assert stat.S_IMODE(store.stat().st_mode) == 0o600
+
+    # Read back through a fresh call, not the returned object.
+    (loaded,) = list_records()
+    assert loaded.absolute_path == target.resolve()
+    assert loaded.content_sha256 == written.content_sha256
+    assert loaded.decision == "approved"
+    assert is_approved(target, b"print('hello')") is True
+
+    # One record per absolute path: re-approving replaces, it never appends.
+    record(target, b"print('goodbye')", "user", "approved")
+    assert len(list_records()) == 1
+    assert is_approved(target, b"print('goodbye')") is True
+    assert is_approved(target, b"print('hello')") is False
+
+    assert revoke(target) is True
+    assert list_records() == []
+    assert revoke(target) is False
+
+
+def test_changed_content_is_no_longer_approved(checkout: Path) -> None:
+    """Approval binds to the content that was approved, not to the path."""
+    target = _write(checkout / "server.py", b"safe")
+    record(target, b"safe", "user", "approved")
+
+    assert is_approved(target, b"safe") is True
+    assert is_approved(target, b"safe ") is False
+    assert is_approved(target, b"rm -rf /") is False
+
+
+def test_an_unknown_path_is_not_approved(checkout: Path) -> None:
+    """Absence is never assent -- with an empty store or a populated one."""
+    unknown = _write(checkout / "unknown.py", b"whatever")
+
+    assert is_approved(unknown, b"whatever") is False
+
+    other = _write(checkout / "known.py", b"known")
+    record(other, b"known", "user", "approved")
+
+    assert is_approved(unknown, b"whatever") is False
+
+
+def test_an_unreadable_store_fails_closed(checkout: Path) -> None:
+    """Any I/O or parse failure answers False; it never raises to the caller.
+
+    A caller that treats an exception as permission would be granted trust by a
+    corrupt file, so the predicate must swallow and refuse.
+    """
+    target = _write(checkout / "server.py", b"payload")
+    record(target, b"payload", "user", "approved")
+    store = trust_store_path()
+    assert is_approved(target, b"payload") is True
+
+    store.write_text("{ not json at all", encoding="utf-8")
+    assert is_approved(target, b"payload") is False
+
+    store.write_text(json.dumps(["not", "a", "store"]), encoding="utf-8")
+    assert is_approved(target, b"payload") is False
+
+    store.write_text(
+        json.dumps({"records": [{"absolute_path": str(target)}]}), encoding="utf-8"
+    )
+    assert is_approved(target, b"payload") is False
+
+    # An unreadable store: a directory where the file should be (an OSError that
+    # does not depend on this process's uid, unlike chmod 0o000 under root).
+    store.unlink()
+    store.mkdir()
+    assert is_approved(target, b"payload") is False
+
+
+def test_a_store_inside_the_checkout_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A checkout-resident store would let a repo ship its own approval."""
+    checkout_dir = tmp_path / "checkout"
+    (checkout_dir / ".git").mkdir(parents=True)
+    home = checkout_dir / "home"  # HOME *inside* the checkout
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(checkout_dir)
+
+    target = _write(checkout_dir / "server.py", b"payload")
+
+    with pytest.raises(TrustStoreError):
+        trust_store_path()
+    with pytest.raises(TrustStoreError):
+        record(target, b"payload", "user", "approved")
+
+    assert is_approved(target, b"payload") is False
+    assert not (home / ".config" / "pmcp" / "trust.json").exists()
+
+
+def test_a_symlinked_store_into_the_checkout_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The residency check resolves symlinks before comparing.
+
+    HOME is outside the checkout here, so only a check that resolves the store
+    path sees that the store really lands inside the repository.
+    """
+    checkout_dir = tmp_path / "checkout"
+    (checkout_dir / ".git").mkdir(parents=True)
+    (checkout_dir / "planted").mkdir()
+    home = tmp_path / "home"
+    (home / ".config").mkdir(parents=True)
+    (home / ".config" / "pmcp").symlink_to(checkout_dir / "planted")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(checkout_dir)
+
+    target = _write(checkout_dir / "server.py", b"payload")
+
+    with pytest.raises(TrustStoreError):
+        trust_store_path()
+    with pytest.raises(TrustStoreError):
+        record(target, b"payload", "user", "approved")
+
+    assert is_approved(target, b"payload") is False
+    assert not (checkout_dir / "planted" / "trust.json").exists()
+
+
+def test_is_approved_judges_supplied_bytes_not_the_path(checkout: Path) -> None:
+    """The predicate hashes the bytes the caller is about to apply.
+
+    Re-reading the file would reopen the check-then-use window the freeze exists
+    to close, so the on-disk bytes must not influence the answer at all.
+    """
+    target = _write(checkout / "server.py", b"A")
+    record(target, b"A", "user", "approved")
+
+    # On-disk bytes are still A; the caller is about to apply B.
+    assert target.read_bytes() == b"A"
+    assert is_approved(target, b"B") is False
+
+    # On-disk bytes swapped to C after approval; the caller still applies A.
+    target.write_bytes(b"C")
+    assert is_approved(target, b"A") is True
+    assert is_approved(target, b"C") is False
+
+    # A deleted file is not an error: the bytes, not the path, are the subject.
+    target.unlink()
+    assert is_approved(target, b"A") is True
+
+
+def test_a_denied_record_is_not_approved(checkout: Path) -> None:
+    """``denied`` is a recorded decision, not merely an absent one."""
+    target = _write(checkout / "server.py", b"payload")
+
+    denied = record(target, b"payload", "user", "denied")
+    assert denied.decision == "denied"
+
+    (loaded,) = list_records()
+    assert loaded.decision == "denied"  # present in the store...
+    assert is_approved(target, b"payload") is False  # ...but never approved
+
+    # The vocabulary is closed: nothing else may be stored.
+    with pytest.raises(ValueError):
+        record(target, b"payload", "user", "approved-ish")
+    with pytest.raises(ValueError):
+        record(target, b"payload", "user", "APPROVED")
+
+    # A denial is replaced by a later approval, one record per path throughout.
+    record(target, b"payload", "user", "approved")
+    assert len(list_records()) == 1
+    assert is_approved(target, b"payload") is True


### PR DESCRIPTION
Executes **Phase 1 (TRUST)** of `specs/phase-plans-v13.md` — the trust-boundary programme opened by the 2026-09-01 codebase review (S-01, S-03, S-11, S-04). Four lanes, each executed in an isolated worktree by a separate agent, merged in dependency order.

**Nothing consults the store yet and no existing behaviour changes.** This ships the primitives that CONSENT, PKGID, EGRESS and SEAL gate on. S-01 stays open until PKGID — that is this phase's stated non-goal, not an oversight.

## What ships

| Lane | Delivers |
|---|---|
| **SL-1** | `src/pmcp/trust_store.py` — user-scoped store at `~/.config/pmcp/trust.json`, keyed on **content, not paths** |
| **SL-2** | `src/pmcp/manifest/package_identity.py` — resolves an npm spec to a pinned identity **without running it** |
| **SL-3** | `pmcp trust approve <path>` / `list` / `revoke <path>` |
| **SL-docs** | CHANGELOG, docs-catalog rescan, three post-execution amendments |

Two design points worth reading:

- **`is_approved(path, content: bytes)` hashes the bytes the caller is about to apply** and never re-reads the file, closing the check-then-use window. Edit one byte and the approval is gone.
- **Every failure denies.** Missing, unreadable, corrupt or checkout-resident store → `False`, never a raise a caller might read as permission. Operator verbs, by contrast, fail *loudly* with a non-zero exit.

## Review history

Three advisor-board rounds on the plans, then one on the implementation, then one on the fixes. The implementation board returned **two blocking defects, both from the red-team seat while the other two returned AGREE** — the same split seen throughout this programme.

**Both reproduced before being fixed:**

1. **A dist-tag target bypassed concrete-version validation.** A packument with `dist-tags.latest = "^1.0.0"` yielded `PackageIdentity(resolved_version='^1.0.0')`. PKGID would then pin argv to `npx -y pkg@^1.0.0`, which re-resolves at every spawn — the exact check-then-use hole this programme exists to close, reached through registry data rather than through the caller.
2. **A concurrent approve could silently resurrect a revoked approval.** `record` and `revoke` each read all records, change one and write the set back, with no locking anywhere in the module.

The re-board of those fixes then found **a regression the fix itself introduced**: the new lock's `mkdir` ran before `_write_store`'s `parent_created` check, so the `chmod 0o700` never fired and a fresh install got the umask default — measured at **0o775**. The file stays `0o600`, but a group-writable *directory* lets another account replace `trust.json` wholesale, and replacing the store is enough to forge an approval. Fixed by giving both call sites one `_ensure_store_dir` decision instead of two independent ones.

Also fixed, raised as a nit but not treated as one: `_write_store` now **fsyncs the directory** after `os.replace`, so a crash right after a revoke cannot leave the pre-revoke store on disk and resurrect the withdrawn approval.

## Verification

Every security property is **mutation-proven** — a test that passes against a broken implementation is worthless:

| Mutation | Result |
|---|---|
| `is_approved` ignores the content hash | 3 tests fail |
| store errors return `True` (fail open) | 5 tests fail |
| revert the dist-tag check | the identity test fails |
| remove both lock sites | the concurrency test fails (race reproduces within 40 iterations) |
| restore the two independent dir decisions | the permissions test fails |

For SL-2, "fails on unchanged `main`" can only be `ImportError` for a new module, so falsification used **two strawmen**: an `npm view` subprocess version failed all 35 tests, while a seam-having naive version *passed* the two spawn tests and failed 15/15 on versions — which is what proves the first set of failures was behavioural rather than structural.

**No regression:** `main` collects 3456 items, this branch 3508 — a delta of exactly **52**, the new tests (8 + 9 + 35). The 107 failures seen in a `/mnt/workspace` worktree are a location artifact: `node_modules` at the volume root trips npm's local-prefix rule and the resolver refuses by design (#195). A checkout outside `/mnt` runs clean, and CI uses one.

## Known follow-ups, recorded not dropped

- **No `deny` verb.** The vocabulary is `{"approved","denied"}` and `is_approved` distinguishes denied from absent, but no CLI verb writes `"denied"`. Absence already denies, so this is a reserved value with no writer, not a hole. CONSENT/PKGID are told to treat it as reserved.
- **`resolve_package_identity` is synchronous** and does blocking network I/O (10 s), while every existing registry lookup in `version_checker.py` is async. PKGID calls it from inside `async def register_discovered_server`, so it needs `anyio.to_thread.run_sync` plus a handler-level timeout — a socket timeout is not a request bound. Carried into PKGID's SL-1 lane, not just the roadmap.
- The last two commits (`78b3bc3`, `4770984`) are **post-board** and no seat has reviewed them.

See #230.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VydToCyPeDKACFYyzaUdiT

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Consiliency/codesmith/pmcp/pr/240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791629199&installation_model_id=427051&pr_number=240&repository=Consiliency%2Fpmcp&return_to=https%3A%2F%2Fgithub.com%2FConsiliency%2Fpmcp%2Fpull%2F240&signature=44afa99410ad901b285f3d0a76ea3bf9b559d70b812bce26a39289e319e4bf3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->